### PR TITLE
feat(rust): add openai provider chat and stream

### DIFF
--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -84,7 +84,9 @@ impl Client {
                 {
                     use crate::providers::openai::OpenAIProvider;
                     use crate::providers::ProviderImpl;
-                    return OpenAIProvider.chat(request).await;
+                    let provider =
+                        OpenAIProvider::new(self.api_key.clone(), self.model.clone(), None);
+                    return provider.chat(request).await;
                 }
                 #[cfg(not(feature = "openai"))]
                 {
@@ -139,7 +141,9 @@ impl Client {
                 {
                     use crate::providers::openai::OpenAIProvider;
                     use crate::providers::ProviderImpl;
-                    return OpenAIProvider.stream(request).await;
+                    let provider =
+                        OpenAIProvider::new(self.api_key.clone(), self.model.clone(), None);
+                    return provider.stream(request).await;
                 }
                 #[cfg(not(feature = "openai"))]
                 {

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -1,23 +1,237 @@
 use crate::error::MotosanError;
 use crate::providers::ProviderImpl;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse};
+use crate::types::{ChatRequest, ChatResponse, StopReason, Usage};
 use async_trait::async_trait;
+use eventsource_stream::Eventsource;
+use reqwest::Client;
+use serde_json::{json, Value};
+use tokio_stream::StreamExt;
 
-pub struct OpenAIProvider;
+pub struct OpenAIProvider {
+    http: Client,
+    api_key: String,
+    model: String,
+    base_url: String,
+}
 
-#[async_trait]
-impl ProviderImpl for OpenAIProvider {
-    async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        Err(MotosanError::ProviderError(
-            "openai provider not implemented".to_string(),
-        ))
-    }
-
-    async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError> {
-        Err(MotosanError::ProviderError(
-            "openai streaming not implemented".to_string(),
-        ))
+impl OpenAIProvider {
+    pub fn new(api_key: impl Into<String>, model: Option<String>, base_url: Option<String>) -> Self {
+        Self {
+            http: Client::new(),
+            api_key: api_key.into(),
+            model: model.unwrap_or_else(|| "gpt-4o".to_string()),
+            base_url: base_url.unwrap_or_else(|| "https://api.openai.com".to_string()),
+        }
     }
 }
 
+#[async_trait]
+impl ProviderImpl for OpenAIProvider {
+    async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
+        let mut messages = Vec::new();
+
+        if let Some(system) = &req.system {
+            messages.push(json!({"role": "system", "content": system}));
+        }
+
+        for message in &req.messages {
+            let role = match message.role {
+                crate::types::Role::User => "user",
+                crate::types::Role::Assistant => "assistant",
+                crate::types::Role::System => "system",
+            };
+            messages.push(json!({"role": role, "content": message.content}));
+        }
+
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+        });
+        if let Some(temperature) = req.temperature {
+            body["temperature"] = json!(temperature);
+        }
+        if let Some(max_tokens) = req.max_tokens {
+            body["max_tokens"] = json!(max_tokens);
+        }
+        if let Some(provider_options) = req.provider_options {
+            if let Some(map) = provider_options.as_object() {
+                for (key, value) in map {
+                    body[key] = value.clone();
+                }
+            }
+        }
+
+        let response = self
+            .http
+            .post(format!("{}/v1/chat/completions", self.base_url))
+            .header("authorization", format!("Bearer {}", self.api_key))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| MotosanError::Network(error.to_string()))?;
+
+        let status = response.status();
+        let payload: Value = response
+            .json()
+            .await
+            .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+
+        if !status.is_success() {
+            let message = payload
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("openai request failed")
+                .to_string();
+            return Err(match status.as_u16() {
+                401 => MotosanError::Auth(message),
+                429 => MotosanError::RateLimit(message),
+                400 => MotosanError::InvalidRequest(message),
+                _ => MotosanError::ProviderError(message),
+            });
+        }
+
+        let content = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"))
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        let stop_reason = match payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("finish_reason"))
+            .and_then(Value::as_str)
+        {
+            Some("stop") => StopReason::Stop,
+            Some("length") => StopReason::MaxTokens,
+            Some("tool_calls") => StopReason::ToolUse,
+            _ => StopReason::Other,
+        };
+
+        let model = payload
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or("gpt-4o")
+            .to_string();
+
+        let usage = Usage {
+            input_tokens: payload
+                .get("usage")
+                .and_then(|usage| usage.get("prompt_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32,
+            output_tokens: payload
+                .get("usage")
+                .and_then(|usage| usage.get("completion_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32,
+        };
+
+        Ok(ChatResponse {
+            content,
+            model,
+            usage,
+            stop_reason,
+        })
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
+        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
+        let mut messages = Vec::new();
+
+        if let Some(system) = &req.system {
+            messages.push(json!({"role": "system", "content": system}));
+        }
+
+        for message in &req.messages {
+            let role = match message.role {
+                crate::types::Role::User => "user",
+                crate::types::Role::Assistant => "assistant",
+                crate::types::Role::System => "system",
+            };
+            messages.push(json!({"role": role, "content": message.content}));
+        }
+
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+            "stream": true,
+        });
+        if let Some(temperature) = req.temperature {
+            body["temperature"] = json!(temperature);
+        }
+        if let Some(max_tokens) = req.max_tokens {
+            body["max_tokens"] = json!(max_tokens);
+        }
+        if let Some(provider_options) = req.provider_options {
+            if let Some(map) = provider_options.as_object() {
+                for (key, value) in map {
+                    body[key] = value.clone();
+                }
+            }
+        }
+
+        let response = self
+            .http
+            .post(format!("{}/v1/chat/completions", self.base_url))
+            .header("authorization", format!("Bearer {}", self.api_key))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| MotosanError::Network(error.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "openai stream request failed".to_string());
+            return Err(match status.as_u16() {
+                401 => MotosanError::Auth(message),
+                429 => MotosanError::RateLimit(message),
+                400 => MotosanError::InvalidRequest(message),
+                _ => MotosanError::ProviderError(message),
+            });
+        }
+
+        let parsed_stream = response
+            .bytes_stream()
+            .eventsource()
+            .filter_map(|event| match event {
+                Ok(event) => {
+                    if event.data.trim() == "[DONE]" {
+                        return Some(crate::types::StreamEvent {
+                            content: String::new(),
+                            done: true,
+                        });
+                    }
+
+                    let payload: Value = serde_json::from_str(&event.data).ok()?;
+                    let text = payload
+                        .get("choices")
+                        .and_then(Value::as_array)
+                        .and_then(|choices| choices.first())
+                        .and_then(|choice| choice.get("delta"))
+                        .and_then(|delta| delta.get("content"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    Some(crate::types::StreamEvent {
+                        content: text,
+                        done: false,
+                    })
+                }
+                Err(_) => None,
+            });
+
+        Ok(Box::pin(parsed_stream))
+    }
+}

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "openai")]
+
+use motosan_ai::providers::openai::OpenAIProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, Message, StopReason};
+use serde_json::json;
+use tokio_stream::StreamExt;
+
+#[tokio::test]
+async fn openai_chat_maps_response() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-4o",
+                "choices": [{"message": {"content": "hello from openai"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 12, "completion_tokens": 8}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest {
+        messages: vec![Message::system("rules"), Message::user("hello")],
+        model: None,
+        system: None,
+        temperature: Some(0.1),
+        max_tokens: Some(50),
+        tools: None,
+        provider_options: None,
+    };
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "hello from openai");
+    assert_eq!(response.model, "gpt-4o");
+    assert_eq!(response.usage.input_tokens, 12);
+    assert!(matches!(response.stop_reason, StopReason::Stop));
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_stream_emits_deltas_and_done() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"hel\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest {
+        messages: vec![Message::user("hello")],
+        model: None,
+        system: None,
+        temperature: None,
+        max_tokens: None,
+        tools: None,
+        provider_options: None,
+    };
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut events = Vec::new();
+
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].content, "hel");
+    assert_eq!(events[1].content, "lo");
+    assert!(events[2].done);
+
+    mock.assert_async().await;
+}
+


### PR DESCRIPTION
## Summary
- implement `OpenAIProvider::chat()` using `/v1/chat/completions`
- implement `OpenAIProvider::stream()` with SSE delta parsing and `[DONE]` handling
- keep system message in the messages array (OpenAI format)
- map HTTP errors to `MotosanError` variants and default model to `gpt-4o`
- add integration tests for OpenAI chat + stream behavior

## Verification
- cargo test -p motosan-ai --features openai --test openai_provider
- cargo build -p motosan-ai --all-features

Closes #6
