### PR TITLE
refactor(minimax): migrate to OpenAI-compatible /chat/completions

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -121,6 +121,11 @@ let client = Client::builder()
 When using `Provider::Anthropic`, pass either token string into `Client::builder().api_key(...)`.
 The SDK auto-selects the correct header mode based on token prefix.
 
+## MiniMax Compatibility
+
+MiniMax provider uses OpenAI-compatible chat completions path (`/chat/completions`) with `Authorization: Bearer` authentication.
+The SDK also maps MiniMax payload-level `base_resp` errors (e.g. invalid API key) into SDK error variants.
+
 Error handling policy reference: `docs/error-handling-policy.md`.
 
 ## Model Maintenance (survey process)

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -31,7 +31,7 @@ impl MinimaxProvider {
             http: Client::new(),
             api_key: api_key.into(),
             model: model.unwrap_or_else(|| DEFAULT_MINIMAX_MODEL.to_string()),
-            base_url: base_url.unwrap_or_else(|| "https://api.minimax.chat".to_string()),
+            base_url: base_url.unwrap_or_else(|| "https://api.minimax.io/v1".to_string()),
             retry_policy: RetryPolicy::default(),
         }
     }
@@ -42,7 +42,24 @@ impl MinimaxProvider {
     }
 
     fn endpoint(&self) -> String {
-        format!("{}/v1/text/chatcompletion_v2", self.base_url)
+        format!("{}/chat/completions", self.base_url.trim_end_matches('/'))
+    }
+
+    fn minimax_payload_error(payload: &Value) -> Option<(u16, String)> {
+        let base_resp = payload.get("base_resp")?;
+        let status_code = base_resp.get("status_code").and_then(Value::as_i64)?;
+        if status_code == 0 {
+            return None;
+        }
+
+        let message = base_resp
+            .get("status_msg")
+            .and_then(Value::as_str)
+            .unwrap_or("minimax request failed")
+            .to_string();
+
+        let mapped_status = if status_code == 2049 { 401 } else { 500 };
+        Some((mapped_status, message))
     }
 }
 
@@ -148,6 +165,11 @@ impl ProviderImpl for MinimaxProvider {
                 .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
 
             if status.is_success() {
+                if let Some((mapped_status, message)) =
+                    Self::minimax_payload_error(&current_payload)
+                {
+                    return Err(map_http_error(mapped_status, message));
+                }
                 payload = current_payload;
                 break;
             }

--- a/sdks/rust/tests/error_mapping.rs
+++ b/sdks/rust/tests/error_mapping.rs
@@ -124,7 +124,7 @@ async fn minimax_maps_401_429_500() {
             .with_retry_policy(RetryPolicy::new().max_retries(0).jitter(false));
 
     let unauthorized = server
-        .mock("POST", "/v1/text/chatcompletion_v2")
+        .mock("POST", "/chat/completions")
         .with_status(401)
         .with_body(json!({"error": {"message": "bad key"}}).to_string())
         .create_async()
@@ -138,7 +138,7 @@ async fn minimax_maps_401_429_500() {
 
     server.reset();
     let rate_limited = server
-        .mock("POST", "/v1/text/chatcompletion_v2")
+        .mock("POST", "/chat/completions")
         .with_status(429)
         .with_body(json!({"error": {"message": "too many"}}).to_string())
         .create_async()
@@ -152,7 +152,7 @@ async fn minimax_maps_401_429_500() {
 
     server.reset();
     let provider_error = server
-        .mock("POST", "/v1/text/chatcompletion_v2")
+        .mock("POST", "/chat/completions")
         .with_status(500)
         .with_body(json!({"error": {"message": "boom"}}).to_string())
         .create_async()

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -3,7 +3,7 @@
 use mockito::Matcher;
 use motosan_ai::providers::minimax::MinimaxProvider;
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, StopReason, DEFAULT_MINIMAX_MODEL};
+use motosan_ai::{ChatRequest, Message, MotosanError, StopReason, DEFAULT_MINIMAX_MODEL};
 use serde_json::json;
 use tokio_stream::StreamExt;
 
@@ -11,7 +11,7 @@ use tokio_stream::StreamExt;
 async fn minimax_chat_maps_response() {
     let mut server = mockito::Server::new_async().await;
     let mock = server
-        .mock("POST", "/v1/text/chatcompletion_v2")
+        .mock("POST", "/chat/completions")
         .match_header("authorization", "Bearer test-key")
         .with_status(200)
         .with_body(
@@ -46,7 +46,7 @@ async fn minimax_request_uses_default_model_and_allows_override() {
     let mut server = mockito::Server::new_async().await;
 
     let default_mock = server
-        .mock("POST", "/v1/text/chatcompletion_v2")
+        .mock("POST", "/chat/completions")
         .match_header("authorization", "Bearer test-key")
         .match_body(Matcher::Regex(format!(
             r#"\"model\"\s*:\s*\"{}\""#,
@@ -74,7 +74,7 @@ async fn minimax_request_uses_default_model_and_allows_override() {
     server.reset();
     let override_model = "MiniMax-Text-01";
     let override_mock = server
-        .mock("POST", "/v1/text/chatcompletion_v2")
+        .mock("POST", "/chat/completions")
         .match_header("authorization", "Bearer test-key")
         .match_body(Matcher::Regex(format!(
             r#"\"model\"\s*:\s*\"{}\""#,
@@ -110,7 +110,7 @@ async fn minimax_stream_emits_content_and_done() {
     );
 
     let mock = server
-        .mock("POST", "/v1/text/chatcompletion_v2")
+        .mock("POST", "/chat/completions")
         .match_header("authorization", "Bearer test-key")
         .with_status(200)
         .with_header("content-type", "text/event-stream")
@@ -147,7 +147,7 @@ async fn minimax_stream_ignores_malformed_chunks() {
     );
 
     let mock = server
-        .mock("POST", "/v1/text/chatcompletion_v2")
+        .mock("POST", "/chat/completions")
         .match_header("authorization", "Bearer test-key")
         .with_status(200)
         .with_header("content-type", "text/event-stream")
@@ -170,6 +170,36 @@ async fn minimax_stream_ignores_malformed_chunks() {
     assert_eq!(events[0].content, "ok");
     assert!(!events[0].done);
     assert!(events[1].done);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_maps_payload_level_invalid_api_key_to_auth_error() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer bad-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "base_resp": {
+                    "status_code": 2049,
+                    "status_msg": "invalid api key"
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("bad-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let result = provider.chat(request).await;
+    assert!(matches!(result, Err(MotosanError::Auth(_))));
 
     mock.assert_async().await;
 }


### PR DESCRIPTION
## Summary
- migrate MiniMax provider endpoint to OpenAI-compatible `/chat/completions`
- use default MiniMax base URL `https://api.minimax.io/v1`
- handle payload-level `base_resp` errors (including invalid API key)
- update MiniMax tests and README notes

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features

Closes #41
