### PR TITLE
chore(rust): centralize model catalog and refresh defaults

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -2,6 +2,23 @@
 
 Feature-flagged Rust SDK for Anthropic, OpenAI, and MiniMax.
 
+## Quickstart
+
+```rust
+use motosan_ai::{Client, Message, Provider};
+
+# async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+let client = Client::builder()
+    .provider(Provider::Anthropic)
+    .api_key(std::env::var("ANTHROPIC_API_KEY")?)
+    .build()?;
+
+let response = client.chat(vec![Message::user("hello")]).await?;
+println!("{}", response.content);
+# Ok(())
+# }
+```
+
 ## Build
 
 ```bash
@@ -16,3 +33,48 @@ cargo build -p motosan-ai --all-features
 - `minimax`
 - `full` (enables all providers)
 
+## Model Defaults
+
+- Anthropic: `claude-sonnet-4-6`
+- OpenAI: `gpt-5.3-codex`
+- MiniMax: `MiniMax-Text-01`
+
+Override per client:
+
+```rust
+let client = Client::builder()
+    .provider(Provider::OpenAI)
+    .api_key("...")
+    .model("gpt-4o")
+    .build()?;
+```
+
+Override per request:
+
+```rust
+use motosan_ai::{ChatRequest, Message};
+
+let request = ChatRequest::builder()
+    .message(Message::user("hello"))
+    .model("gpt-4o")
+    .build();
+```
+
+## Error Handling Example
+
+```rust
+match client.chat(vec![Message::user("hello")]).await {
+    Ok(response) => println!("{}", response.content),
+    Err(error) => eprintln!("request failed: {error}"),
+}
+```
+
+## Model Maintenance (survey process)
+
+When updating model defaults, verify against official provider documentation:
+
+- Anthropic models: https://docs.anthropic.com/
+- OpenAI models: https://platform.openai.com/docs/models
+- MiniMax API docs: https://www.minimax.io/platform/document
+
+Prefer stable aliases for defaults and keep dated snapshots listed in `src/models.rs`.

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -1,11 +1,16 @@
 pub mod client;
 pub mod error;
+pub mod models;
 pub mod providers;
 pub mod stream;
 pub mod types;
 
 pub use client::{Client, ClientBuilder};
 pub use error::MotosanError;
+pub use models::{
+    ANTHROPIC_MODELS, DEFAULT_ANTHROPIC_MODEL, DEFAULT_MINIMAX_MODEL, DEFAULT_OPENAI_MODEL,
+    MINIMAX_MODELS, OPENAI_MODELS,
+};
 pub use providers::Provider;
 pub use stream::{BoxStream, StreamEvent};
 pub use types::{

--- a/sdks/rust/src/models.rs
+++ b/sdks/rust/src/models.rs
@@ -1,0 +1,19 @@
+pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-6";
+pub const DEFAULT_OPENAI_MODEL: &str = "gpt-5.3-codex";
+pub const DEFAULT_MINIMAX_MODEL: &str = "MiniMax-Text-01";
+
+pub const ANTHROPIC_MODELS: &[&str] = &[
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-sonnet-4-5-20250929",
+    "claude-opus-4-5-20251101",
+    "claude-opus-4-1-20250805",
+    "claude-sonnet-4-20250514",
+    "claude-opus-4-20250514",
+    "claude-3-haiku-20240307",
+];
+
+pub const OPENAI_MODELS: &[&str] = &["gpt-5.3-codex", "gpt-4o"];
+
+pub const MINIMAX_MODELS: &[&str] = &["MiniMax-Text-01"];

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1,4 +1,5 @@
 use crate::error::MotosanError;
+use crate::models::DEFAULT_ANTHROPIC_MODEL;
 use crate::providers::{extract_error_message, map_http_error, ChatResponseBuilder, ProviderImpl};
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
@@ -24,7 +25,7 @@ impl AnthropicProvider {
         Self {
             http: Client::new(),
             api_key: api_key.into(),
-            model: model.unwrap_or_else(|| "claude-sonnet-4-5".to_string()),
+            model: model.unwrap_or_else(|| DEFAULT_ANTHROPIC_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| "https://api.anthropic.com".to_string()),
         }
     }
@@ -174,7 +175,7 @@ impl ProviderImpl for AnthropicProvider {
             _ => StopReason::Other,
         };
 
-        Ok(ChatResponseBuilder::new("claude-sonnet-4-5")
+        Ok(ChatResponseBuilder::new(DEFAULT_ANTHROPIC_MODEL)
             .content(content)
             .model(model)
             .usage(input_tokens, output_tokens)

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -1,4 +1,5 @@
 use crate::error::MotosanError;
+use crate::models::DEFAULT_MINIMAX_MODEL;
 use crate::providers::{extract_error_message, map_http_error, ChatResponseBuilder, ProviderImpl};
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
@@ -24,7 +25,7 @@ impl MinimaxProvider {
         Self {
             http: Client::new(),
             api_key: api_key.into(),
-            model: model.unwrap_or_else(|| "MiniMax-Text-01".to_string()),
+            model: model.unwrap_or_else(|| DEFAULT_MINIMAX_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| "https://api.minimax.chat".to_string()),
         }
     }
@@ -152,7 +153,7 @@ impl ProviderImpl for MinimaxProvider {
         let model = payload
             .get("model")
             .and_then(Value::as_str)
-            .unwrap_or("MiniMax-Text-01")
+            .unwrap_or(DEFAULT_MINIMAX_MODEL)
             .to_string();
         let input_tokens = payload
             .get("usage")
@@ -165,7 +166,7 @@ impl ProviderImpl for MinimaxProvider {
             .and_then(Value::as_u64)
             .unwrap_or(0) as u32;
 
-        Ok(ChatResponseBuilder::new("MiniMax-Text-01")
+        Ok(ChatResponseBuilder::new(DEFAULT_MINIMAX_MODEL)
             .content(content)
             .model(model)
             .usage(input_tokens, output_tokens)

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -1,4 +1,5 @@
 use crate::error::MotosanError;
+use crate::models::DEFAULT_OPENAI_MODEL;
 use crate::providers::{extract_error_message, map_http_error, ChatResponseBuilder, ProviderImpl};
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
@@ -24,7 +25,7 @@ impl OpenAIProvider {
         Self {
             http: Client::new(),
             api_key: api_key.into(),
-            model: model.unwrap_or_else(|| "gpt-4o".to_string()),
+            model: model.unwrap_or_else(|| DEFAULT_OPENAI_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| "https://api.openai.com".to_string()),
         }
     }
@@ -152,7 +153,7 @@ impl ProviderImpl for OpenAIProvider {
         let model = payload
             .get("model")
             .and_then(Value::as_str)
-            .unwrap_or("gpt-4o")
+            .unwrap_or(DEFAULT_OPENAI_MODEL)
             .to_string();
         let input_tokens = payload
             .get("usage")
@@ -165,7 +166,7 @@ impl ProviderImpl for OpenAIProvider {
             .and_then(Value::as_u64)
             .unwrap_or(0) as u32;
 
-        Ok(ChatResponseBuilder::new("gpt-4o")
+        Ok(ChatResponseBuilder::new(DEFAULT_OPENAI_MODEL)
             .content(content)
             .model(model)
             .usage(input_tokens, output_tokens)

--- a/sdks/rust/tests/anthropic_chat.rs
+++ b/sdks/rust/tests/anthropic_chat.rs
@@ -1,8 +1,9 @@
 #![cfg(feature = "anthropic")]
 
+use mockito::Matcher;
 use motosan_ai::providers::anthropic::AnthropicProvider;
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, StopReason};
+use motosan_ai::{ChatRequest, Message, StopReason, DEFAULT_ANTHROPIC_MODEL};
 use serde_json::json;
 
 #[tokio::test]
@@ -41,4 +42,65 @@ async fn anthropic_chat_maps_response() {
     assert!(matches!(response.stop_reason, StopReason::EndTurn));
 
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn anthropic_request_uses_default_model_and_allows_override() {
+    let mut server = mockito::Server::new_async().await;
+
+    let default_mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_body(Matcher::Regex(format!(
+            r#"\"model\"\s*:\s*\"{}\""#,
+            DEFAULT_ANTHROPIC_MODEL
+        )))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": DEFAULT_ANTHROPIC_MODEL,
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+    let _ = provider.chat(request).await.expect("chat response");
+    default_mock.assert_async().await;
+
+    server.reset();
+    let override_model = "claude-opus-4-6";
+    let override_mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_body(Matcher::Regex(format!(
+            r#"\"model\"\s*:\s*\"{}\""#,
+            override_model
+        )))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": override_model,
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .model(override_model)
+        .build();
+    let _ = provider.chat(request).await.expect("chat response");
+    override_mock.assert_async().await;
 }

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -1,8 +1,9 @@
 #![cfg(feature = "minimax")]
 
+use mockito::Matcher;
 use motosan_ai::providers::minimax::MinimaxProvider;
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, StopReason};
+use motosan_ai::{ChatRequest, Message, StopReason, DEFAULT_MINIMAX_MODEL};
 use serde_json::json;
 use tokio_stream::StreamExt;
 
@@ -38,6 +39,65 @@ async fn minimax_chat_maps_response() {
     assert!(matches!(response.stop_reason, StopReason::Stop));
 
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_request_uses_default_model_and_allows_override() {
+    let mut server = mockito::Server::new_async().await;
+
+    let default_mock = server
+        .mock("POST", "/v1/text/chatcompletion_v2")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(format!(
+            r#"\"model\"\s*:\s*\"{}\""#,
+            DEFAULT_MINIMAX_MODEL
+        )))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": DEFAULT_MINIMAX_MODEL,
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+    let _ = provider.chat(request).await.expect("chat response");
+    default_mock.assert_async().await;
+
+    server.reset();
+    let override_model = "MiniMax-Text-01";
+    let override_mock = server
+        .mock("POST", "/v1/text/chatcompletion_v2")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(format!(
+            r#"\"model\"\s*:\s*\"{}\""#,
+            override_model
+        )))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": override_model,
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .model(override_model)
+        .build();
+    let _ = provider.chat(request).await.expect("chat response");
+    override_mock.assert_async().await;
 }
 
 #[tokio::test]

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -1,8 +1,9 @@
 #![cfg(feature = "openai")]
 
+use mockito::Matcher;
 use motosan_ai::providers::openai::OpenAIProvider;
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, StopReason};
+use motosan_ai::{ChatRequest, Message, StopReason, DEFAULT_OPENAI_MODEL};
 use serde_json::json;
 use tokio_stream::StreamExt;
 
@@ -39,6 +40,65 @@ async fn openai_chat_maps_response() {
     assert!(matches!(response.stop_reason, StopReason::Stop));
 
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_request_uses_default_model_and_allows_override() {
+    let mut server = mockito::Server::new_async().await;
+
+    let default_mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(format!(
+            r#"\"model\"\s*:\s*\"{}\""#,
+            DEFAULT_OPENAI_MODEL
+        )))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": DEFAULT_OPENAI_MODEL,
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+    let _ = provider.chat(request).await.expect("chat response");
+    default_mock.assert_async().await;
+
+    server.reset();
+    let override_model = "gpt-4o";
+    let override_mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(format!(
+            r#"\"model\"\s*:\s*\"{}\""#,
+            override_model
+        )))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": override_model,
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .model(override_model)
+        .build();
+    let _ = provider.chat(request).await.expect("chat response");
+    override_mock.assert_async().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add `src/models.rs` as centralized model catalog and provider defaults
- update provider defaults to use catalog constants:
  - Anthropic: `claude-sonnet-4-6`
  - OpenAI: `gpt-5.3-codex`
  - MiniMax: `MiniMax-Text-01`
- add test coverage for default-model wiring and explicit model override per provider
- update Rust README with quickstart, model defaults, override examples, and maintenance links

## Verification
- `cd sdks/rust && cargo fmt --all -- --check`
- `cd sdks/rust && cargo clippy --all-features --all-targets -- -D warnings`
- `cd sdks/rust && cargo test --all-features`

Closes #24
