### PR TITLE
feat(anthropic): support setup-token auth mode and auth guidance

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -113,6 +113,14 @@ let client = Client::builder()
     .build()?;
 ```
 
+## Anthropic Auth Matrix
+
+- `sk-ant-api*` or regular Anthropic API key → `x-api-key` header
+- `sk-ant-oat01*` setup token → `Authorization: Bearer <token>` plus `anthropic-beta: oauth-2025-04-20`
+
+When using `Provider::Anthropic`, pass either token string into `Client::builder().api_key(...)`.
+The SDK auto-selects the correct header mode based on token prefix.
+
 Error handling policy reference: `docs/error-handling-policy.md`.
 
 ## Model Maintenance (survey process)

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -44,6 +44,36 @@ impl AnthropicProvider {
     fn endpoint(&self) -> String {
         format!("{}/v1/messages", self.base_url)
     }
+
+    fn is_setup_token(token: &str) -> bool {
+        token.starts_with("sk-ant-oat01-")
+    }
+
+    fn apply_auth(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if Self::is_setup_token(&self.api_key) {
+            request
+                .header("authorization", format!("Bearer {}", self.api_key))
+                .header("anthropic-beta", "oauth-2025-04-20")
+        } else {
+            request.header("x-api-key", &self.api_key)
+        }
+    }
+
+    fn with_auth_hint(status_code: u16, message: String, is_setup_token: bool) -> String {
+        if status_code != 401 {
+            return message;
+        }
+
+        if is_setup_token {
+            format!(
+                "{message}. Hint: setup tokens (sk-ant-oat01-*) require Authorization: Bearer and anthropic-beta: oauth-2025-04-20"
+            )
+        } else {
+            format!(
+                "{message}. Hint: Anthropic API keys use x-api-key; setup tokens (sk-ant-oat01-*) use Authorization: Bearer plus anthropic-beta: oauth-2025-04-20"
+            )
+        }
+    }
 }
 
 struct AnthropicRequestBuilder {
@@ -130,15 +160,12 @@ impl ProviderImpl for AnthropicProvider {
         let mut attempt = 0;
         let payload: Value;
         loop {
-            let response = match self
+            let request = self
                 .http
                 .post(self.endpoint())
-                .header("x-api-key", &self.api_key)
                 .header("anthropic-version", "2023-06-01")
-                .json(&body)
-                .send()
-                .await
-            {
+                .json(&body);
+            let response = match self.apply_auth(request).send().await {
                 Ok(response) => response,
                 Err(error) => {
                     if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
@@ -170,6 +197,11 @@ impl ProviderImpl for AnthropicProvider {
             }
 
             let message = extract_error_message(&current_payload, "anthropic request failed");
+            let message = Self::with_auth_hint(
+                status.as_u16(),
+                message,
+                Self::is_setup_token(&self.api_key),
+            );
             return Err(map_http_error(status.as_u16(), message));
         }
 
@@ -188,7 +220,7 @@ impl ProviderImpl for AnthropicProvider {
         let model = payload
             .get("model")
             .and_then(Value::as_str)
-            .unwrap_or("claude-sonnet-4-5")
+            .unwrap_or(DEFAULT_ANTHROPIC_MODEL)
             .to_string();
 
         let input_tokens = payload
@@ -224,15 +256,12 @@ impl ProviderImpl for AnthropicProvider {
             .build();
         let mut attempt = 0;
         let response = loop {
-            let response = match self
+            let request = self
                 .http
                 .post(self.endpoint())
-                .header("x-api-key", &self.api_key)
                 .header("anthropic-version", "2023-06-01")
-                .json(&body)
-                .send()
-                .await
-            {
+                .json(&body);
+            let response = match self.apply_auth(request).send().await {
                 Ok(response) => response,
                 Err(error) => {
                     if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
@@ -261,6 +290,11 @@ impl ProviderImpl for AnthropicProvider {
                 .text()
                 .await
                 .unwrap_or_else(|_| "anthropic stream request failed".to_string());
+            let message = Self::with_auth_hint(
+                status.as_u16(),
+                message,
+                Self::is_setup_token(&self.api_key),
+            );
             return Err(map_http_error(status.as_u16(), message));
         };
 

--- a/sdks/rust/tests/anthropic_chat.rs
+++ b/sdks/rust/tests/anthropic_chat.rs
@@ -3,7 +3,7 @@
 use mockito::Matcher;
 use motosan_ai::providers::anthropic::AnthropicProvider;
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, StopReason, DEFAULT_ANTHROPIC_MODEL};
+use motosan_ai::{ChatRequest, Message, MotosanError, StopReason, DEFAULT_ANTHROPIC_MODEL};
 use serde_json::json;
 
 #[tokio::test]
@@ -103,4 +103,54 @@ async fn anthropic_request_uses_default_model_and_allows_override() {
         .build();
     let _ = provider.chat(request).await.expect("chat response");
     override_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn anthropic_setup_token_uses_bearer_and_oauth_beta_header() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("authorization", "Bearer sk-ant-oat01-test-token")
+        .match_header("anthropic-beta", "oauth-2025-04-20")
+        .match_header("anthropic-version", "2023-06-01")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": DEFAULT_ANTHROPIC_MODEL,
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("sk-ant-oat01-test-token", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+    let _ = provider.chat(request).await.expect("chat response");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn anthropic_setup_token_401_includes_actionable_hint() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .with_status(401)
+        .with_body(json!({"error": {"message": "invalid token"}}).to_string())
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("sk-ant-oat01-test-token", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+    let err = provider.chat(request).await.expect_err("should fail");
+
+    assert!(matches!(err, MotosanError::Auth(_)));
+    assert!(format!("{err}").contains("oauth-2025-04-20"));
+    mock.assert_async().await;
 }

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -92,3 +92,38 @@ async fn anthropic_stream_ignores_unknown_and_malformed_events() {
 
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn anthropic_stream_setup_token_uses_bearer_and_oauth_beta_header() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"ok\"}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("authorization", "Bearer sk-ant-oat01-stream-token")
+        .match_header("anthropic-beta", "oauth-2025-04-20")
+        .match_header("anthropic-version", "2023-06-01")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("sk-ant-oat01-stream-token", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let first = stream.next().await.expect("first event");
+    let done = stream.next().await.expect("done event");
+
+    assert_eq!(first.content, "ok");
+    assert!(done.done);
+    mock.assert_async().await;
+}


### PR DESCRIPTION
Implements optimization issues #35, #36, #37, and #38.

## What changed
- Added Anthropic setup-token auth mode in provider:
  - `sk-ant-oat01-*` => `Authorization: Bearer <token>` + `anthropic-beta: oauth-2025-04-20`
  - Regular keys => `x-api-key`
- Added actionable 401 auth hints for credential/header mismatch scenarios
- Replaced hardcoded Anthropic response fallback model with `DEFAULT_ANTHROPIC_MODEL`
- Added stream-path setup-token auth header coverage
- Updated README with explicit Anthropic auth matrix

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features`

Closes #35
Closes #36
Closes #37
Closes #38