### PR TITLE
feat(minimax): strip <think> reasoning by default

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -126,6 +126,33 @@ The SDK auto-selects the correct header mode based on token prefix.
 MiniMax provider uses OpenAI-compatible chat completions path (`/chat/completions`) with `Authorization: Bearer` authentication.
 The SDK also maps MiniMax payload-level `base_resp` errors (e.g. invalid API key) into SDK error variants.
 
+For `MiniMax-M2.5-highspeed`, responses can include `<think>...</think>` reasoning blocks.
+By default, the SDK strips these blocks and returns only the final answer text.
+
+To expose raw reasoning content:
+
+```rust
+use motosan_ai::{Client, Provider};
+
+let client = Client::builder()
+    .provider(Provider::Minimax)
+    .api_key("...")
+    .minimax_expose_reasoning(true)
+    .build()?;
+```
+
+Or per request:
+
+```rust
+use motosan_ai::{ChatRequest, Message};
+use serde_json::json;
+
+let request = ChatRequest::builder()
+    .message(Message::user("hello"))
+    .provider_options(json!({"minimax_expose_reasoning": true}))
+    .build();
+```
+
 Error handling policy reference: `docs/error-handling-policy.md`.
 
 ## Model Maintenance (survey process)

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -9,6 +9,7 @@ pub struct Client {
     provider: Provider,
     api_key: String,
     model: Option<String>,
+    minimax_expose_reasoning: bool,
     retry_policy: RetryPolicy,
 }
 
@@ -31,6 +32,10 @@ impl Client {
 
     pub fn retry_policy(&self) -> &RetryPolicy {
         &self.retry_policy
+    }
+
+    pub fn minimax_expose_reasoning(&self) -> bool {
+        self.minimax_expose_reasoning
     }
 
     pub async fn chat(&self, messages: Vec<Message>) -> Result<ChatResponse, MotosanError> {
@@ -173,6 +178,7 @@ impl Client {
             self.model.clone(),
             None,
         )
+        .with_expose_reasoning(self.minimax_expose_reasoning)
         .with_retry_policy(self.retry_policy.clone())
     }
 }
@@ -182,6 +188,7 @@ pub struct ClientBuilder {
     provider: Option<Provider>,
     api_key: Option<String>,
     model: Option<String>,
+    minimax_expose_reasoning: Option<bool>,
     retry_policy: Option<RetryPolicy>,
 }
 
@@ -206,6 +213,11 @@ impl ClientBuilder {
         self
     }
 
+    pub fn minimax_expose_reasoning(mut self, minimax_expose_reasoning: bool) -> Self {
+        self.minimax_expose_reasoning = Some(minimax_expose_reasoning);
+        self
+    }
+
     pub fn build(self) -> Result<Client, MotosanError> {
         let provider = self
             .provider
@@ -218,6 +230,7 @@ impl ClientBuilder {
             provider,
             api_key,
             model: self.model,
+            minimax_expose_reasoning: self.minimax_expose_reasoning.unwrap_or(false),
             retry_policy: self.retry_policy.unwrap_or_default(),
         })
     }

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -18,6 +18,7 @@ pub struct MinimaxProvider {
     api_key: String,
     model: String,
     base_url: String,
+    expose_reasoning: bool,
     retry_policy: RetryPolicy,
 }
 
@@ -32,8 +33,14 @@ impl MinimaxProvider {
             api_key: api_key.into(),
             model: model.unwrap_or_else(|| DEFAULT_MINIMAX_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| "https://api.minimax.io/v1".to_string()),
+            expose_reasoning: false,
             retry_policy: RetryPolicy::default(),
         }
+    }
+
+    pub fn with_expose_reasoning(mut self, expose_reasoning: bool) -> Self {
+        self.expose_reasoning = expose_reasoning;
+        self
     }
 
     pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
