### PR TITLE
feat(rust): implement core types and errors

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -8,18 +8,20 @@ repository = "https://github.com/motosan-dev/motosan-ai"
 
 [features]
 default = []
-anthropic = ["dep:reqwest", "dep:serde_json", "dep:eventsource-stream", "dep:tokio-stream"]
-openai = ["dep:reqwest", "dep:serde_json", "dep:eventsource-stream", "dep:tokio-stream"]
-minimax = ["dep:reqwest", "dep:serde_json", "dep:eventsource-stream", "dep:tokio-stream"]
+anthropic = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream"]
+openai = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream"]
+minimax = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream"]
 full = ["anthropic", "openai", "minimax"]
 
 [dependencies]
 async-trait = "0.1"
 futures-core = "0.3"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 reqwest = { version = "0.12", optional = true, features = ["json", "stream", "rustls-tls"] }
-serde_json = { version = "1", optional = true }
 eventsource-stream = { version = "0.2", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 
+[dev-dependencies]
+serde_json = "1"

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -2,18 +2,27 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone)]
 pub enum MotosanError {
+    Auth(String),
+    RateLimit(String),
+    InvalidRequest(String),
     Config(String),
     ProviderError(String),
+    Network(String),
+    Stream(String),
 }
 
 impl Display for MotosanError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Auth(message) => write!(f, "auth error: {message}"),
+            Self::RateLimit(message) => write!(f, "rate limit error: {message}"),
+            Self::InvalidRequest(message) => write!(f, "invalid request: {message}"),
             Self::Config(message) => write!(f, "config error: {message}"),
             Self::ProviderError(message) => write!(f, "provider error: {message}"),
+            Self::Network(message) => write!(f, "network error: {message}"),
+            Self::Stream(message) => write!(f, "stream error: {message}"),
         }
     }
 }
 
 impl std::error::Error for MotosanError {}
-

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -8,5 +8,4 @@ pub use client::{Client, ClientBuilder};
 pub use error::MotosanError;
 pub use providers::Provider;
 pub use stream::{BoxStream, StreamEvent};
-pub use types::{ChatRequest, ChatResponse, Message, Role, StopReason, Usage};
-
+pub use types::{ChatRequest, ChatResponse, Message, Role, StopReason, Tool, Usage};

--- a/sdks/rust/src/stream.rs
+++ b/sdks/rust/src/stream.rs
@@ -1,11 +1,5 @@
+pub use crate::types::StreamEvent;
 use futures_core::Stream;
 use std::pin::Pin;
 
-#[derive(Debug, Clone)]
-pub struct StreamEvent {
-    pub content: String,
-    pub done: bool,
-}
-
 pub type BoxStream = Pin<Box<dyn Stream<Item = StreamEvent> + Send>>;
-

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -1,22 +1,62 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
 pub enum Role {
     User,
     Assistant,
     System,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Message {
     pub role: Role,
     pub content: String,
 }
 
-#[derive(Debug, Clone)]
-pub struct ChatRequest {
-    pub messages: Vec<Message>,
+impl Message {
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: content.into(),
+        }
+    }
+
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: content.into(),
+        }
+    }
+
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::System,
+            content: content.into(),
+        }
+    }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tool {
+    pub name: String,
+    pub description: Option<String>,
+    pub input_schema: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatRequest {
+    pub messages: Vec<Message>,
+    pub model: Option<String>,
+    pub system: Option<String>,
+    pub temperature: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub tools: Option<Vec<Tool>>,
+    pub provider_options: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatResponse {
     pub content: String,
     pub model: String,
@@ -24,13 +64,14 @@ pub struct ChatResponse {
     pub stop_reason: StopReason,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Usage {
     pub input_tokens: u32,
     pub output_tokens: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum StopReason {
     EndTurn,
     MaxTokens,
@@ -39,3 +80,8 @@ pub enum StopReason {
     Other,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StreamEvent {
+    pub content: String,
+    pub done: bool,
+}

--- a/sdks/rust/tests/core_types.rs
+++ b/sdks/rust/tests/core_types.rs
@@ -1,0 +1,20 @@
+use motosan_ai::{Message, Role, StopReason};
+
+#[test]
+fn message_constructors_set_role_and_content() {
+    let user = Message::user("hello");
+    let assistant = Message::assistant("world");
+    let system = Message::system("policy");
+
+    assert!(matches!(user.role, Role::User));
+    assert!(matches!(assistant.role, Role::Assistant));
+    assert!(matches!(system.role, Role::System));
+    assert_eq!(user.content, "hello");
+}
+
+#[test]
+fn stop_reason_serializes_to_snake_case() {
+    let serialized = serde_json::to_string(&StopReason::EndTurn).expect("serialize stop reason");
+    assert_eq!(serialized, "\"end_turn\"");
+}
+


### PR DESCRIPTION
## Summary
- implement core types in `types.rs`: `Role`, `Message`, `Tool`, `ChatRequest`, `ChatResponse`, `Usage`, `StopReason`, `StreamEvent`
- add `Message::user()`, `Message::assistant()`, `Message::system()` constructors
- expand `MotosanError` with `Auth`, `RateLimit`, `InvalidRequest`, `ProviderError`, `Network`, `Stream`, `Config`
- define `BoxStream` in `stream.rs` and re-export stream types
- add `core_types` integration tests for constructors and serde mapping

## Verification
- cargo test -p motosan-ai --test core_types
- cargo build -p motosan-ai --all-features

Closes #2
