### PR TITLE
refactor(rust): adopt builders and shared provider mapping

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -18,6 +18,7 @@ async-trait = "0.1"
 futures-core = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror = "2"
 
 reqwest = { version = "0.12", optional = true, features = ["json", "stream", "rustls-tls"] }
 eventsource-stream = { version = "0.2", optional = true }

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -28,16 +28,12 @@ impl Client {
     }
 
     pub async fn chat(&self, messages: Vec<Message>) -> Result<ChatResponse, MotosanError> {
-        self.chat_with(ChatRequest {
-            messages,
-            model: self.model.clone(),
-            system: None,
-            temperature: None,
-            max_tokens: None,
-            tools: None,
-            provider_options: None,
-        })
-        .await
+        let mut request_builder = ChatRequest::builder().messages(messages);
+        if let Some(model) = &self.model {
+            request_builder = request_builder.model(model.clone());
+        }
+
+        self.chat_with(request_builder.build()).await
     }
 
     pub async fn chat_with(&self, request: ChatRequest) -> Result<ChatResponse, MotosanError> {
@@ -45,16 +41,12 @@ impl Client {
     }
 
     pub async fn stream(&self, messages: Vec<Message>) -> Result<BoxStream, MotosanError> {
-        self.dispatch_stream(ChatRequest {
-            messages,
-            model: self.model.clone(),
-            system: None,
-            temperature: None,
-            max_tokens: None,
-            tools: None,
-            provider_options: None,
-        })
-        .await
+        let mut request_builder = ChatRequest::builder().messages(messages);
+        if let Some(model) = &self.model {
+            request_builder = request_builder.model(model.clone());
+        }
+
+        self.dispatch_stream(request_builder.build()).await
     }
 
     async fn dispatch_chat(&self, request: ChatRequest) -> Result<ChatResponse, MotosanError> {
@@ -62,52 +54,37 @@ impl Client {
             Provider::Anthropic => {
                 #[cfg(feature = "anthropic")]
                 {
-                    use crate::providers::anthropic::AnthropicProvider;
                     use crate::providers::ProviderImpl;
-                    let provider =
-                        AnthropicProvider::new(self.api_key.clone(), self.model.clone(), None);
-                    return provider.chat(request).await;
+                    return self.build_anthropic_provider().chat(request).await;
                 }
                 #[cfg(not(feature = "anthropic"))]
                 {
                     let _ = request;
-                    return Err(MotosanError::Config(
-                        "anthropic feature is not enabled".to_string(),
-                    ));
+                    return Err(Self::feature_not_enabled("anthropic"));
                 }
             }
             Provider::OpenAI => {
                 #[cfg(feature = "openai")]
                 {
-                    use crate::providers::openai::OpenAIProvider;
                     use crate::providers::ProviderImpl;
-                    let provider =
-                        OpenAIProvider::new(self.api_key.clone(), self.model.clone(), None);
-                    return provider.chat(request).await;
+                    return self.build_openai_provider().chat(request).await;
                 }
                 #[cfg(not(feature = "openai"))]
                 {
                     let _ = request;
-                    return Err(MotosanError::Config(
-                        "openai feature is not enabled".to_string(),
-                    ));
+                    return Err(Self::feature_not_enabled("openai"));
                 }
             }
             Provider::Minimax => {
                 #[cfg(feature = "minimax")]
                 {
-                    use crate::providers::minimax::MinimaxProvider;
                     use crate::providers::ProviderImpl;
-                    let provider =
-                        MinimaxProvider::new(self.api_key.clone(), self.model.clone(), None);
-                    return provider.chat(request).await;
+                    return self.build_minimax_provider().chat(request).await;
                 }
                 #[cfg(not(feature = "minimax"))]
                 {
                     let _ = request;
-                    return Err(MotosanError::Config(
-                        "minimax feature is not enabled".to_string(),
-                    ));
+                    return Err(Self::feature_not_enabled("minimax"));
                 }
             }
         }
@@ -118,55 +95,76 @@ impl Client {
             Provider::Anthropic => {
                 #[cfg(feature = "anthropic")]
                 {
-                    use crate::providers::anthropic::AnthropicProvider;
                     use crate::providers::ProviderImpl;
-                    let provider =
-                        AnthropicProvider::new(self.api_key.clone(), self.model.clone(), None);
-                    return provider.stream(request).await;
+                    return self.build_anthropic_provider().stream(request).await;
                 }
                 #[cfg(not(feature = "anthropic"))]
                 {
                     let _ = request;
-                    return Err(MotosanError::Config(
-                        "anthropic feature is not enabled".to_string(),
-                    ));
+                    return Err(Self::feature_not_enabled("anthropic"));
                 }
             }
             Provider::OpenAI => {
                 #[cfg(feature = "openai")]
                 {
-                    use crate::providers::openai::OpenAIProvider;
                     use crate::providers::ProviderImpl;
-                    let provider =
-                        OpenAIProvider::new(self.api_key.clone(), self.model.clone(), None);
-                    return provider.stream(request).await;
+                    return self.build_openai_provider().stream(request).await;
                 }
                 #[cfg(not(feature = "openai"))]
                 {
                     let _ = request;
-                    return Err(MotosanError::Config(
-                        "openai feature is not enabled".to_string(),
-                    ));
+                    return Err(Self::feature_not_enabled("openai"));
                 }
             }
             Provider::Minimax => {
                 #[cfg(feature = "minimax")]
                 {
-                    use crate::providers::minimax::MinimaxProvider;
                     use crate::providers::ProviderImpl;
-                    let provider =
-                        MinimaxProvider::new(self.api_key.clone(), self.model.clone(), None);
-                    return provider.stream(request).await;
+                    return self.build_minimax_provider().stream(request).await;
                 }
                 #[cfg(not(feature = "minimax"))]
                 {
                     let _ = request;
-                    return Err(MotosanError::Config(
-                        "minimax feature is not enabled".to_string(),
-                    ));
+                    return Err(Self::feature_not_enabled("minimax"));
                 }
             }
         }
+    }
+
+    #[cfg(any(
+        not(feature = "anthropic"),
+        not(feature = "openai"),
+        not(feature = "minimax")
+    ))]
+    fn feature_not_enabled(provider: &str) -> MotosanError {
+        MotosanError::Config(format!("{provider} feature is not enabled"))
+    }
+
+    #[cfg(feature = "anthropic")]
+    fn build_anthropic_provider(&self) -> crate::providers::anthropic::AnthropicProvider {
+        crate::providers::anthropic::AnthropicProvider::new(
+            self.api_key.clone(),
+            self.model.clone(),
+            None,
+        )
+    }
+
+    #[cfg(feature = "openai")]
+    fn build_openai_provider(&self) -> crate::providers::openai::OpenAIProvider {
+        crate::providers::openai::OpenAIProvider::new(
+            self.api_key.clone(),
+            self.model.clone(),
+            None,
+        )
+    }
+
+    #[cfg(feature = "minimax")]
+    fn build_minimax_provider(&self) -> crate::providers::minimax::MinimaxProvider {
+        crate::providers::minimax::MinimaxProvider::new(
+            self.api_key.clone(),
+            self.model.clone(),
+            None,
+        )
     }
 }
 

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -1,28 +1,19 @@
-use std::fmt::{Display, Formatter};
+use thiserror::Error;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
 pub enum MotosanError {
+    #[error("auth error: {0}")]
     Auth(String),
+    #[error("rate limit error: {0}")]
     RateLimit(String),
+    #[error("invalid request: {0}")]
     InvalidRequest(String),
+    #[error("config error: {0}")]
     Config(String),
+    #[error("provider error: {0}")]
     ProviderError(String),
+    #[error("network error: {0}")]
     Network(String),
+    #[error("stream error: {0}")]
     Stream(String),
 }
