### PR TITLE
feat(openai): harden streaming and add compatibility options

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -92,6 +92,21 @@ match client.chat(vec![Message::user("hello")]).await {
 }
 ```
 
+## OpenAI Provider Options
+
+Advanced OpenAI-compatible usage:
+
+```rust
+use motosan_ai::providers::openai::{OpenAIAuthStyle, OpenAIProvider};
+
+let provider = OpenAIProvider::new("api-key", None, Some("https://api.openai.com".to_string()))
+    .with_auth_style(OpenAIAuthStyle::Bearer)
+    .with_responses_fallback(true);
+```
+
+- `with_auth_style(...)`: supports `Bearer`, `XApiKey`, or custom header.
+- `with_responses_fallback(true)`: when `/v1/chat/completions` returns `404`, fallback to `/v1/responses`.
+
 ## Retry Policy
 
 Retry is enabled by default for transient failures (`429`, `5xx`, timeout/connect errors).

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -13,11 +13,20 @@ use reqwest::Client;
 use serde_json::{json, Value};
 use tokio_stream::StreamExt;
 
+#[derive(Debug, Clone)]
+pub enum OpenAIAuthStyle {
+    Bearer,
+    XApiKey,
+    Custom(String),
+}
+
 pub struct OpenAIProvider {
     http: Client,
     api_key: String,
     model: String,
     base_url: String,
+    auth_style: OpenAIAuthStyle,
+    responses_fallback: bool,
     retry_policy: RetryPolicy,
 }
 
@@ -32,8 +41,20 @@ impl OpenAIProvider {
             api_key: api_key.into(),
             model: model.unwrap_or_else(|| DEFAULT_OPENAI_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| "https://api.openai.com".to_string()),
+            auth_style: OpenAIAuthStyle::Bearer,
+            responses_fallback: false,
             retry_policy: RetryPolicy::default(),
         }
+    }
+
+    pub fn with_auth_style(mut self, auth_style: OpenAIAuthStyle) -> Self {
+        self.auth_style = auth_style;
+        self
+    }
+
+    pub fn with_responses_fallback(mut self, enabled: bool) -> Self {
+        self.responses_fallback = enabled;
+        self
     }
 
     pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
@@ -42,7 +63,185 @@ impl OpenAIProvider {
     }
 
     fn endpoint(&self) -> String {
-        format!("{}/v1/chat/completions", self.base_url)
+        format!(
+            "{}/v1/chat/completions",
+            self.base_url.trim_end_matches('/')
+        )
+    }
+
+    fn responses_endpoint(&self) -> String {
+        let normalized = self.base_url.trim_end_matches('/');
+        if let Some(prefix) = normalized.strip_suffix("/chat/completions") {
+            return format!("{prefix}/responses");
+        }
+        if normalized.ends_with("/v1") {
+            return format!("{normalized}/responses");
+        }
+        format!("{normalized}/v1/responses")
+    }
+
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.auth_style {
+            OpenAIAuthStyle::Bearer => {
+                req.header("authorization", format!("Bearer {}", self.api_key))
+            }
+            OpenAIAuthStyle::XApiKey => req.header("x-api-key", self.api_key.clone()),
+            OpenAIAuthStyle::Custom(header_name) => req.header(header_name, self.api_key.clone()),
+        }
+    }
+
+    fn first_non_empty_text(value: Option<&Value>) -> Option<&str> {
+        value
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+    }
+
+    fn extract_chat_content(payload: &Value) -> String {
+        let message = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"));
+
+        let content = Self::first_non_empty_text(message.and_then(|msg| msg.get("content")));
+        let reasoning =
+            Self::first_non_empty_text(message.and_then(|msg| msg.get("reasoning_content")));
+
+        content.or(reasoning).unwrap_or_default().to_string()
+    }
+
+    fn extract_stream_delta_text(payload: &Value) -> String {
+        let delta = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("delta"));
+
+        let content = Self::first_non_empty_text(delta.and_then(|d| d.get("content")));
+        let reasoning = Self::first_non_empty_text(delta.and_then(|d| d.get("reasoning_content")));
+
+        content.or(reasoning).unwrap_or_default().to_string()
+    }
+
+    fn extract_responses_text(payload: &Value) -> String {
+        if let Some(text) = Self::first_non_empty_text(payload.get("output_text")) {
+            return text.to_string();
+        }
+
+        payload
+            .get("output")
+            .and_then(Value::as_array)
+            .and_then(|outputs| outputs.first())
+            .and_then(|output| output.get("content"))
+            .and_then(Value::as_array)
+            .and_then(|content_items| {
+                content_items.iter().find_map(|item| {
+                    Self::first_non_empty_text(item.get("text")).or_else(|| {
+                        Self::first_non_empty_text(
+                            item.get("content")
+                                .and_then(Value::as_array)
+                                .and_then(|inner| inner.first())
+                                .and_then(|inner_item| inner_item.get("text")),
+                        )
+                    })
+                })
+            })
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    async fn chat_via_responses(&self, req: &ChatRequest) -> Result<ChatResponse, MotosanError> {
+        let model = req.model.clone().unwrap_or_else(|| self.model.clone());
+        let mut instructions_parts = Vec::new();
+        if let Some(system) = &req.system {
+            let trimmed = system.trim();
+            if !trimmed.is_empty() {
+                instructions_parts.push(trimmed.to_string());
+            }
+        }
+
+        let mut input = Vec::new();
+        for message in &req.messages {
+            match message.role {
+                Role::System => {
+                    let trimmed = message.content.trim();
+                    if !trimmed.is_empty() {
+                        instructions_parts.push(trimmed.to_string());
+                    }
+                }
+                Role::Assistant => {
+                    input.push(json!({"role": "assistant", "content": message.content}))
+                }
+                Role::User => input.push(json!({"role": "user", "content": message.content})),
+            }
+        }
+
+        let mut body = json!({
+            "model": model,
+            "input": input,
+        });
+
+        if !instructions_parts.is_empty() {
+            body["instructions"] = json!(instructions_parts.join("\n\n"));
+        }
+
+        if let Some(provider_options) = &req.provider_options {
+            if let Some(map) = provider_options.as_object() {
+                for (key, value) in map {
+                    body[key] = value.clone();
+                }
+            }
+        }
+
+        let response = self
+            .apply_auth(self.http.post(self.responses_endpoint()).json(&body))
+            .send()
+            .await
+            .map_err(|error| MotosanError::Network(error.to_string()))?;
+
+        let status = response.status();
+        let payload: Value = response
+            .json()
+            .await
+            .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+
+        if !status.is_success() {
+            let message = extract_error_message(&payload, "openai responses request failed");
+            return Err(map_http_error(status.as_u16(), message));
+        }
+
+        let content = Self::extract_responses_text(&payload);
+        let model = payload
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or(DEFAULT_OPENAI_MODEL)
+            .to_string();
+        let input_tokens = payload
+            .get("usage")
+            .and_then(|usage| {
+                usage
+                    .get("input_tokens")
+                    .or_else(|| usage.get("prompt_tokens"))
+            })
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+        let output_tokens = payload
+            .get("usage")
+            .and_then(|usage| {
+                usage
+                    .get("output_tokens")
+                    .or_else(|| usage.get("completion_tokens"))
+            })
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+
+        Ok(ChatResponseBuilder::new(DEFAULT_OPENAI_MODEL)
+            .content(content)
+            .model(model)
+            .usage(input_tokens, output_tokens)
+            .stop_reason(StopReason::Stop)
+            .build())
     }
 }
 
@@ -116,15 +315,13 @@ impl OpenAIRequestBuilder {
 #[async_trait]
 impl ProviderImpl for OpenAIProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+        let fallback_request = req.clone();
         let body = OpenAIRequestBuilder::new(req, self.model.clone()).build();
         let mut attempt = 0;
         let payload: Value;
         loop {
             let response = match self
-                .http
-                .post(self.endpoint())
-                .header("authorization", format!("Bearer {}", self.api_key))
-                .json(&body)
+                .apply_auth(self.http.post(self.endpoint()).json(&body))
                 .send()
                 .await
             {
@@ -142,6 +339,11 @@ impl ProviderImpl for OpenAIProvider {
 
             let status = response.status();
             let retry_after = parse_retry_after(response.headers());
+
+            if self.responses_fallback && status.as_u16() == 404 {
+                return self.chat_via_responses(&fallback_request).await;
+            }
+
             let current_payload: Value = response
                 .json()
                 .await
@@ -162,15 +364,7 @@ impl ProviderImpl for OpenAIProvider {
             return Err(map_http_error(status.as_u16(), message));
         }
 
-        let content = payload
-            .get("choices")
-            .and_then(Value::as_array)
-            .and_then(|choices| choices.first())
-            .and_then(|choice| choice.get("message"))
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string();
+        let content = Self::extract_chat_content(&payload);
 
         let stop_reason = match payload
             .get("choices")
@@ -216,10 +410,7 @@ impl ProviderImpl for OpenAIProvider {
         let mut attempt = 0;
         let response = loop {
             let response = match self
-                .http
-                .post(self.endpoint())
-                .header("authorization", format!("Bearer {}", self.api_key))
-                .json(&body)
+                .apply_auth(self.http.post(self.endpoint()).json(&body))
                 .send()
                 .await
             {
@@ -247,10 +438,11 @@ impl ProviderImpl for OpenAIProvider {
                 continue;
             }
 
-            let message = response
-                .text()
+            let current_payload: Value = response
+                .json()
                 .await
-                .unwrap_or_else(|_| "openai stream request failed".to_string());
+                .unwrap_or_else(|_| json!({"error": {"message": "openai stream request failed"}}));
+            let message = extract_error_message(&current_payload, "openai stream request failed");
             return Err(map_http_error(status.as_u16(), message));
         };
 
@@ -267,15 +459,10 @@ impl ProviderImpl for OpenAIProvider {
                     }
 
                     let payload: Value = serde_json::from_str(&event.data).ok()?;
-                    let text = payload
-                        .get("choices")
-                        .and_then(Value::as_array)
-                        .and_then(|choices| choices.first())
-                        .and_then(|choice| choice.get("delta"))
-                        .and_then(|delta| delta.get("content"))
-                        .and_then(Value::as_str)
-                        .unwrap_or("")
-                        .to_string();
+                    let text = Self::extract_stream_delta_text(&payload);
+                    if text.is_empty() {
+                        return None;
+                    }
                     Some(crate::types::StreamEvent {
                         content: text,
                         done: false,

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "openai")]
 
 use mockito::Matcher;
-use motosan_ai::providers::openai::OpenAIProvider;
+use motosan_ai::providers::openai::{OpenAIAuthStyle, OpenAIProvider};
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, StopReason, DEFAULT_OPENAI_MODEL};
+use motosan_ai::{ChatRequest, Message, MotosanError, StopReason, DEFAULT_OPENAI_MODEL};
 use serde_json::json;
 use tokio_stream::StreamExt;
 
@@ -175,4 +175,184 @@ async fn openai_stream_ignores_malformed_chunks() {
     assert!(events[1].done);
 
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_endpoint_normalizes_trailing_slash_base_url() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-4o",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(format!("{}/", server.url())));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "ok");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_chat_falls_back_to_reasoning_content_when_content_empty() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{"message": {"content": "", "reasoning_content": "fallback"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "fallback");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_stream_falls_back_to_reasoning_content_and_skips_empty_chunks() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"thinking fallback\"}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].content, "thinking fallback");
+    assert!(events[1].done);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_stream_maps_structured_error_payload() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(401)
+        .with_body(json!({"error": {"message": "bad key"}}).to_string())
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let result = provider.stream(request).await;
+    assert!(matches!(result, Err(MotosanError::Auth(_))));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_auth_style_x_api_key_is_supported() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-4o",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()))
+        .with_auth_style(OpenAIAuthStyle::XApiKey);
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "ok");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_chat_can_fallback_to_responses_api_on_404() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(404)
+        .with_body(json!({"error": {"message": "not found"}}).to_string())
+        .create_async()
+        .await;
+
+    let responses_mock = server
+        .mock("POST", "/v1/responses")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "output_text": "fallback response",
+                "usage": {"input_tokens": 5, "output_tokens": 3}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider =
+        OpenAIProvider::new("test-key", None, Some(server.url())).with_responses_fallback(true);
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "fallback response");
+    assert_eq!(response.usage.input_tokens, 5);
+    assert_eq!(response.usage.output_tokens, 3);
+    responses_mock.assert_async().await;
 }


### PR DESCRIPTION
## Summary
- parse structured JSON error payloads in OpenAI stream failure path
- suppress empty non-done stream chunks
- add `reasoning_content` fallback for chat and stream parsing
- normalize custom base URLs when building chat endpoint
- add configurable OpenAI auth style (`Bearer`, `XApiKey`, `Custom`)
- add optional chat fallback to `/v1/responses` on `404`
- add comprehensive provider tests and README usage notes

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features

Closes #54
Closes #55
Closes #56
Closes #57
Closes #58
