### PR TITLE
feat(minimax): refresh models and improve payload error mapping

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -60,7 +60,7 @@ cargo build -p motosan-ai --all-features
 
 - Anthropic: `claude-sonnet-4-6`
 - OpenAI: `gpt-5.3-codex`
-- MiniMax: `MiniMax-Text-01`
+- MiniMax: `MiniMax-M2.5-highspeed`
 
 Override per client:
 

--- a/sdks/rust/src/models.rs
+++ b/sdks/rust/src/models.rs
@@ -1,6 +1,6 @@
 pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-6";
 pub const DEFAULT_OPENAI_MODEL: &str = "gpt-5.3-codex";
-pub const DEFAULT_MINIMAX_MODEL: &str = "MiniMax-Text-01";
+pub const DEFAULT_MINIMAX_MODEL: &str = "MiniMax-M2.5-highspeed";
 
 pub const ANTHROPIC_MODELS: &[&str] = &[
     "claude-opus-4-6",
@@ -16,4 +16,11 @@ pub const ANTHROPIC_MODELS: &[&str] = &[
 
 pub const OPENAI_MODELS: &[&str] = &["gpt-5.3-codex", "gpt-4o"];
 
-pub const MINIMAX_MODELS: &[&str] = &["MiniMax-Text-01"];
+pub const MINIMAX_MODELS: &[&str] = &[
+    "MiniMax-M2.5-highspeed",
+    "MiniMax-M2.5",
+    "MiniMax-M2.1-highspeed",
+    "MiniMax-M2.1",
+    "MiniMax-M2",
+    "MiniMax-Text-01",
+];

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -65,7 +65,27 @@ impl MinimaxProvider {
             .unwrap_or("minimax request failed")
             .to_string();
 
-        let mapped_status = if status_code == 2049 { 401 } else { 500 };
+        let message_lower = message.to_ascii_lowercase();
+        let mapped_status = match status_code {
+            2049 => 401,
+            1008 => 429,
+            4000..=4999 => 400,
+            5000..=5999 => 500,
+            _ if message_lower.contains("invalid api key")
+                || message_lower.contains("unauthorized")
+                || message_lower.contains("authentication") =>
+            {
+                401
+            }
+            _ if message_lower.contains("insufficient balance")
+                || message_lower.contains("quota")
+                || message_lower.contains("rate limit")
+                || message_lower.contains("too many") =>
+            {
+                429
+            }
+            _ => 500,
+        };
         Some((mapped_status, message))
     }
 

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -284,6 +284,66 @@ async fn minimax_maps_payload_level_invalid_api_key_to_auth_error() {
 }
 
 #[tokio::test]
+async fn minimax_maps_payload_level_insufficient_balance_to_rate_limit_error() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "base_resp": {
+                    "status_code": 1008,
+                    "status_msg": "insufficient balance (1008)"
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let result = provider.chat(request).await;
+    assert!(matches!(result, Err(MotosanError::RateLimit(_))));
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_maps_payload_level_4xxx_to_invalid_request_error() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "base_resp": {
+                    "status_code": 4001,
+                    "status_msg": "bad request"
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let result = provider.chat(request).await;
+    assert!(matches!(result, Err(MotosanError::InvalidRequest(_))));
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn minimax_chat_strips_think_blocks_by_default() {
     let mut server = mockito::Server::new_async().await;
     let mock = server


### PR DESCRIPTION
## Summary
- refresh MiniMax Rust SDK model defaults/catalog to include current M2.5 family
- set `DEFAULT_MINIMAX_MODEL` to `MiniMax-M2.5-highspeed`
- improve MiniMax payload-level `base_resp.status_code` mapping semantics
  - map `2049` to auth (`401`)
  - map `1008` to rate-limit/quota (`429`)
  - map `4xxx` to invalid request (`400`)
  - map `5xxx` to provider/server (`500`)
  - add message-based fallback mapping for auth/quota hints
- add tests for payload-level balance and 4xxx mapping behavior
- update Rust README default model note

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features

Closes #49
Closes #50