-
-impl Display for MotosanError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Auth(message) => write!(f, "auth error: {message}"),
-            Self::RateLimit(message) => write!(f, "rate limit error: {message}"),
-            Self::InvalidRequest(message) => write!(f, "invalid request: {message}"),
-            Self::Config(message) => write!(f, "config error: {message}"),
-            Self::ProviderError(message) => write!(f, "provider error: {message}"),
-            Self::Network(message) => write!(f, "network error: {message}"),
-            Self::Stream(message) => write!(f, "stream error: {message}"),
-        }
-    }
-}
-
-impl std::error::Error for MotosanError {}

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -8,4 +8,6 @@ pub use client::{Client, ClientBuilder};
 pub use error::MotosanError;
 pub use providers::Provider;
 pub use stream::{BoxStream, StreamEvent};
-pub use types::{ChatRequest, ChatResponse, Message, Role, StopReason, Tool, Usage};
+pub use types::{
+    ChatRequest, ChatRequestBuilder, ChatResponse, Message, Role, StopReason, Tool, Usage,
+};

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1,7 +1,7 @@
 use crate::error::MotosanError;
-use crate::providers::ProviderImpl;
+use crate::providers::{extract_error_message, map_http_error, ChatResponseBuilder, ProviderImpl};
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, StopReason, Usage};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use reqwest::Client;
@@ -28,23 +28,47 @@ impl AnthropicProvider {
             base_url: base_url.unwrap_or_else(|| "https://api.anthropic.com".to_string()),
         }
     }
+
+    fn endpoint(&self) -> String {
+        format!("{}/v1/messages", self.base_url)
+    }
 }
 
