### PR TITLE
feat(rust): add configurable retry policy for transient failures

### DIFF
--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 - Provider implementations for chat + streaming on Anthropic/OpenAI/MiniMax.
 - Shared provider mapping utilities and robust SSE parsing behavior.
 - Integration tests for provider happy paths, streaming behavior, and error mapping.
+- Configurable retry policy (`RetryPolicy`) with exponential backoff, optional jitter, and `Retry-After` support.
 - Rust CI workflow (`fmt`, `clippy`, `test`).
 
 ### Changed

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["api-bindings", "asynchronous"]
 
 [features]
 default = []
-anthropic = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream"]
-openai = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream"]
-minimax = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream"]
+anthropic = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream", "dep:tokio"]
+openai = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream", "dep:tokio"]
+minimax = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream", "dep:tokio"]
 full = ["anthropic", "openai", "minimax"]
 
 [dependencies]
@@ -29,6 +29,7 @@ thiserror = "2"
 reqwest = { version = "0.12", optional = true, features = ["json", "stream", "rustls-tls"] }
 eventsource-stream = { version = "0.2", optional = true }
 tokio-stream = { version = "0.1", optional = true }
+tokio = { version = "1", optional = true, features = ["time"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -92,6 +92,27 @@ match client.chat(vec![Message::user("hello")]).await {
 }
 ```
 
+## Retry Policy
+
+Retry is enabled by default for transient failures (`429`, `5xx`, timeout/connect errors).
+
+```rust
+use motosan_ai::{Client, Provider, RetryPolicy};
+
+let retry_policy = RetryPolicy::new()
+    .max_retries(3)
+    .base_delay_ms(100)
+    .max_delay_ms(2_000)
+    .jitter(true)
+    .respect_retry_after(true);
+
+let client = Client::builder()
+    .provider(Provider::OpenAI)
+    .api_key("...")
+    .retry_policy(retry_policy)
+    .build()?;
+```
+
 Error handling policy reference: `docs/error-handling-policy.md`.
 
 ## Model Maintenance (survey process)

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,5 +1,6 @@
 use crate::error::MotosanError;
 use crate::providers::Provider;
+use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, Message};
 
@@ -8,6 +9,7 @@ pub struct Client {
     provider: Provider,
     api_key: String,
     model: Option<String>,
+    retry_policy: RetryPolicy,
 }
 
 impl Client {
@@ -25,6 +27,10 @@ impl Client {
 
     pub fn model(&self) -> Option<&str> {
         self.model.as_deref()
+    }
+
+    pub fn retry_policy(&self) -> &RetryPolicy {
+        &self.retry_policy
     }
 
     pub async fn chat(&self, messages: Vec<Message>) -> Result<ChatResponse, MotosanError> {
@@ -147,6 +153,7 @@ impl Client {
             self.model.clone(),
             None,
         )
+        .with_retry_policy(self.retry_policy.clone())
     }
 
     #[cfg(feature = "openai")]
@@ -156,6 +163,7 @@ impl Client {
             self.model.clone(),
             None,
         )
+        .with_retry_policy(self.retry_policy.clone())
     }
 
     #[cfg(feature = "minimax")]
@@ -165,6 +173,7 @@ impl Client {
             self.model.clone(),
             None,
         )
+        .with_retry_policy(self.retry_policy.clone())
     }
 }
 
@@ -173,6 +182,7 @@ pub struct ClientBuilder {
     provider: Option<Provider>,
     api_key: Option<String>,
     model: Option<String>,
+    retry_policy: Option<RetryPolicy>,
 }
 
 impl ClientBuilder {
@@ -191,6 +201,11 @@ impl ClientBuilder {
         self
     }
 
+    pub fn retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
+        self.retry_policy = Some(retry_policy);
+        self
+    }
+
     pub fn build(self) -> Result<Client, MotosanError> {
         let provider = self
             .provider
@@ -203,6 +218,7 @@ impl ClientBuilder {
             provider,
             api_key,
             model: self.model,
+            retry_policy: self.retry_policy.unwrap_or_default(),
         })
     }
 }

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -2,6 +2,7 @@ pub mod client;
 pub mod error;
 pub mod models;
 pub mod providers;
+pub mod retry;
 pub mod stream;
 pub mod types;
 
@@ -12,6 +13,7 @@ pub use models::{
     MINIMAX_MODELS, OPENAI_MODELS,
 };
 pub use providers::Provider;
+pub use retry::RetryPolicy;
 pub use stream::{BoxStream, StreamEvent};
 pub use types::{
     ChatRequest, ChatRequestBuilder, ChatResponse, Message, Role, StopReason, Tool, Usage,

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1,6 +1,10 @@
 use crate::error::MotosanError;
 use crate::models::DEFAULT_ANTHROPIC_MODEL;
-use crate::providers::{extract_error_message, map_http_error, ChatResponseBuilder, ProviderImpl};
+use crate::providers::{
+    extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
+    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+};
+use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
 use async_trait::async_trait;
@@ -14,6 +18,7 @@ pub struct AnthropicProvider {
     api_key: String,
     model: String,
     base_url: String,
+    retry_policy: RetryPolicy,
 }
 
 impl AnthropicProvider {
@@ -27,7 +32,13 @@ impl AnthropicProvider {
             api_key: api_key.into(),
             model: model.unwrap_or_else(|| DEFAULT_ANTHROPIC_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| "https://api.anthropic.com".to_string()),
+            retry_policy: RetryPolicy::default(),
         }
+    }
+
+    pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
+        self.retry_policy = retry_policy;
+        self
     }
 
     fn endpoint(&self) -> String {
@@ -116,25 +127,49 @@ impl AnthropicRequestBuilder {
 impl ProviderImpl for AnthropicProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let body = AnthropicRequestBuilder::new(req, self.model.clone()).build();
+        let mut attempt = 0;
+        let payload: Value;
+        loop {
+            let response = match self
+                .http
+                .post(self.endpoint())
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", "2023-06-01")
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
+                    {
+                        attempt += 1;
+                        sleep_before_retry(&self.retry_policy, attempt, None).await;
+                        continue;
+                    }
+                    return Err(MotosanError::Network(error.to_string()));
+                }
+            };
 
-        let response = self
-            .http
-            .post(self.endpoint())
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", "2023-06-01")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| MotosanError::Network(error.to_string()))?;
+            let status = response.status();
+            let retry_after = parse_retry_after(response.headers());
+            let current_payload: Value = response
+                .json()
+                .await
+                .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
 
-        let status = response.status();
-        let payload: Value = response
-            .json()
-            .await
-            .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+            if status.is_success() {
+                payload = current_payload;
+                break;
+            }
 
-        if !status.is_success() {
-            let message = extract_error_message(&payload, "anthropic request failed");
+            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
+                attempt += 1;
+                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
+                continue;
+            }
+
+            let message = extract_error_message(&current_payload, "anthropic request failed");
             return Err(map_http_error(status.as_u16(), message));
         }
 
@@ -187,25 +222,47 @@ impl ProviderImpl for AnthropicProvider {
         let body = AnthropicRequestBuilder::new(req, self.model.clone())
             .stream(true)
             .build();
+        let mut attempt = 0;
+        let response = loop {
+            let response = match self
+                .http
+                .post(self.endpoint())
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", "2023-06-01")
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
+                    {
+                        attempt += 1;
+                        sleep_before_retry(&self.retry_policy, attempt, None).await;
+                        continue;
+                    }
+                    return Err(MotosanError::Network(error.to_string()));
+                }
+            };
 
-        let response = self
-            .http
-            .post(self.endpoint())
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", "2023-06-01")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| MotosanError::Network(error.to_string()))?;
+            let status = response.status();
+            if status.is_success() {
+                break response;
+            }
 
-        let status = response.status();
-        if !status.is_success() {
+            let retry_after = parse_retry_after(response.headers());
+            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
+                attempt += 1;
+                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
+                continue;
+            }
+
             let message = response
                 .text()
                 .await
                 .unwrap_or_else(|_| "anthropic stream request failed".to_string());
             return Err(map_http_error(status.as_u16(), message));
-        }
+        };
 
         let parsed_stream = response
             .bytes_stream()

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -1,6 +1,10 @@
 use crate::error::MotosanError;
 use crate::models::DEFAULT_MINIMAX_MODEL;
-use crate::providers::{extract_error_message, map_http_error, ChatResponseBuilder, ProviderImpl};
+use crate::providers::{
+    extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
+    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+};
+use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
 use async_trait::async_trait;
@@ -14,6 +18,7 @@ pub struct MinimaxProvider {
     api_key: String,
     model: String,
     base_url: String,
+    retry_policy: RetryPolicy,
 }
 
 impl MinimaxProvider {
@@ -27,7 +32,13 @@ impl MinimaxProvider {
             api_key: api_key.into(),
             model: model.unwrap_or_else(|| DEFAULT_MINIMAX_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| "https://api.minimax.chat".to_string()),
+            retry_policy: RetryPolicy::default(),
         }
+    }
+
+    pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
+        self.retry_policy = retry_policy;
+        self
     }
 
     fn endpoint(&self) -> String {
@@ -106,24 +117,48 @@ impl MinimaxRequestBuilder {
 impl ProviderImpl for MinimaxProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let body = MinimaxRequestBuilder::new(req, self.model.clone()).build();
+        let mut attempt = 0;
+        let payload: Value;
+        loop {
+            let response = match self
+                .http
+                .post(self.endpoint())
+                .header("authorization", format!("Bearer {}", self.api_key))
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
+                    {
+                        attempt += 1;
+                        sleep_before_retry(&self.retry_policy, attempt, None).await;
+                        continue;
+                    }
+                    return Err(MotosanError::Network(error.to_string()));
+                }
+            };
 
-        let response = self
-            .http
-            .post(self.endpoint())
-            .header("authorization", format!("Bearer {}", self.api_key))
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| MotosanError::Network(error.to_string()))?;
+            let status = response.status();
+            let retry_after = parse_retry_after(response.headers());
+            let current_payload: Value = response
+                .json()
+                .await
+                .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
 
-        let status = response.status();
-        let payload: Value = response
-            .json()
-            .await
-            .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+            if status.is_success() {
+                payload = current_payload;
+                break;
+            }
 
-        if !status.is_success() {
-            let message = extract_error_message(&payload, "minimax request failed");
+            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
+                attempt += 1;
+                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
+                continue;
+            }
+
+            let message = extract_error_message(&current_payload, "minimax request failed");
             return Err(map_http_error(status.as_u16(), message));
         }
 
@@ -178,24 +213,46 @@ impl ProviderImpl for MinimaxProvider {
         let body = MinimaxRequestBuilder::new(req, self.model.clone())
             .stream(true)
             .build();
+        let mut attempt = 0;
+        let response = loop {
+            let response = match self
+                .http
+                .post(self.endpoint())
+                .header("authorization", format!("Bearer {}", self.api_key))
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
+                    {
+                        attempt += 1;
+                        sleep_before_retry(&self.retry_policy, attempt, None).await;
+                        continue;
+                    }
+                    return Err(MotosanError::Network(error.to_string()));
+                }
+            };
 
-        let response = self
-            .http
-            .post(self.endpoint())
-            .header("authorization", format!("Bearer {}", self.api_key))
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| MotosanError::Network(error.to_string()))?;
+            let status = response.status();
+            if status.is_success() {
+                break response;
+            }
 
-        let status = response.status();
-        if !status.is_success() {
+            let retry_after = parse_retry_after(response.headers());
+            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
+                attempt += 1;
+                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
+                continue;
+            }
+
             let message = response
                 .text()
                 .await
                 .unwrap_or_else(|_| "minimax stream request failed".to_string());
             return Err(map_http_error(status.as_u16(), message));
-        }
+        };
 
         let parsed_stream = response
             .bytes_stream()

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -1,11 +1,17 @@
 use crate::error::MotosanError;
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse};
 #[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 use crate::types::{StopReason, Usage};
 use async_trait::async_trait;
 #[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+use reqwest::header::HeaderMap;
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 use serde_json::Value;
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+use std::time::Duration;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Provider {
@@ -93,6 +99,38 @@ pub(crate) fn map_http_error(status_code: u16, message: String) -> MotosanError 
         400 => MotosanError::InvalidRequest(message),
         _ => MotosanError::ProviderError(message),
     }
+}
+
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+pub(crate) fn is_retryable_status(status_code: u16) -> bool {
+    status_code == 429 || status_code >= 500
+}
+
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+pub(crate) fn is_retryable_network_error(error: &reqwest::Error) -> bool {
+    error.is_timeout() || error.is_connect() || error.is_request() || error.is_body()
+}
+
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+pub(crate) fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
+    let raw = headers.get("retry-after")?.to_str().ok()?.trim();
+    let seconds = raw.parse::<u64>().ok()?;
+    Some(Duration::from_secs(seconds))
+}
+
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+pub(crate) async fn sleep_before_retry(
+    policy: &RetryPolicy,
+    attempt: u32,
+    retry_after: Option<Duration>,
+) {
+    let delay = if policy.respect_retry_after {
+        retry_after.unwrap_or_else(|| policy.delay_for_attempt(attempt))
+    } else {
+        policy.delay_for_attempt(attempt)
+    };
+
+    tokio::time::sleep(delay).await;
 }
 
 #[cfg(feature = "anthropic")]

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -1,6 +1,10 @@
 use crate::error::MotosanError;
 use crate::models::DEFAULT_OPENAI_MODEL;
-use crate::providers::{extract_error_message, map_http_error, ChatResponseBuilder, ProviderImpl};
+use crate::providers::{
+    extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
+    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+};
+use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
 use async_trait::async_trait;
@@ -14,6 +18,7 @@ pub struct OpenAIProvider {
     api_key: String,
     model: String,
     base_url: String,
+    retry_policy: RetryPolicy,
 }
 
 impl OpenAIProvider {
@@ -27,7 +32,13 @@ impl OpenAIProvider {
             api_key: api_key.into(),
             model: model.unwrap_or_else(|| DEFAULT_OPENAI_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| "https://api.openai.com".to_string()),
+            retry_policy: RetryPolicy::default(),
         }
+    }
+
+    pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
+        self.retry_policy = retry_policy;
+        self
     }
 
     fn endpoint(&self) -> String {
@@ -106,24 +117,48 @@ impl OpenAIRequestBuilder {
 impl ProviderImpl for OpenAIProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let body = OpenAIRequestBuilder::new(req, self.model.clone()).build();
+        let mut attempt = 0;
+        let payload: Value;
+        loop {
+            let response = match self
+                .http
+                .post(self.endpoint())
+                .header("authorization", format!("Bearer {}", self.api_key))
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
+                    {
+                        attempt += 1;
+                        sleep_before_retry(&self.retry_policy, attempt, None).await;
+                        continue;
+                    }
+                    return Err(MotosanError::Network(error.to_string()));
+                }
+            };
 
-        let response = self
-            .http
-            .post(self.endpoint())
-            .header("authorization", format!("Bearer {}", self.api_key))
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| MotosanError::Network(error.to_string()))?;
+            let status = response.status();
+            let retry_after = parse_retry_after(response.headers());
+            let current_payload: Value = response
+                .json()
+                .await
+                .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
 
-        let status = response.status();
-        let payload: Value = response
-            .json()
-            .await
-            .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+            if status.is_success() {
+                payload = current_payload;
+                break;
+            }
 
-        if !status.is_success() {
-            let message = extract_error_message(&payload, "openai request failed");
+            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
+                attempt += 1;
+                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
+                continue;
+            }
+
+            let message = extract_error_message(&current_payload, "openai request failed");
             return Err(map_http_error(status.as_u16(), message));
         }
 
@@ -178,24 +213,46 @@ impl ProviderImpl for OpenAIProvider {
         let body = OpenAIRequestBuilder::new(req, self.model.clone())
             .stream(true)
             .build();
+        let mut attempt = 0;
+        let response = loop {
+            let response = match self
+                .http
+                .post(self.endpoint())
+                .header("authorization", format!("Bearer {}", self.api_key))
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
+                    {
+                        attempt += 1;
+                        sleep_before_retry(&self.retry_policy, attempt, None).await;
+                        continue;
+                    }
+                    return Err(MotosanError::Network(error.to_string()));
+                }
+            };
 
-        let response = self
-            .http
-            .post(self.endpoint())
-            .header("authorization", format!("Bearer {}", self.api_key))
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| MotosanError::Network(error.to_string()))?;
+            let status = response.status();
+            if status.is_success() {
+                break response;
+            }
 
-        let status = response.status();
-        if !status.is_success() {
+            let retry_after = parse_retry_after(response.headers());
+            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
+                attempt += 1;
+                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
+                continue;
+            }
+
             let message = response
                 .text()
                 .await
                 .unwrap_or_else(|_| "openai stream request failed".to_string());
             return Err(map_http_error(status.as_u16(), message));
-        }
+        };
 
         let parsed_stream = response
             .bytes_stream()

--- a/sdks/rust/src/retry.rs
+++ b/sdks/rust/src/retry.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    pub max_retries: u32,
+    pub base_delay_ms: u64,
+    pub max_delay_ms: u64,
+    pub jitter: bool,
+    pub respect_retry_after: bool,
+}
+
+impl RetryPolicy {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    pub fn base_delay_ms(mut self, base_delay_ms: u64) -> Self {
+        self.base_delay_ms = base_delay_ms;
+        self
+    }
+
+    pub fn max_delay_ms(mut self, max_delay_ms: u64) -> Self {
+        self.max_delay_ms = max_delay_ms;
+        self
+    }
+
+    pub fn jitter(mut self, jitter: bool) -> Self {
+        self.jitter = jitter;
+        self
+    }
+
+    pub fn respect_retry_after(mut self, respect_retry_after: bool) -> Self {
+        self.respect_retry_after = respect_retry_after;
+        self
+    }
+
+    pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
+        let exponent = attempt.saturating_sub(1).min(31);
+        let exp_factor = 1_u64 << exponent;
+        let mut delay_ms = self.base_delay_ms.saturating_mul(exp_factor);
+        delay_ms = delay_ms.min(self.max_delay_ms);
+
+        if self.jitter {
+            let jitter_seed = attempt as u64 * 1_103_515_245 + 12_345;
+            let jitter_percent = jitter_seed % 100;
+            let jittered = delay_ms + (delay_ms.saturating_mul(jitter_percent) / 100);
+            delay_ms = jittered.min(self.max_delay_ms);
+        }
+
+        Duration::from_millis(delay_ms)
+    }
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            base_delay_ms: 100,
+            max_delay_ms: 2_000,
+            jitter: true,
+            respect_retry_after: true,
+        }
+    }
+}

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -1,4 +1,4 @@
-use motosan_ai::{Client, Message, MotosanError, Provider};
+use motosan_ai::{Client, Message, MotosanError, Provider, RetryPolicy};
 
 #[test]
 fn builder_requires_provider_and_api_key() {
@@ -7,6 +7,48 @@ fn builder_requires_provider_and_api_key() {
 
     let missing_api_key = Client::builder().provider(Provider::OpenAI).build();
     assert!(matches!(missing_api_key, Err(MotosanError::Config(_))));
+}
+
+#[test]
+fn builder_uses_default_retry_policy_and_allows_override() {
+    let client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .build()
+        .expect("build client");
+    assert_eq!(
+        client.retry_policy().max_retries,
+        RetryPolicy::default().max_retries
+    );
+
+    let custom_policy = RetryPolicy::new()
+        .max_retries(5)
+        .base_delay_ms(10)
+        .max_delay_ms(100)
+        .jitter(false)
+        .respect_retry_after(false);
+
+    let client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .retry_policy(custom_policy.clone())
+        .build()
+        .expect("build client");
+
+    assert_eq!(client.retry_policy().max_retries, custom_policy.max_retries);
+    assert_eq!(
+        client.retry_policy().base_delay_ms,
+        custom_policy.base_delay_ms
+    );
+    assert_eq!(
+        client.retry_policy().max_delay_ms,
+        custom_policy.max_delay_ms
+    );
+    assert_eq!(client.retry_policy().jitter, custom_policy.jitter);
+    assert_eq!(
+        client.retry_policy().respect_retry_after,
+        custom_policy.respect_retry_after
+    );
 }
 
 #[tokio::test]

--- a/sdks/rust/tests/error_mapping.rs
+++ b/sdks/rust/tests/error_mapping.rs
@@ -1,7 +1,11 @@
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, MotosanError};
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+use motosan_ai::{ChatRequest, Message, MotosanError, RetryPolicy};
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 use serde_json::json;
 
+#[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 fn sample_request() -> ChatRequest {
     ChatRequest::builder()
         .message(Message::user("hello"))
@@ -16,7 +20,8 @@ async fn anthropic_maps_401_429_500() {
         "test-key",
         None,
         Some(server.url()),
-    );
+    )
+    .with_retry_policy(RetryPolicy::new().max_retries(0).jitter(false));
 
     let unauthorized = server
         .mock("POST", "/v1/messages")
@@ -65,7 +70,8 @@ async fn anthropic_maps_401_429_500() {
 async fn openai_maps_401_429_500() {
     let mut server = mockito::Server::new_async().await;
     let provider =
-        motosan_ai::providers::openai::OpenAIProvider::new("test-key", None, Some(server.url()));
+        motosan_ai::providers::openai::OpenAIProvider::new("test-key", None, Some(server.url()))
+            .with_retry_policy(RetryPolicy::new().max_retries(0).jitter(false));
 
     let unauthorized = server
         .mock("POST", "/v1/chat/completions")
@@ -114,7 +120,8 @@ async fn openai_maps_401_429_500() {
 async fn minimax_maps_401_429_500() {
     let mut server = mockito::Server::new_async().await;
     let provider =
-        motosan_ai::providers::minimax::MinimaxProvider::new("test-key", None, Some(server.url()));
+        motosan_ai::providers::minimax::MinimaxProvider::new("test-key", None, Some(server.url()))
+            .with_retry_policy(RetryPolicy::new().max_retries(0).jitter(false));
 
     let unauthorized = server
         .mock("POST", "/v1/text/chatcompletion_v2")

--- a/sdks/rust/tests/openai_retry.rs
+++ b/sdks/rust/tests/openai_retry.rs
@@ -1,0 +1,215 @@
+#![cfg(feature = "openai")]
+
+use motosan_ai::providers::openai::OpenAIProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, Message, MotosanError, RetryPolicy};
+use serde_json::json;
+use std::time::{Duration, Instant};
+use tokio_stream::StreamExt;
+
+#[tokio::test]
+async fn openai_chat_retries_429_then_succeeds() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_body(json!({"error": {"message": "rate limited"}}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    let provider =
+        OpenAIProvider::new("test-key", None, Some(server.url())).with_retry_policy(policy);
+
+    let response = provider
+        .chat(
+            ChatRequest::builder()
+                .message(Message::user("hello"))
+                .build(),
+        )
+        .await
+        .expect("should retry and succeed");
+
+    assert_eq!(response.content, "ok");
+}
+
+#[tokio::test]
+async fn openai_chat_retries_500_twice_then_succeeds() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(500)
+        .with_body(json!({"error": {"message": "server error"}}).to_string())
+        .expect(2)
+        .create_async()
+        .await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{"message": {"content": "recovered"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let policy = RetryPolicy::new()
+        .max_retries(2)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    let provider =
+        OpenAIProvider::new("test-key", None, Some(server.url())).with_retry_policy(policy);
+
+    let response = provider
+        .chat(
+            ChatRequest::builder()
+                .message(Message::user("hello"))
+                .build(),
+        )
+        .await
+        .expect("should retry and succeed");
+
+    assert_eq!(response.content, "recovered");
+}
+
+#[tokio::test]
+async fn openai_chat_does_not_retry_on_400() {
+    let mut server = mockito::Server::new_async().await;
+    let bad_request = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(400)
+        .with_body(json!({"error": {"message": "bad request"}}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let policy = RetryPolicy::new()
+        .max_retries(3)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    let provider =
+        OpenAIProvider::new("test-key", None, Some(server.url())).with_retry_policy(policy);
+
+    let result = provider
+        .chat(
+            ChatRequest::builder()
+                .message(Message::user("hello"))
+                .build(),
+        )
+        .await;
+
+    assert!(matches!(result, Err(MotosanError::InvalidRequest(_))));
+    bad_request.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_chat_honors_retry_after_header() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_header("retry-after", "1")
+        .with_body(json!({"error": {"message": "rate limited"}}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false)
+        .respect_retry_after(true);
+    let provider =
+        OpenAIProvider::new("test-key", None, Some(server.url())).with_retry_policy(policy);
+
+    let started = Instant::now();
+    let _ = provider
+        .chat(
+            ChatRequest::builder()
+                .message(Message::user("hello"))
+                .build(),
+        )
+        .await
+        .expect("should retry and succeed");
+
+    assert!(started.elapsed() >= Duration::from_millis(900));
+}
+
+#[tokio::test]
+async fn openai_stream_retries_initial_call() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(500)
+        .with_body(json!({"error": {"message": "server error"}}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    let provider =
+        OpenAIProvider::new("test-key", None, Some(server.url())).with_retry_policy(policy);
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let first = stream.next().await.expect("first event");
+    let second = stream.next().await.expect("done event");
+
+    assert_eq!(first.content, "ok");
+    assert!(second.done);
+}


### PR DESCRIPTION
Implements #28.

## What's included
- Add `RetryPolicy` with defaults and builder-style config
- Add `ClientBuilder::retry_policy(...)` and propagate into providers
- Retry chat + initial stream request for transient failures (`429`, `5xx`, timeout/connect/request/body errors)
- Respect `Retry-After` header (delta-seconds) when enabled
- Add retry tests covering:
  - `429 -> 200`
  - `500 -> 500 -> 200`
  - `400` no retry
  - `Retry-After` behavior
  - stream initial call retry
- Update README + changelog

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features`