### PR TITLE
feat(minimax): fallback to reasoning_content in chat and stream

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -128,6 +128,8 @@ The SDK also maps MiniMax payload-level `base_resp` errors (e.g. invalid API key
 
 For `MiniMax-M2.5-highspeed`, responses can include `<think>...</think>` reasoning blocks.
 By default, the SDK strips these blocks and returns only the final answer text.
+If `message.content` is empty (or only contains `<think>` blocks), the SDK falls back to
+`message.reasoning_content` for chat and stream parsing.
 
 To expose raw reasoning content:
 

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -96,6 +96,62 @@ impl MinimaxProvider {
         sanitized.push_str(remaining);
         sanitized.trim().to_string()
     }
+
+    fn first_non_empty_text(value: Option<&Value>) -> Option<&str> {
+        value
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+    }
+
+    fn extract_chat_content(payload: &Value, expose_reasoning: bool) -> String {
+        let message = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"));
+
+        let content = Self::first_non_empty_text(message.and_then(|msg| msg.get("content")));
+        let reasoning =
+            Self::first_non_empty_text(message.and_then(|msg| msg.get("reasoning_content")));
+
+        if expose_reasoning {
+            return content.or(reasoning).unwrap_or_default().to_string();
+        }
+
+        if let Some(content_text) = content {
+            let sanitized = Self::strip_think_blocks(content_text);
+            if !sanitized.is_empty() {
+                return sanitized;
+            }
+        }
+
+        reasoning.map(Self::strip_think_blocks).unwrap_or_default()
+    }
+
+    fn extract_stream_delta_text(payload: &Value, expose_reasoning: bool) -> String {
+        let delta = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("delta"));
+
+        let content = Self::first_non_empty_text(delta.and_then(|d| d.get("content")));
+        let reasoning = Self::first_non_empty_text(delta.and_then(|d| d.get("reasoning_content")));
+
+        if expose_reasoning {
+            return content.or(reasoning).unwrap_or_default().to_string();
+        }
+
+        if let Some(content_text) = content {
+            let sanitized = Self::strip_think_blocks(content_text);
+            if !sanitized.is_empty() {
+                return sanitized;
+            }
+        }
+
+        reasoning.map(Self::strip_think_blocks).unwrap_or_default()
+    }
 }
 
 struct MinimaxRequestBuilder {
@@ -223,21 +279,7 @@ impl ProviderImpl for MinimaxProvider {
             return Err(map_http_error(status.as_u16(), message));
         }
 
-        let raw_content = payload
-            .get("choices")
-            .and_then(Value::as_array)
-            .and_then(|choices| choices.first())
-            .and_then(|choice| choice.get("message"))
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string();
-
-        let content = if expose_reasoning {
-            raw_content
-        } else {
-            Self::strip_think_blocks(&raw_content)
-        };
+        let content = Self::extract_chat_content(&payload, expose_reasoning);
 
         let stop_reason = match payload
             .get("choices")
@@ -277,6 +319,7 @@ impl ProviderImpl for MinimaxProvider {
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
+        let expose_reasoning = self.resolve_expose_reasoning(&req);
         let body = MinimaxRequestBuilder::new(req, self.model.clone())
             .stream(true)
             .build();
@@ -324,7 +367,7 @@ impl ProviderImpl for MinimaxProvider {
         let parsed_stream = response
             .bytes_stream()
             .eventsource()
-            .filter_map(|event| match event {
+            .filter_map(move |event| match event {
                 Ok(event) => {
                     if event.data.trim() == "[DONE]" {
                         return Some(crate::types::StreamEvent {
@@ -334,15 +377,7 @@ impl ProviderImpl for MinimaxProvider {
                     }
 
                     let payload: Value = serde_json::from_str(&event.data).ok()?;
-                    let text = payload
-                        .get("choices")
-                        .and_then(Value::as_array)
-                        .and_then(|choices| choices.first())
-                        .and_then(|choice| choice.get("delta"))
-                        .and_then(|delta| delta.get("content"))
-                        .and_then(Value::as_str)
-                        .unwrap_or("")
-                        .to_string();
+                    let text = Self::extract_stream_delta_text(&payload, expose_reasoning);
                     Some(crate::types::StreamEvent {
                         content: text,
                         done: false,

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -294,3 +294,96 @@ async fn minimax_chat_can_expose_reasoning_from_request_options() {
     assert!(response.content.ends_with("pong"));
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn minimax_chat_falls_back_to_reasoning_content_when_content_empty() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-M2.5-highspeed",
+                "choices": [{"message": {"content": "", "reasoning_content": "fallback answer"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 4},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("reply"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "fallback answer");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_chat_uses_reasoning_content_when_content_only_think_blocks() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-M2.5-highspeed",
+                "choices": [{"message": {"content": "<think>secret</think>", "reasoning_content": "public fallback"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 4},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("reply"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "public fallback");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_stream_falls_back_to_reasoning_content_when_delta_content_empty() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"reasoning_content\":\"fallback\"}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].content, "fallback");
+    assert!(!events[0].done);
+    assert!(events[1].done);
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- add MiniMax chat fallback from `message.content` to `message.reasoning_content`
- keep default `<think>...</think>` stripping before returning user-visible content
- add stream fallback from `delta.content` to `delta.reasoning_content`
- preserve `minimax_expose_reasoning` behavior for raw output mode
- add integration tests for chat and stream fallback cases
- document fallback behavior in Rust README

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features

Closes #45
