### PR TITLE
chore(release): complete P0 pre-publish checklist

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 motosan-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -1,7 +1,10 @@
 use crate::error::MotosanError;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, StopReason, Usage};
+use crate::types::{ChatRequest, ChatResponse};
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+use crate::types::{StopReason, Usage};
 use async_trait::async_trait;
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 use serde_json::Value;
 
 #[derive(Debug, Clone, Copy)]
@@ -17,6 +20,7 @@ pub trait ProviderImpl: Send + Sync {
     async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError>;
 }
 
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 pub(crate) struct ChatResponseBuilder {
     content: String,
     model: String,
@@ -24,6 +28,7 @@ pub(crate) struct ChatResponseBuilder {
     stop_reason: StopReason,
 }
 
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 impl ChatResponseBuilder {
     pub(crate) fn new(default_model: impl Into<String>) -> Self {
         Self {
@@ -70,6 +75,7 @@ impl ChatResponseBuilder {
     }
 }
 
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 pub(crate) fn extract_error_message(payload: &Value, fallback: &str) -> String {
     payload
         .get("error")
@@ -79,6 +85,7 @@ pub(crate) fn extract_error_message(payload: &Value, fallback: &str) -> String {
         .to_string()
 }
 
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 pub(crate) fn map_http_error(status_code: u16, message: String) -> MotosanError {
     match status_code {
         401 => MotosanError::Auth(message),


### PR DESCRIPTION
## Summary
- add root `LICENSE` (MIT)
- fix no-feature compile warnings by feature-gating shared provider utility imports/symbols
- confirm release preflight commands pass cleanly:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-features --all-targets -- -D warnings`
  - `cargo test --all-features`
  - `cd sdks/rust && cargo publish --dry-run`

Closes #25
