### PR TITLE
feat(minimax): merge system prompts into first user message

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -125,6 +125,7 @@ The SDK auto-selects the correct header mode based on token prefix.
 
 MiniMax provider uses OpenAI-compatible chat completions path (`/chat/completions`) with `Authorization: Bearer` authentication.
 The SDK also maps MiniMax payload-level `base_resp` errors (e.g. invalid API key) into SDK error variants.
+For compatibility, MiniMax system prompts are merged into the first user message (instead of sending `role: system`).
 
 For `MiniMax-M2.5-highspeed`, responses can include `<think>...</think>` reasoning blocks.
 By default, the SDK strips these blocks and returns only the final answer text.

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -180,20 +180,43 @@ impl MinimaxRequestBuilder {
             .model
             .clone()
             .unwrap_or_else(|| self.default_model.clone());
-        let mut messages = Vec::new();
-
+        let mut system_parts = Vec::new();
         if let Some(system) = &self.req.system {
-            messages.push(json!({"role": "system", "content": system}));
+            let trimmed = system.trim();
+            if !trimmed.is_empty() {
+                system_parts.push(trimmed.to_string());
+            }
         }
 
+        let mut messages: Vec<(String, String)> = Vec::new();
         for message in &self.req.messages {
-            let role = match message.role {
-                Role::User => "user",
-                Role::Assistant => "assistant",
-                Role::System => "system",
-            };
-            messages.push(json!({"role": role, "content": message.content}));
+            match message.role {
+                Role::System => {
+                    let trimmed = message.content.trim();
+                    if !trimmed.is_empty() {
+                        system_parts.push(trimmed.to_string());
+                    }
+                }
+                Role::User => messages.push(("user".to_string(), message.content.clone())),
+                Role::Assistant => {
+                    messages.push(("assistant".to_string(), message.content.clone()))
+                }
+            }
         }
+
+        if !system_parts.is_empty() {
+            let merged_system = system_parts.join("\n\n");
+            if let Some((_, content)) = messages.iter_mut().find(|(role, _)| role == "user") {
+                *content = format!("{}\n\n{}", merged_system, content);
+            } else {
+                messages.insert(0, ("user".to_string(), merged_system));
+            }
+        }
+
+        let messages: Vec<Value> = messages
+            .into_iter()
+            .map(|(role, content)| json!({"role": role, "content": content}))
+            .collect();
 
         let mut body = json!({
             "model": model,

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -101,6 +101,85 @@ async fn minimax_request_uses_default_model_and_allows_override() {
 }
 
 #[tokio::test]
+async fn minimax_request_merges_system_prompt_into_first_user_message() {
+    let mut server = mockito::Server::new_async().await;
+
+    let no_system_role_mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(r#"\"role\"\s*:\s*\"system\""#.to_string()))
+        .expect(0)
+        .with_status(200)
+        .with_body("{}")
+        .create_async()
+        .await;
+
+    let merged_system_mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(
+            r#"\"content\"\s*:\s*\"global rules\\n\\nmessage rules\\n\\nhello\""#.to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-Text-01",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .system("global rules")
+        .message(Message::system("message rules"))
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "ok");
+
+    merged_system_mock.assert_async().await;
+    no_system_role_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_request_inserts_user_message_when_only_system_prompts_exist() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(r#"\"role\"\s*:\s*\"user\""#.to_string()))
+        .match_body(Matcher::Regex(
+            r#"\"content\"\s*:\s*\"only system\""#.to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-Text-01",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().system("only system").build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "ok");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn minimax_stream_emits_content_and_done() {
     let mut server = mockito::Server::new_async().await;
     let sse_body = concat!(


### PR DESCRIPTION
## Summary
- merge MiniMax system prompts into the first user message for compatibility
- include both top-level `ChatRequest.system` and `Role::System` messages in merged text
- insert synthetic user message when only system prompts are provided
- keep MiniMax reasoning fallback and think-tag stripping behavior unchanged
- add integration tests for merged request payload shape
- document MiniMax system-merge behavior in README

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features

Closes #47