@@ -60,6 +67,34 @@ impl MinimaxProvider {
 
         let mapped_status = if status_code == 2049 { 401 } else { 500 };
         Some((mapped_status, message))
+    }
+
+    fn resolve_expose_reasoning(&self, req: &ChatRequest) -> bool {
+        req.provider_options
+            .as_ref()
+            .and_then(Value::as_object)
+            .and_then(|opts| opts.get("minimax_expose_reasoning"))
+            .and_then(Value::as_bool)
+            .unwrap_or(self.expose_reasoning)
+    }
+
+    fn strip_think_blocks(content: &str) -> String {
+        let mut remaining = content;
+        let mut sanitized = String::new();
+
+        while let Some(open_idx) = remaining.find("<think>") {
+            sanitized.push_str(&remaining[..open_idx]);
+            let after_open = &remaining[open_idx + "<think>".len()..];
+            if let Some(close_idx) = after_open.find("</think>") {
+                remaining = &after_open[close_idx + "</think>".len()..];
+            } else {
+                remaining = "";
+                break;
+            }
+        }
+
+        sanitized.push_str(remaining);
+        sanitized.trim().to_string()
     }
 }
 
@@ -121,6 +156,9 @@ impl MinimaxRequestBuilder {
         if let Some(provider_options) = self.req.provider_options {
             if let Some(map) = provider_options.as_object() {
                 for (key, value) in map {
+                    if key == "minimax_expose_reasoning" {
+                        continue;
+                    }
                     body[key] = value.clone();
                 }
             }
@@ -133,6 +171,7 @@ impl MinimaxRequestBuilder {
 #[async_trait]
 impl ProviderImpl for MinimaxProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        let expose_reasoning = self.resolve_expose_reasoning(&req);
         let body = MinimaxRequestBuilder::new(req, self.model.clone()).build();
         let mut attempt = 0;
         let payload: Value;
@@ -184,7 +223,7 @@ impl ProviderImpl for MinimaxProvider {
             return Err(map_http_error(status.as_u16(), message));
         }
 
-        let content = payload
+        let raw_content = payload
             .get("choices")
             .and_then(Value::as_array)
             .and_then(|choices| choices.first())
@@ -193,6 +232,12 @@ impl ProviderImpl for MinimaxProvider {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
+
+        let content = if expose_reasoning {
+            raw_content
+        } else {
+            Self::strip_think_blocks(&raw_content)
+        };
 
         let stop_reason = match payload
             .get("choices")

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -51,6 +51,24 @@ fn builder_uses_default_retry_policy_and_allows_override() {
     );
 }
 
+#[test]
+fn builder_defaults_minimax_expose_reasoning_to_false_and_allows_override() {
+    let default_client = Client::builder()
+        .provider(Provider::Minimax)
+        .api_key("k")
+        .build()
+        .expect("build client");
+    assert!(!default_client.minimax_expose_reasoning());
+
+    let custom_client = Client::builder()
+        .provider(Provider::Minimax)
+        .api_key("k")
+        .minimax_expose_reasoning(true)
+        .build()
+        .expect("build client");
+    assert!(custom_client.minimax_expose_reasoning());
+}
+
 #[tokio::test]
 async fn chat_and_stream_exist_and_dispatch() {
     let client = Client::builder()

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -203,3 +203,94 @@ async fn minimax_maps_payload_level_invalid_api_key_to_auth_error() {
 
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn minimax_chat_strips_think_blocks_by_default() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-M2.5-highspeed",
+                "choices": [{"message": {"content": "<think>internal chain</think>\n\npong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 4},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("reply pong"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "pong");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_chat_can_expose_reasoning_from_provider_flag() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-M2.5-highspeed",
+                "choices": [{"message": {"content": "<think>internal chain</think>\n\npong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 4},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider =
+        MinimaxProvider::new("test-key", None, Some(server.url())).with_expose_reasoning(true);
+    let request = ChatRequest::builder()
+        .message(Message::user("reply pong"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert!(response.content.contains("<think>internal chain</think>"));
+    assert!(response.content.ends_with("pong"));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_chat_can_expose_reasoning_from_request_options() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-M2.5-highspeed",
+                "choices": [{"message": {"content": "<think>internal chain</think>\n\npong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 4},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("reply pong"))
+        .provider_options(json!({"minimax_expose_reasoning": true}))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert!(response.content.contains("<think>internal chain</think>"));
+    assert!(response.content.ends_with("pong"));
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- strip MiniMax `<think>...</think>` reasoning blocks from chat content by default
- add configurable override on client builder: `minimax_expose_reasoning(true)`
- add request-level override via `provider_options.minimax_expose_reasoning`
- keep MiniMax payload-level error mapping behavior unchanged
- add tests for default strip behavior and both override paths
- document reasoning behavior in Rust SDK README

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features

Closes #43
