### PR TITLE
feat(rust): add anthropic chat implementation

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -26,3 +26,4 @@ tokio-stream = { version = "0.1", optional = true }
 [dev-dependencies]
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
+mockito = "1"

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -64,7 +64,12 @@ impl Client {
                 {
                     use crate::providers::anthropic::AnthropicProvider;
                     use crate::providers::ProviderImpl;
-                    return AnthropicProvider.chat(request).await;
+                    let provider = AnthropicProvider::new(
+                        self.api_key.clone(),
+                        self.model.clone(),
+                        None,
+                    );
+                    return provider.chat(request).await;
                 }
                 #[cfg(not(feature = "anthropic"))]
                 {
@@ -114,7 +119,12 @@ impl Client {
                 {
                     use crate::providers::anthropic::AnthropicProvider;
                     use crate::providers::ProviderImpl;
-                    return AnthropicProvider.stream(request).await;
+                    let provider = AnthropicProvider::new(
+                        self.api_key.clone(),
+                        self.model.clone(),
+                        None,
+                    );
+                    return provider.stream(request).await;
                 }
                 #[cfg(not(feature = "anthropic"))]
                 {

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1,17 +1,155 @@
 use crate::error::MotosanError;
 use crate::providers::ProviderImpl;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse};
+use crate::types::{ChatRequest, ChatResponse, StopReason, Usage};
 use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::{json, Value};
 
-pub struct AnthropicProvider;
+pub struct AnthropicProvider {
+    http: Client,
+    api_key: String,
+    model: String,
+    base_url: String,
+}
+
+impl AnthropicProvider {
+    pub fn new(api_key: impl Into<String>, model: Option<String>, base_url: Option<String>) -> Self {
+        Self {
+            http: Client::new(),
+            api_key: api_key.into(),
+            model: model.unwrap_or_else(|| "claude-sonnet-4-5".to_string()),
+            base_url: base_url.unwrap_or_else(|| "https://api.anthropic.com".to_string()),
+        }
+    }
+}
 
 #[async_trait]
 impl ProviderImpl for AnthropicProvider {
-    async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        Err(MotosanError::ProviderError(
-            "anthropic provider not implemented".to_string(),
-        ))
+    async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
+        let explicit_system = req.system.clone();
+        let mut extracted_systems = Vec::new();
+        let mut messages = Vec::new();
+
+        for message in &req.messages {
+            match message.role {
+                crate::types::Role::System => extracted_systems.push(message.content.clone()),
+                crate::types::Role::User => {
+                    messages.push(json!({"role": "user", "content": message.content}))
+                }
+                crate::types::Role::Assistant => {
+                    messages.push(json!({"role": "assistant", "content": message.content}))
+                }
+            }
+        }
+
+        let system = explicit_system.or_else(|| {
+            if extracted_systems.is_empty() {
+                None
+            } else {
+                Some(extracted_systems.join("\n"))
+            }
+        });
+
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+        });
+
+        if let Some(system_prompt) = system {
+            body["system"] = json!(system_prompt);
+        }
+        if let Some(temperature) = req.temperature {
+            body["temperature"] = json!(temperature);
+        }
+        if let Some(max_tokens) = req.max_tokens {
+            body["max_tokens"] = json!(max_tokens);
+        }
+        if let Some(provider_options) = req.provider_options {
+            if let Some(map) = provider_options.as_object() {
+                for (key, value) in map {
+                    body[key] = value.clone();
+                }
+            }
+        }
+
+        let response = self
+            .http
+            .post(format!("{}/v1/messages", self.base_url))
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| MotosanError::Network(error.to_string()))?;
+
+        let status = response.status();
+        let payload: Value = response
+            .json()
+            .await
+            .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+
+        if !status.is_success() {
+            let message = payload
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("anthropic request failed")
+                .to_string();
+            return Err(match status.as_u16() {
+                401 => MotosanError::Auth(message),
+                429 => MotosanError::RateLimit(message),
+                400 => MotosanError::InvalidRequest(message),
+                _ => MotosanError::ProviderError(message),
+            });
+        }
+
+        let content = payload
+            .get("content")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.get("text").and_then(Value::as_str))
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+            .unwrap_or_default();
+
+        let model = payload
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or("claude-sonnet-4-5")
+            .to_string();
+
+        let usage = Usage {
+            input_tokens: payload
+                .get("usage")
+                .and_then(|usage| usage.get("input_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32,
+            output_tokens: payload
+                .get("usage")
+                .and_then(|usage| usage.get("output_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32,
+        };
+
+        let stop_reason = match payload.get("stop_reason").and_then(Value::as_str) {
+            Some("end_turn") => StopReason::EndTurn,
+            Some("max_tokens") => StopReason::MaxTokens,
+            Some("tool_use") => StopReason::ToolUse,
+            Some("stop") => StopReason::Stop,
+            _ => StopReason::Other,
+        };
+
+        Ok(ChatResponse {
+            content,
+            model,
+            usage,
+            stop_reason,
+        })
     }
 
     async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError> {
@@ -20,4 +158,3 @@ impl ProviderImpl for AnthropicProvider {
         ))
     }
 }
-

--- a/sdks/rust/tests/anthropic_chat.rs
+++ b/sdks/rust/tests/anthropic_chat.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "anthropic")]
+
+use motosan_ai::providers::anthropic::AnthropicProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, Message, StopReason};
+use serde_json::json;
+
+#[tokio::test]
+async fn anthropic_chat_maps_response() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_header("anthropic-version", "2023-06-01")
+        .with_status(200)
+        .with_body(
+            json!({
+                "id": "msg_1",
+                "model": "claude-sonnet-4-5",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+                "content": [{"type": "text", "text": "hello from anthropic"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest {
+        messages: vec![Message::system("rules"), Message::user("hello")],
+        model: None,
+        system: None,
+        temperature: Some(0.2),
+        max_tokens: Some(100),
+        tools: None,
+        provider_options: None,
+    };
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "hello from anthropic");
+    assert_eq!(response.model, "claude-sonnet-4-5");
+    assert_eq!(response.usage.input_tokens, 10);
+    assert!(matches!(response.stop_reason, StopReason::EndTurn));
+
+    mock.assert_async().await;
+}
+


### PR DESCRIPTION
## Summary
- implement `AnthropicProvider::chat()` using `POST /v1/messages`
- normalize request mapping including system extraction to top-level `system`
- map response fields into unified `ChatResponse` and `Usage`
- map HTTP errors (`401`, `429`, `400`, fallback) to `MotosanError`
- add integration test with `mockito` under `anthropic` feature

## Verification
- cargo test -p motosan-ai --features anthropic --test anthropic_chat
- cargo build -p motosan-ai --all-features

Closes #4
