### PR TITLE
feat(rust): add client builder dispatch and APIs

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -25,3 +25,4 @@ tokio-stream = { version = "0.1", optional = true }
 
 [dev-dependencies]
 serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,5 +1,7 @@
 use crate::error::MotosanError;
 use crate::providers::Provider;
+use crate::stream::BoxStream;
+use crate::types::{ChatRequest, ChatResponse, Message};
 
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -23,6 +25,136 @@ impl Client {
 
     pub fn model(&self) -> Option<&str> {
         self.model.as_deref()
+    }
+
+    pub async fn chat(&self, messages: Vec<Message>) -> Result<ChatResponse, MotosanError> {
+        self.chat_with(ChatRequest {
+            messages,
+            model: self.model.clone(),
+            system: None,
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            provider_options: None,
+        })
+        .await
+    }
+
+    pub async fn chat_with(&self, request: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        self.dispatch_chat(request).await
+    }
+
+    pub async fn stream(&self, messages: Vec<Message>) -> Result<BoxStream, MotosanError> {
+        self.dispatch_stream(ChatRequest {
+            messages,
+            model: self.model.clone(),
+            system: None,
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            provider_options: None,
+        })
+        .await
+    }
+
+    async fn dispatch_chat(&self, request: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        match self.provider {
+            Provider::Anthropic => {
+                #[cfg(feature = "anthropic")]
+                {
+                    use crate::providers::anthropic::AnthropicProvider;
+                    use crate::providers::ProviderImpl;
+                    return AnthropicProvider.chat(request).await;
+                }
+                #[cfg(not(feature = "anthropic"))]
+                {
+                    let _ = request;
+                    return Err(MotosanError::Config(
+                        "anthropic feature is not enabled".to_string(),
+                    ));
+                }
+            }
+            Provider::OpenAI => {
+                #[cfg(feature = "openai")]
+                {
+                    use crate::providers::openai::OpenAIProvider;
+                    use crate::providers::ProviderImpl;
+                    return OpenAIProvider.chat(request).await;
+                }
+                #[cfg(not(feature = "openai"))]
+                {
+                    let _ = request;
+                    return Err(MotosanError::Config(
+                        "openai feature is not enabled".to_string(),
+                    ));
+                }
+            }
+            Provider::Minimax => {
+                #[cfg(feature = "minimax")]
+                {
+                    use crate::providers::minimax::MinimaxProvider;
+                    use crate::providers::ProviderImpl;
+                    return MinimaxProvider.chat(request).await;
+                }
+                #[cfg(not(feature = "minimax"))]
+                {
+                    let _ = request;
+                    return Err(MotosanError::Config(
+                        "minimax feature is not enabled".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    async fn dispatch_stream(&self, request: ChatRequest) -> Result<BoxStream, MotosanError> {
+        match self.provider {
+            Provider::Anthropic => {
+                #[cfg(feature = "anthropic")]
+                {
+                    use crate::providers::anthropic::AnthropicProvider;
+                    use crate::providers::ProviderImpl;
+                    return AnthropicProvider.stream(request).await;
+                }
+                #[cfg(not(feature = "anthropic"))]
+                {
+                    let _ = request;
+                    return Err(MotosanError::Config(
+                        "anthropic feature is not enabled".to_string(),
+                    ));
+                }
+            }
+            Provider::OpenAI => {
+                #[cfg(feature = "openai")]
+                {
+                    use crate::providers::openai::OpenAIProvider;
+                    use crate::providers::ProviderImpl;
+                    return OpenAIProvider.stream(request).await;
+                }
+                #[cfg(not(feature = "openai"))]
+                {
+                    let _ = request;
+                    return Err(MotosanError::Config(
+                        "openai feature is not enabled".to_string(),
+                    ));
+                }
+            }
+            Provider::Minimax => {
+                #[cfg(feature = "minimax")]
+                {
+                    use crate::providers::minimax::MinimaxProvider;
+                    use crate::providers::ProviderImpl;
+                    return MinimaxProvider.stream(request).await;
+                }
+                #[cfg(not(feature = "minimax"))]
+                {
+                    let _ = request;
+                    return Err(MotosanError::Config(
+                        "minimax feature is not enabled".to_string(),
+                    ));
+                }
+            }
+        }
     }
 }
 
@@ -64,4 +196,3 @@ impl ClientBuilder {
         })
     }
 }
-

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -1,0 +1,27 @@
+use motosan_ai::{Client, Message, MotosanError, Provider};
+
+#[test]
+fn builder_requires_provider_and_api_key() {
+    let missing_provider = Client::builder().api_key("k").build();
+    assert!(matches!(missing_provider, Err(MotosanError::Config(_))));
+
+    let missing_api_key = Client::builder().provider(Provider::OpenAI).build();
+    assert!(matches!(missing_api_key, Err(MotosanError::Config(_))));
+}
+
+#[tokio::test]
+async fn chat_and_stream_exist_and_dispatch() {
+    let client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .build()
+        .expect("build client");
+
+    let messages = vec![Message::user("hello")];
+    let chat_result = client.chat(messages.clone()).await;
+    let stream_result = client.stream(messages).await;
+
+    assert!(matches!(chat_result, Err(MotosanError::Config(_))));
+    assert!(matches!(stream_result, Err(MotosanError::Config(_))));
+}
+


### PR DESCRIPTION
## Summary
- add `Client::chat`, `Client::chat_with`, and `Client::stream`
- add provider dispatch by `Provider` enum with feature-gated provider routing
- return `MotosanError::Config` when requested provider feature is not enabled
- keep `ClientBuilder::build()` required fields contract (`provider`, `api_key`)
- add integration tests for builder requirements and dispatch entrypoints

## Verification
- cargo test -p motosan-ai --test client_builder
- cargo build -p motosan-ai --all-features

Closes #3
