### PR TITLE
feat(rust): add minimax provider chat and stream

### DIFF
--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -101,7 +101,9 @@ impl Client {
                 {
                     use crate::providers::minimax::MinimaxProvider;
                     use crate::providers::ProviderImpl;
-                    return MinimaxProvider.chat(request).await;
+                    let provider =
+                        MinimaxProvider::new(self.api_key.clone(), self.model.clone(), None);
+                    return provider.chat(request).await;
                 }
                 #[cfg(not(feature = "minimax"))]
                 {
@@ -158,7 +160,9 @@ impl Client {
                 {
                     use crate::providers::minimax::MinimaxProvider;
                     use crate::providers::ProviderImpl;
-                    return MinimaxProvider.stream(request).await;
+                    let provider =
+                        MinimaxProvider::new(self.api_key.clone(), self.model.clone(), None);
+                    return provider.stream(request).await;
                 }
                 #[cfg(not(feature = "minimax"))]
                 {

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -1,23 +1,237 @@
 use crate::error::MotosanError;
 use crate::providers::ProviderImpl;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse};
+use crate::types::{ChatRequest, ChatResponse, StopReason, Usage};
 use async_trait::async_trait;
+use eventsource_stream::Eventsource;
+use reqwest::Client;
+use serde_json::{json, Value};
+use tokio_stream::StreamExt;
 
-pub struct MinimaxProvider;
+pub struct MinimaxProvider {
+    http: Client,
+    api_key: String,
+    model: String,
+    base_url: String,
+}
 
-#[async_trait]
-impl ProviderImpl for MinimaxProvider {
-    async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        Err(MotosanError::ProviderError(
-            "minimax provider not implemented".to_string(),
-        ))
-    }
-
-    async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError> {
-        Err(MotosanError::ProviderError(
-            "minimax streaming not implemented".to_string(),
-        ))
+impl MinimaxProvider {
+    pub fn new(api_key: impl Into<String>, model: Option<String>, base_url: Option<String>) -> Self {
+        Self {
+            http: Client::new(),
+            api_key: api_key.into(),
+            model: model.unwrap_or_else(|| "MiniMax-Text-01".to_string()),
+            base_url: base_url.unwrap_or_else(|| "https://api.minimax.chat".to_string()),
+        }
     }
 }
 
+#[async_trait]
+impl ProviderImpl for MinimaxProvider {
+    async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
+        let mut messages = Vec::new();
+
+        if let Some(system) = &req.system {
+            messages.push(json!({"role": "system", "content": system}));
+        }
+
+        for message in &req.messages {
+            let role = match message.role {
+                crate::types::Role::User => "user",
+                crate::types::Role::Assistant => "assistant",
+                crate::types::Role::System => "system",
+            };
+            messages.push(json!({"role": role, "content": message.content}));
+        }
+
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+        });
+        if let Some(temperature) = req.temperature {
+            body["temperature"] = json!(temperature);
+        }
+        if let Some(max_tokens) = req.max_tokens {
+            body["max_tokens"] = json!(max_tokens);
+        }
+        if let Some(provider_options) = req.provider_options {
+            if let Some(map) = provider_options.as_object() {
+                for (key, value) in map {
+                    body[key] = value.clone();
+                }
+            }
+        }
+
+        let response = self
+            .http
+            .post(format!("{}/v1/text/chatcompletion_v2", self.base_url))
+            .header("authorization", format!("Bearer {}", self.api_key))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| MotosanError::Network(error.to_string()))?;
+
+        let status = response.status();
+        let payload: Value = response
+            .json()
+            .await
+            .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+
+        if !status.is_success() {
+            let message = payload
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("minimax request failed")
+                .to_string();
+            return Err(match status.as_u16() {
+                401 => MotosanError::Auth(message),
+                429 => MotosanError::RateLimit(message),
+                400 => MotosanError::InvalidRequest(message),
+                _ => MotosanError::ProviderError(message),
+            });
+        }
+
+        let content = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"))
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        let stop_reason = match payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("finish_reason"))
+            .and_then(Value::as_str)
+        {
+            Some("stop") => StopReason::Stop,
+            Some("length") => StopReason::MaxTokens,
+            Some("tool_calls") => StopReason::ToolUse,
+            _ => StopReason::Other,
+        };
+
+        let model = payload
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or("MiniMax-Text-01")
+            .to_string();
+
+        let usage = Usage {
+            input_tokens: payload
+                .get("usage")
+                .and_then(|usage| usage.get("prompt_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32,
+            output_tokens: payload
+                .get("usage")
+                .and_then(|usage| usage.get("completion_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32,
+        };
+
+        Ok(ChatResponse {
+            content,
+            model,
+            usage,
+            stop_reason,
+        })
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
+        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
+        let mut messages = Vec::new();
+
+        if let Some(system) = &req.system {
+            messages.push(json!({"role": "system", "content": system}));
+        }
+
+        for message in &req.messages {
+            let role = match message.role {
+                crate::types::Role::User => "user",
+                crate::types::Role::Assistant => "assistant",
+                crate::types::Role::System => "system",
+            };
+            messages.push(json!({"role": role, "content": message.content}));
+        }
+
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+            "stream": true,
+        });
+        if let Some(temperature) = req.temperature {
+            body["temperature"] = json!(temperature);
+        }
+        if let Some(max_tokens) = req.max_tokens {
+            body["max_tokens"] = json!(max_tokens);
+        }
+        if let Some(provider_options) = req.provider_options {
+            if let Some(map) = provider_options.as_object() {
+                for (key, value) in map {
+                    body[key] = value.clone();
+                }
+            }
+        }
+
+        let response = self
+            .http
+            .post(format!("{}/v1/text/chatcompletion_v2", self.base_url))
+            .header("authorization", format!("Bearer {}", self.api_key))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| MotosanError::Network(error.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "minimax stream request failed".to_string());
+            return Err(match status.as_u16() {
+                401 => MotosanError::Auth(message),
+                429 => MotosanError::RateLimit(message),
+                400 => MotosanError::InvalidRequest(message),
+                _ => MotosanError::ProviderError(message),
+            });
+        }
+
+        let parsed_stream = response
+            .bytes_stream()
+            .eventsource()
+            .filter_map(|event| match event {
+                Ok(event) => {
+                    if event.data.trim() == "[DONE]" {
+                        return Some(crate::types::StreamEvent {
+                            content: String::new(),
+                            done: true,
+                        });
+                    }
+
+                    let payload: Value = serde_json::from_str(&event.data).ok()?;
+                    let text = payload
+                        .get("choices")
+                        .and_then(Value::as_array)
+                        .and_then(|choices| choices.first())
+                        .and_then(|choice| choice.get("delta"))
+                        .and_then(|delta| delta.get("content"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    Some(crate::types::StreamEvent {
+                        content: text,
+                        done: false,
+                    })
+                }
+                Err(_) => None,
+            });
+
+        Ok(Box::pin(parsed_stream))
+    }
+}

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -1,0 +1,88 @@
+#![cfg(feature = "minimax")]
+
+use motosan_ai::providers::minimax::MinimaxProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, Message, StopReason};
+use serde_json::json;
+use tokio_stream::StreamExt;
+
+#[tokio::test]
+async fn minimax_chat_maps_response() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/text/chatcompletion_v2")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-Text-01",
+                "choices": [{"message": {"content": "hello from minimax"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 4}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest {
+        messages: vec![Message::user("hello")],
+        model: None,
+        system: Some("rules".to_string()),
+        temperature: Some(0.3),
+        max_tokens: Some(40),
+        tools: None,
+        provider_options: None,
+    };
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "hello from minimax");
+    assert_eq!(response.model, "MiniMax-Text-01");
+    assert!(matches!(response.stop_reason, StopReason::Stop));
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_stream_emits_content_and_done() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"hel\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/text/chatcompletion_v2")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest {
+        messages: vec![Message::user("hello")],
+        model: None,
+        system: None,
+        temperature: None,
+        max_tokens: None,
+        tools: None,
+        provider_options: None,
+    };
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].content, "hel");
+    assert_eq!(events[1].content, "lo");
+    assert!(events[2].done);
+
+    mock.assert_async().await;
+}
+


### PR DESCRIPTION
## Summary
- implement `MinimaxProvider::chat()` and `MinimaxProvider::stream()`
- use MiniMax endpoint `/v1/text/chatcompletion_v2` with OpenAI-compatible payload
- normalize responses to unified `ChatResponse` and `StreamEvent`
- support SSE delta parsing and terminal `[DONE]` event
- set default model to `MiniMax-Text-01`
- add integration tests for MiniMax chat + stream

## Verification
- cargo test -p motosan-ai --features minimax --test minimax_provider
- cargo build -p motosan-ai --all-features

Closes #7
