### PR TITLE
feat(minimax): update SDK default to MiniMax M2.5

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -60,7 +60,7 @@ cargo build -p motosan-ai --all-features
 
 - Anthropic: `claude-sonnet-4-6`
 - OpenAI: `gpt-5.3-codex`
-- MiniMax: `MiniMax-Text-01`
+- MiniMax: `MiniMax-M2.5`
 
 Override per client:
 

--- a/sdks/rust/src/models.rs
+++ b/sdks/rust/src/models.rs
@@ -1,6 +1,6 @@
 pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-6";
 pub const DEFAULT_OPENAI_MODEL: &str = "gpt-5.3-codex";
-pub const DEFAULT_MINIMAX_MODEL: &str = "MiniMax-Text-01";
+pub const DEFAULT_MINIMAX_MODEL: &str = "MiniMax-M2.5";
 
 pub const ANTHROPIC_MODELS: &[&str] = &[
     "claude-opus-4-6",
@@ -16,4 +16,9 @@ pub const ANTHROPIC_MODELS: &[&str] = &[
 
 pub const OPENAI_MODELS: &[&str] = &["gpt-5.3-codex", "gpt-4o"];
 
-pub const MINIMAX_MODELS: &[&str] = &["MiniMax-Text-01"];
+pub const MINIMAX_MODELS: &[&str] = &[
+    "MiniMax-M2.5",
+    "MiniMax-M2.5-highspeed",
+    "MiniMax-M2.1",
+    "MiniMax-M2",
+];

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -16,7 +16,7 @@ async fn minimax_chat_maps_response() {
         .with_status(200)
         .with_body(
             json!({
-                "model": "MiniMax-Text-01",
+                "model": "MiniMax-M2.5",
                 "choices": [{"message": {"content": "hello from minimax"}, "finish_reason": "stop"}],
                 "usage": {"prompt_tokens": 9, "completion_tokens": 4}
             })
@@ -35,7 +35,7 @@ async fn minimax_chat_maps_response() {
 
     let response = provider.chat(request).await.expect("chat response");
     assert_eq!(response.content, "hello from minimax");
-    assert_eq!(response.model, "MiniMax-Text-01");
+    assert_eq!(response.model, "MiniMax-M2.5");
     assert!(matches!(response.stop_reason, StopReason::Stop));
 
     mock.assert_async().await;
@@ -72,7 +72,7 @@ async fn minimax_request_uses_default_model_and_allows_override() {
     default_mock.assert_async().await;
 
     server.reset();
-    let override_model = "MiniMax-Text-01";
+    let override_model = "MiniMax-M2.5-highspeed";
     let override_mock = server
         .mock("POST", "/v1/text/chatcompletion_v2")
         .match_header("authorization", "Bearer test-key")


### PR DESCRIPTION
Updated MiniMax model catalog based on official API docs.

## Changes
- Set `DEFAULT_MINIMAX_MODEL` to `MiniMax-M2.5`
- Expanded `MINIMAX_MODELS` to include:
  - `MiniMax-M2.5`
  - `MiniMax-M2.5-highspeed`
  - `MiniMax-M2.1`
  - `MiniMax-M2`
- Updated MiniMax provider tests to validate the new default/override behavior
- Updated README model default section

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-features`