-#[async_trait]
-impl ProviderImpl for AnthropicProvider {
-    async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
-        let explicit_system = req.system.clone();
+struct AnthropicRequestBuilder {
+    req: ChatRequest,
+    default_model: String,
+    stream: bool,
+}
+
+impl AnthropicRequestBuilder {
+    fn new(req: ChatRequest, default_model: String) -> Self {
+        Self {
+            req,
+            default_model,
+            stream: false,
+        }
+    }
+
+    fn stream(mut self, stream: bool) -> Self {
+        self.stream = stream;
+        self
+    }
+
+    fn build(self) -> Value {
+        let model = self
+            .req
+            .model
+            .clone()
+            .unwrap_or_else(|| self.default_model.clone());
+        let explicit_system = self.req.system.clone();
         let mut extracted_systems = Vec::new();
         let mut messages = Vec::new();
 
-        for message in &req.messages {
+        for message in &self.req.messages {
             match message.role {
-                crate::types::Role::System => extracted_systems.push(message.content.clone()),
-                crate::types::Role::User => {
-                    messages.push(json!({"role": "user", "content": message.content}))
-                }
-                crate::types::Role::Assistant => {
+                Role::System => extracted_systems.push(message.content.clone()),
+                Role::User => messages.push(json!({"role": "user", "content": message.content})),
+                Role::Assistant => {
                     messages.push(json!({"role": "assistant", "content": message.content}))
                 }
             }
@@ -63,16 +87,19 @@ impl ProviderImpl for AnthropicProvider {
             "messages": messages,
         });
 
+        if self.stream {
+            body["stream"] = json!(true);
+        }
         if let Some(system_prompt) = system {
             body["system"] = json!(system_prompt);
         }
-        if let Some(temperature) = req.temperature {
+        if let Some(temperature) = self.req.temperature {
             body["temperature"] = json!(temperature);
         }
-        if let Some(max_tokens) = req.max_tokens {
+        if let Some(max_tokens) = self.req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
         }
-        if let Some(provider_options) = req.provider_options {
+        if let Some(provider_options) = self.req.provider_options {
             if let Some(map) = provider_options.as_object() {
                 for (key, value) in map {
                     body[key] = value.clone();
@@ -80,9 +107,18 @@ impl ProviderImpl for AnthropicProvider {
             }
         }
 
+        body
+    }
+}
+
+#[async_trait]
+impl ProviderImpl for AnthropicProvider {
+    async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        let body = AnthropicRequestBuilder::new(req, self.model.clone()).build();
+
         let response = self
             .http
-            .post(format!("{}/v1/messages", self.base_url))
+            .post(self.endpoint())
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", "2023-06-01")
             .json(&body)
@@ -97,18 +133,8 @@ impl ProviderImpl for AnthropicProvider {
             .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
 
         if !status.is_success() {
-            let message = payload
-                .get("error")
-                .and_then(|error| error.get("message"))
-                .and_then(Value::as_str)
-                .unwrap_or("anthropic request failed")
-                .to_string();
-            return Err(match status.as_u16() {
-                401 => MotosanError::Auth(message),
-                429 => MotosanError::RateLimit(message),
-                400 => MotosanError::InvalidRequest(message),
-                _ => MotosanError::ProviderError(message),
-            });
+            let message = extract_error_message(&payload, "anthropic request failed");
+            return Err(map_http_error(status.as_u16(), message));
         }
 
         let content = payload
@@ -129,18 +155,16 @@ impl ProviderImpl for AnthropicProvider {
             .unwrap_or("claude-sonnet-4-5")
             .to_string();
 
-        let usage = Usage {
-            input_tokens: payload
-                .get("usage")
-                .and_then(|usage| usage.get("input_tokens"))
-                .and_then(Value::as_u64)
-                .unwrap_or(0) as u32,
-            output_tokens: payload
-                .get("usage")
-                .and_then(|usage| usage.get("output_tokens"))
-                .and_then(Value::as_u64)
-                .unwrap_or(0) as u32,
-        };
+        let input_tokens = payload
+            .get("usage")
+            .and_then(|usage| usage.get("input_tokens"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+        let output_tokens = payload
+            .get("usage")
+            .and_then(|usage| usage.get("output_tokens"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
 
         let stop_reason = match payload.get("stop_reason").and_then(Value::as_str) {
             Some("end_turn") => StopReason::EndTurn,
@@ -150,66 +174,22 @@ impl ProviderImpl for AnthropicProvider {
             _ => StopReason::Other,
         };
 
-        Ok(ChatResponse {
-            content,
-            model,
-            usage,
-            stop_reason,
-        })
+        Ok(ChatResponseBuilder::new("claude-sonnet-4-5")
+            .content(content)
+            .model(model)
+            .usage(input_tokens, output_tokens)
+            .stop_reason(stop_reason)
+            .build())
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
-        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
-        let explicit_system = req.system.clone();
-        let mut extracted_systems = Vec::new();
-        let mut messages = Vec::new();
-
-        for message in &req.messages {
-            match message.role {
-                crate::types::Role::System => extracted_systems.push(message.content.clone()),
-                crate::types::Role::User => {
-                    messages.push(json!({"role": "user", "content": message.content}))
-                }
-                crate::types::Role::Assistant => {
-                    messages.push(json!({"role": "assistant", "content": message.content}))
-                }
-            }
-        }
-
-        let system = explicit_system.or_else(|| {
-            if extracted_systems.is_empty() {
-                None
-            } else {
-                Some(extracted_systems.join("\n"))
-            }
-        });
-
-        let mut body = json!({
-            "model": model,
-            "messages": messages,
-            "stream": true,
-        });
-
-        if let Some(system_prompt) = system {
-            body["system"] = json!(system_prompt);
-        }
-        if let Some(temperature) = req.temperature {
-            body["temperature"] = json!(temperature);
-        }
-        if let Some(max_tokens) = req.max_tokens {
-            body["max_tokens"] = json!(max_tokens);
-        }
-        if let Some(provider_options) = req.provider_options {
-            if let Some(map) = provider_options.as_object() {
-                for (key, value) in map {
-                    body[key] = value.clone();
-                }
-            }
-        }
+        let body = AnthropicRequestBuilder::new(req, self.model.clone())
+            .stream(true)
+            .build();
 
         let response = self
             .http
-            .post(format!("{}/v1/messages", self.base_url))
+            .post(self.endpoint())
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", "2023-06-01")
             .json(&body)
@@ -223,12 +203,7 @@ impl ProviderImpl for AnthropicProvider {
                 .text()
                 .await
                 .unwrap_or_else(|_| "anthropic stream request failed".to_string());
-            return Err(match status.as_u16() {
-                401 => MotosanError::Auth(message),
-                429 => MotosanError::RateLimit(message),
-                400 => MotosanError::InvalidRequest(message),
-                _ => MotosanError::ProviderError(message),
-            });
+            return Err(map_http_error(status.as_u16(), message));
         }
 
         let parsed_stream = response

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -1,7 +1,7 @@
 use crate::error::MotosanError;
-use crate::providers::ProviderImpl;
+use crate::providers::{extract_error_message, map_http_error, ChatResponseBuilder, ProviderImpl};
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, StopReason, Usage};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use reqwest::Client;
@@ -28,23 +28,49 @@ impl MinimaxProvider {
             base_url: base_url.unwrap_or_else(|| "https://api.minimax.chat".to_string()),
         }
     }
+
+    fn endpoint(&self) -> String {
+        format!("{}/v1/text/chatcompletion_v2", self.base_url)
+    }
 }
 
-#[async_trait]
-impl ProviderImpl for MinimaxProvider {
-    async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
+struct MinimaxRequestBuilder {
+    req: ChatRequest,
+    default_model: String,
+    stream: bool,
+}
+
+impl MinimaxRequestBuilder {
+    fn new(req: ChatRequest, default_model: String) -> Self {
+        Self {
+            req,
+            default_model,
+            stream: false,
+        }
+    }
+
+    fn stream(mut self, stream: bool) -> Self {
+        self.stream = stream;
+        self
+    }
+
+    fn build(self) -> Value {
+        let model = self
+            .req
+            .model
+            .clone()
+            .unwrap_or_else(|| self.default_model.clone());
         let mut messages = Vec::new();
 
-        if let Some(system) = &req.system {
+        if let Some(system) = &self.req.system {
             messages.push(json!({"role": "system", "content": system}));
         }
 
-        for message in &req.messages {
+        for message in &self.req.messages {
             let role = match message.role {
-                crate::types::Role::User => "user",
-                crate::types::Role::Assistant => "assistant",
-                crate::types::Role::System => "system",
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::System => "system",
             };
             messages.push(json!({"role": role, "content": message.content}));
         }
@@ -53,13 +79,17 @@ impl ProviderImpl for MinimaxProvider {
             "model": model,
             "messages": messages,
         });
-        if let Some(temperature) = req.temperature {
+
+        if self.stream {
+            body["stream"] = json!(true);
+        }
+        if let Some(temperature) = self.req.temperature {
             body["temperature"] = json!(temperature);
         }
-        if let Some(max_tokens) = req.max_tokens {
+        if let Some(max_tokens) = self.req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
         }
-        if let Some(provider_options) = req.provider_options {
+        if let Some(provider_options) = self.req.provider_options {
             if let Some(map) = provider_options.as_object() {
                 for (key, value) in map {
                     body[key] = value.clone();
@@ -67,9 +97,18 @@ impl ProviderImpl for MinimaxProvider {
             }
         }
 
+        body
+    }
+}
+
+#[async_trait]
+impl ProviderImpl for MinimaxProvider {
+    async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        let body = MinimaxRequestBuilder::new(req, self.model.clone()).build();
+
         let response = self
             .http
-            .post(format!("{}/v1/text/chatcompletion_v2", self.base_url))
+            .post(self.endpoint())
             .header("authorization", format!("Bearer {}", self.api_key))
             .json(&body)
             .send()
@@ -83,18 +122,8 @@ impl ProviderImpl for MinimaxProvider {
             .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
 
         if !status.is_success() {
-            let message = payload
-                .get("error")
-                .and_then(|error| error.get("message"))
-                .and_then(Value::as_str)
-                .unwrap_or("minimax request failed")
-                .to_string();
-            return Err(match status.as_u16() {
-                401 => MotosanError::Auth(message),
-                429 => MotosanError::RateLimit(message),
-                400 => MotosanError::InvalidRequest(message),
-                _ => MotosanError::ProviderError(message),
-            });
+            let message = extract_error_message(&payload, "minimax request failed");
+            return Err(map_http_error(status.as_u16(), message));
         }
 
         let content = payload
@@ -125,67 +154,33 @@ impl ProviderImpl for MinimaxProvider {
             .and_then(Value::as_str)
             .unwrap_or("MiniMax-Text-01")
             .to_string();
+        let input_tokens = payload
+            .get("usage")
+            .and_then(|usage| usage.get("prompt_tokens"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+        let output_tokens = payload
+            .get("usage")
+            .and_then(|usage| usage.get("completion_tokens"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
 
-        let usage = Usage {
-            input_tokens: payload
-                .get("usage")
-                .and_then(|usage| usage.get("prompt_tokens"))
-                .and_then(Value::as_u64)
-                .unwrap_or(0) as u32,
-            output_tokens: payload
-                .get("usage")
-                .and_then(|usage| usage.get("completion_tokens"))
-                .and_then(Value::as_u64)
-                .unwrap_or(0) as u32,
-        };
-
-        Ok(ChatResponse {
-            content,
-            model,
-            usage,
-            stop_reason,
-        })
+        Ok(ChatResponseBuilder::new("MiniMax-Text-01")
+            .content(content)
+            .model(model)
+            .usage(input_tokens, output_tokens)
+            .stop_reason(stop_reason)
+            .build())
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
-        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
-        let mut messages = Vec::new();
-
-        if let Some(system) = &req.system {
-            messages.push(json!({"role": "system", "content": system}));
-        }
-
-        for message in &req.messages {
-            let role = match message.role {
-                crate::types::Role::User => "user",
-                crate::types::Role::Assistant => "assistant",
-                crate::types::Role::System => "system",
-            };
-            messages.push(json!({"role": role, "content": message.content}));
-        }
-
-        let mut body = json!({
-            "model": model,
-            "messages": messages,
-            "stream": true,
-        });
-        if let Some(temperature) = req.temperature {
-            body["temperature"] = json!(temperature);
-        }
-        if let Some(max_tokens) = req.max_tokens {
-            body["max_tokens"] = json!(max_tokens);
-        }
-        if let Some(provider_options) = req.provider_options {
-            if let Some(map) = provider_options.as_object() {
-                for (key, value) in map {
-                    body[key] = value.clone();
-                }
-            }
-        }
+        let body = MinimaxRequestBuilder::new(req, self.model.clone())
+            .stream(true)
+            .build();
 
         let response = self
             .http
-            .post(format!("{}/v1/text/chatcompletion_v2", self.base_url))
+            .post(self.endpoint())
             .header("authorization", format!("Bearer {}", self.api_key))
             .json(&body)
             .send()
@@ -198,12 +193,7 @@ impl ProviderImpl for MinimaxProvider {
                 .text()
                 .await
                 .unwrap_or_else(|_| "minimax stream request failed".to_string());
-            return Err(match status.as_u16() {
-                401 => MotosanError::Auth(message),
-                429 => MotosanError::RateLimit(message),
-                400 => MotosanError::InvalidRequest(message),
-                _ => MotosanError::ProviderError(message),
-            });
+            return Err(map_http_error(status.as_u16(), message));
         }
 
         let parsed_stream = response

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -1,7 +1,8 @@
 use crate::error::MotosanError;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse};
+use crate::types::{ChatRequest, ChatResponse, StopReason, Usage};
 use async_trait::async_trait;
+use serde_json::Value;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Provider {
@@ -14,6 +15,77 @@ pub enum Provider {
 pub trait ProviderImpl: Send + Sync {
     async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError>;
     async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError>;
+}
+
+pub(crate) struct ChatResponseBuilder {
+    content: String,
+    model: String,
+    usage: Usage,
+    stop_reason: StopReason,
+}
+
+impl ChatResponseBuilder {
+    pub(crate) fn new(default_model: impl Into<String>) -> Self {
+        Self {
+            content: String::new(),
+            model: default_model.into(),
+            usage: Usage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+            stop_reason: StopReason::Other,
+        }
+    }
+
+    pub(crate) fn content(mut self, content: impl Into<String>) -> Self {
+        self.content = content.into();
+        self
+    }
+
+    pub(crate) fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub(crate) fn usage(mut self, input_tokens: u32, output_tokens: u32) -> Self {
+        self.usage = Usage {
+            input_tokens,
+            output_tokens,
+        };
+        self
+    }
+
+    pub(crate) fn stop_reason(mut self, stop_reason: StopReason) -> Self {
+        self.stop_reason = stop_reason;
+        self
+    }
+
+    pub(crate) fn build(self) -> ChatResponse {
+        ChatResponse {
+            content: self.content,
+            model: self.model,
+            usage: self.usage,
+            stop_reason: self.stop_reason,
+        }
+    }
+}
+
+pub(crate) fn extract_error_message(payload: &Value, fallback: &str) -> String {
+    payload
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+pub(crate) fn map_http_error(status_code: u16, message: String) -> MotosanError {
+    match status_code {
+        401 => MotosanError::Auth(message),
+        429 => MotosanError::RateLimit(message),
+        400 => MotosanError::InvalidRequest(message),
+        _ => MotosanError::ProviderError(message),
+    }
 }
 
 #[cfg(feature = "anthropic")]

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -1,7 +1,7 @@
 use crate::error::MotosanError;
-use crate::providers::ProviderImpl;
+use crate::providers::{extract_error_message, map_http_error, ChatResponseBuilder, ProviderImpl};
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, StopReason, Usage};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use reqwest::Client;
@@ -28,23 +28,49 @@ impl OpenAIProvider {
             base_url: base_url.unwrap_or_else(|| "https://api.openai.com".to_string()),
         }
     }
+
+    fn endpoint(&self) -> String {
+        format!("{}/v1/chat/completions", self.base_url)
+    }
 }
 
-#[async_trait]
-impl ProviderImpl for OpenAIProvider {
-    async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
+struct OpenAIRequestBuilder {
+    req: ChatRequest,
+    default_model: String,
+    stream: bool,
+}
+
+impl OpenAIRequestBuilder {
+    fn new(req: ChatRequest, default_model: String) -> Self {
+        Self {
+            req,
+            default_model,
+            stream: false,
+        }
+    }
+
+    fn stream(mut self, stream: bool) -> Self {
+        self.stream = stream;
+        self
+    }
+
+    fn build(self) -> Value {
+        let model = self
+            .req
+            .model
+            .clone()
+            .unwrap_or_else(|| self.default_model.clone());
         let mut messages = Vec::new();
 
-        if let Some(system) = &req.system {
+        if let Some(system) = &self.req.system {
             messages.push(json!({"role": "system", "content": system}));
         }
 
-        for message in &req.messages {
+        for message in &self.req.messages {
             let role = match message.role {
-                crate::types::Role::User => "user",
-                crate::types::Role::Assistant => "assistant",
-                crate::types::Role::System => "system",
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::System => "system",
             };
             messages.push(json!({"role": role, "content": message.content}));
         }
@@ -53,13 +79,17 @@ impl ProviderImpl for OpenAIProvider {
             "model": model,
             "messages": messages,
         });
-        if let Some(temperature) = req.temperature {
+
+        if self.stream {
+            body["stream"] = json!(true);
+        }
+        if let Some(temperature) = self.req.temperature {
             body["temperature"] = json!(temperature);
         }
-        if let Some(max_tokens) = req.max_tokens {
+        if let Some(max_tokens) = self.req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
         }
-        if let Some(provider_options) = req.provider_options {
+        if let Some(provider_options) = self.req.provider_options {
             if let Some(map) = provider_options.as_object() {
                 for (key, value) in map {
                     body[key] = value.clone();
@@ -67,9 +97,18 @@ impl ProviderImpl for OpenAIProvider {
             }
         }
 
+        body
+    }
+}
+
+#[async_trait]
+impl ProviderImpl for OpenAIProvider {
+    async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        let body = OpenAIRequestBuilder::new(req, self.model.clone()).build();
+
         let response = self
             .http
-            .post(format!("{}/v1/chat/completions", self.base_url))
+            .post(self.endpoint())
             .header("authorization", format!("Bearer {}", self.api_key))
             .json(&body)
             .send()
@@ -83,18 +122,8 @@ impl ProviderImpl for OpenAIProvider {
             .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
 
         if !status.is_success() {
-            let message = payload
-                .get("error")
-                .and_then(|error| error.get("message"))
-                .and_then(Value::as_str)
-                .unwrap_or("openai request failed")
-                .to_string();
-            return Err(match status.as_u16() {
-                401 => MotosanError::Auth(message),
-                429 => MotosanError::RateLimit(message),
-                400 => MotosanError::InvalidRequest(message),
-                _ => MotosanError::ProviderError(message),
-            });
+            let message = extract_error_message(&payload, "openai request failed");
+            return Err(map_http_error(status.as_u16(), message));
         }
 
         let content = payload
@@ -125,67 +154,33 @@ impl ProviderImpl for OpenAIProvider {
             .and_then(Value::as_str)
             .unwrap_or("gpt-4o")
             .to_string();
+        let input_tokens = payload
+            .get("usage")
+            .and_then(|usage| usage.get("prompt_tokens"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+        let output_tokens = payload
+            .get("usage")
+            .and_then(|usage| usage.get("completion_tokens"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
 
-        let usage = Usage {
-            input_tokens: payload
-                .get("usage")
-                .and_then(|usage| usage.get("prompt_tokens"))
-                .and_then(Value::as_u64)
-                .unwrap_or(0) as u32,
-            output_tokens: payload
-                .get("usage")
-                .and_then(|usage| usage.get("completion_tokens"))
-                .and_then(Value::as_u64)
-                .unwrap_or(0) as u32,
-        };
-
-        Ok(ChatResponse {
-            content,
-            model,
-            usage,
-            stop_reason,
-        })
+        Ok(ChatResponseBuilder::new("gpt-4o")
+            .content(content)
+            .model(model)
+            .usage(input_tokens, output_tokens)
+            .stop_reason(stop_reason)
+            .build())
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
-        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
-        let mut messages = Vec::new();
-
-        if let Some(system) = &req.system {
-            messages.push(json!({"role": "system", "content": system}));
-        }
-
-        for message in &req.messages {
-            let role = match message.role {
-                crate::types::Role::User => "user",
-                crate::types::Role::Assistant => "assistant",
-                crate::types::Role::System => "system",
-            };
-            messages.push(json!({"role": role, "content": message.content}));
-        }
-
-        let mut body = json!({
-            "model": model,
-            "messages": messages,
-            "stream": true,
-        });
-        if let Some(temperature) = req.temperature {
-            body["temperature"] = json!(temperature);
-        }
-        if let Some(max_tokens) = req.max_tokens {
-            body["max_tokens"] = json!(max_tokens);
-        }
-        if let Some(provider_options) = req.provider_options {
-            if let Some(map) = provider_options.as_object() {
-                for (key, value) in map {
-                    body[key] = value.clone();
-                }
-            }
-        }
+        let body = OpenAIRequestBuilder::new(req, self.model.clone())
+            .stream(true)
+            .build();
 
         let response = self
             .http
-            .post(format!("{}/v1/chat/completions", self.base_url))
+            .post(self.endpoint())
             .header("authorization", format!("Bearer {}", self.api_key))
             .json(&body)
             .send()
@@ -198,12 +193,7 @@ impl ProviderImpl for OpenAIProvider {
                 .text()
                 .await
                 .unwrap_or_else(|_| "openai stream request failed".to_string());
-            return Err(match status.as_u16() {
-                401 => MotosanError::Auth(message),
-                429 => MotosanError::RateLimit(message),
-                400 => MotosanError::InvalidRequest(message),
-                _ => MotosanError::ProviderError(message),
-            });
+            return Err(map_http_error(status.as_u16(), message));
         }
 
         let parsed_stream = response

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -56,6 +56,77 @@ pub struct ChatRequest {
     pub provider_options: Option<Value>,
 }
 
+impl ChatRequest {
+    pub fn builder() -> ChatRequestBuilder {
+        ChatRequestBuilder::default()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ChatRequestBuilder {
+    messages: Vec<Message>,
+    model: Option<String>,
+    system: Option<String>,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    tools: Option<Vec<Tool>>,
+    provider_options: Option<Value>,
+}
+
+impl ChatRequestBuilder {
+    pub fn messages(mut self, messages: Vec<Message>) -> Self {
+        self.messages = messages;
+        self
+    }
+
+    pub fn message(mut self, message: Message) -> Self {
+        self.messages.push(message);
+        self
+    }
+
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    pub fn system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    pub fn temperature(mut self, temperature: f32) -> Self {
+        self.temperature = Some(temperature);
+        self
+    }
+
+    pub fn max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+
+    pub fn tools(mut self, tools: Vec<Tool>) -> Self {
+        self.tools = Some(tools);
+        self
+    }
+
+    pub fn provider_options(mut self, provider_options: Value) -> Self {
+        self.provider_options = Some(provider_options);
+        self
+    }
+
+    pub fn build(self) -> ChatRequest {
+        ChatRequest {
+            messages: self.messages,
+            model: self.model,
+            system: self.system,
+            temperature: self.temperature,
+            max_tokens: self.max_tokens,
+            tools: self.tools,
+            provider_options: self.provider_options,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatResponse {
     pub content: String,

--- a/sdks/rust/tests/anthropic_chat.rs
+++ b/sdks/rust/tests/anthropic_chat.rs
@@ -27,15 +27,12 @@ async fn anthropic_chat_maps_response() {
         .await;
 
     let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
-    let request = ChatRequest {
-        messages: vec![Message::system("rules"), Message::user("hello")],
-        model: None,
-        system: None,
-        temperature: Some(0.2),
-        max_tokens: Some(100),
-        tools: None,
-        provider_options: None,
-    };
+    let request = ChatRequest::builder()
+        .message(Message::system("rules"))
+        .message(Message::user("hello"))
+        .temperature(0.2)
+        .max_tokens(100)
+        .build();
 
     let response = provider.chat(request).await.expect("chat response");
     assert_eq!(response.content, "hello from anthropic");

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -27,15 +27,9 @@ async fn anthropic_stream_emits_content_and_done_event() {
         .await;
 
     let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
-    let request = ChatRequest {
-        messages: vec![Message::user("hello")],
-        model: None,
-        system: None,
-        temperature: None,
-        max_tokens: None,
-        tools: None,
-        provider_options: None,
-    };
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
 
     let mut stream = provider.stream(request).await.expect("stream response");
     let mut received = Vec::new();
@@ -50,6 +44,51 @@ async fn anthropic_stream_emits_content_and_done_event() {
     assert_eq!(received[1].content, "lo");
     assert!(!received[1].done);
     assert!(received[2].done);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn anthropic_stream_ignores_unknown_and_malformed_events() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: ping\n",
+        "data: {\"type\":\"ping\"}\n\n",
+        "event: content_block_delta\n",
+        "data: not-json\n\n",
+        "event: some_unknown_event\n",
+        "data: {\"type\":\"unknown\"}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"ok\"}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut received = Vec::new();
+
+    while let Some(event) = stream.next().await {
+        received.push(event);
+    }
+
+    assert_eq!(received.len(), 2);
+    assert_eq!(received[0].content, "ok");
+    assert!(!received[0].done);
+    assert!(received[1].done);
 
     mock.assert_async().await;
 }

--- a/sdks/rust/tests/core_types.rs
+++ b/sdks/rust/tests/core_types.rs
@@ -1,4 +1,4 @@
-use motosan_ai::{Message, Role, StopReason};
+use motosan_ai::{ChatRequest, Message, Role, StopReason};
 
 #[test]
 fn message_constructors_set_role_and_content() {
@@ -16,4 +16,23 @@ fn message_constructors_set_role_and_content() {
 fn stop_reason_serializes_to_snake_case() {
     let serialized = serde_json::to_string(&StopReason::EndTurn).expect("serialize stop reason");
     assert_eq!(serialized, "\"end_turn\"");
+}
+
+#[test]
+fn chat_request_builder_populates_optional_fields() {
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .system("rules")
+        .model("gpt-4o")
+        .temperature(0.2)
+        .max_tokens(128)
+        .provider_options(serde_json::json!({"reasoning_effort": "low"}))
+        .build();
+
+    assert_eq!(request.messages.len(), 1);
+    assert_eq!(request.system.as_deref(), Some("rules"));
+    assert_eq!(request.model.as_deref(), Some("gpt-4o"));
+    assert_eq!(request.temperature, Some(0.2));
+    assert_eq!(request.max_tokens, Some(128));
+    assert!(request.provider_options.is_some());
 }

--- a/sdks/rust/tests/error_mapping.rs
+++ b/sdks/rust/tests/error_mapping.rs
@@ -3,15 +3,9 @@ use motosan_ai::{ChatRequest, Message, MotosanError};
 use serde_json::json;
 
 fn sample_request() -> ChatRequest {
-    ChatRequest {
-        messages: vec![Message::user("hello")],
-        model: None,
-        system: None,
-        temperature: None,
-        max_tokens: None,
-        tools: None,
-        provider_options: None,
-    }
+    ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build()
 }
 
 #[cfg(feature = "anthropic")]

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -25,15 +25,12 @@ async fn minimax_chat_maps_response() {
         .await;
 
     let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
-    let request = ChatRequest {
-        messages: vec![Message::user("hello")],
-        model: None,
-        system: Some("rules".to_string()),
-        temperature: Some(0.3),
-        max_tokens: Some(40),
-        tools: None,
-        provider_options: None,
-    };
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .system("rules")
+        .temperature(0.3)
+        .max_tokens(40)
+        .build();
 
     let response = provider.chat(request).await.expect("chat response");
     assert_eq!(response.content, "hello from minimax");
@@ -62,15 +59,9 @@ async fn minimax_stream_emits_content_and_done() {
         .await;
 
     let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
-    let request = ChatRequest {
-        messages: vec![Message::user("hello")],
-        model: None,
-        system: None,
-        temperature: None,
-        max_tokens: None,
-        tools: None,
-        provider_options: None,
-    };
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
 
     let mut stream = provider.stream(request).await.expect("stream response");
     let mut events = Vec::new();
@@ -82,6 +73,43 @@ async fn minimax_stream_emits_content_and_done() {
     assert_eq!(events[0].content, "hel");
     assert_eq!(events[1].content, "lo");
     assert!(events[2].done);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_stream_ignores_malformed_chunks() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "data: not-json\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/text/chatcompletion_v2")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].content, "ok");
+    assert!(!events[0].done);
+    assert!(events[1].done);
 
     mock.assert_async().await;
 }

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -25,15 +25,12 @@ async fn openai_chat_maps_response() {
         .await;
 
     let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
-    let request = ChatRequest {
-        messages: vec![Message::system("rules"), Message::user("hello")],
-        model: None,
-        system: None,
-        temperature: Some(0.1),
-        max_tokens: Some(50),
-        tools: None,
-        provider_options: None,
-    };
+    let request = ChatRequest::builder()
+        .message(Message::system("rules"))
+        .message(Message::user("hello"))
+        .temperature(0.1)
+        .max_tokens(50)
+        .build();
 
     let response = provider.chat(request).await.expect("chat response");
     assert_eq!(response.content, "hello from openai");
@@ -63,15 +60,9 @@ async fn openai_stream_emits_deltas_and_done() {
         .await;
 
     let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
-    let request = ChatRequest {
-        messages: vec![Message::user("hello")],
-        model: None,
-        system: None,
-        temperature: None,
-        max_tokens: None,
-        tools: None,
-        provider_options: None,
-    };
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
 
     let mut stream = provider.stream(request).await.expect("stream response");
     let mut events = Vec::new();
@@ -84,6 +75,44 @@ async fn openai_stream_emits_deltas_and_done() {
     assert_eq!(events[0].content, "hel");
     assert_eq!(events[1].content, "lo");
     assert!(events[2].done);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_stream_ignores_malformed_chunks() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "data: not-json\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut events = Vec::new();
+
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].content, "ok");
+    assert!(!events[0].done);
+    assert!(events[1].done);
 
     mock.assert_async().await;
 }


### PR DESCRIPTION
## Summary
- add `ChatRequestBuilder` and migrate request construction call sites to builder style
- refactor providers to use per-provider request builders:
  - `AnthropicRequestBuilder`
  - `OpenAIRequestBuilder`
  - `MinimaxRequestBuilder`
- centralize shared provider utilities:
  - `ChatResponseBuilder`
  - shared HTTP error mapping helpers
- simplify `Client` dispatch by extracting provider factory helpers
- migrate error definition to `thiserror`
- expand streaming robustness tests for malformed/unknown SSE events

## Verification
- `cd sdks/rust && cargo fmt --all`
- `cd sdks/rust && cargo clippy --all-features --all-targets -- -D warnings`
- `cd sdks/rust && cargo test --all-features`

## Notes
- This PR is focused on internal API consistency and maintainability before release hardening.
