### PR TITLE
feat(client): expose OpenAI auth and fallback options in builder

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -107,6 +107,19 @@ let provider = OpenAIProvider::new("api-key", None, Some("https://api.openai.com
 - `with_auth_style(...)`: supports `Bearer`, `XApiKey`, or custom header.
 - `with_responses_fallback(true)`: when `/v1/chat/completions` returns `404`, fallback to `/v1/responses`.
 
+The same behavior is available from `Client::builder()`:
+
+```rust
+use motosan_ai::{Client, Provider};
+
+let client = Client::builder()
+    .provider(Provider::OpenAI)
+    .api_key("...")
+    .openai_auth_x_api_key() // or .openai_auth_custom_header("X-Auth-Token")
+    .openai_responses_fallback(true)
+    .build()?;
+```
+
 ## Retry Policy
 
 Retry is enabled by default for transient failures (`429`, `5xx`, timeout/connect errors).

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -9,6 +9,8 @@ pub struct Client {
     provider: Provider,
     api_key: String,
     model: Option<String>,
+    openai_auth_header: Option<String>,
+    openai_responses_fallback: bool,
     minimax_expose_reasoning: bool,
     retry_policy: RetryPolicy,
 }
@@ -36,6 +38,14 @@ impl Client {
 
     pub fn minimax_expose_reasoning(&self) -> bool {
         self.minimax_expose_reasoning
+    }
+
+    pub fn openai_auth_header(&self) -> Option<&str> {
+        self.openai_auth_header.as_deref()
+    }
+
+    pub fn openai_responses_fallback(&self) -> bool {
+        self.openai_responses_fallback
     }
 
     pub async fn chat(&self, messages: Vec<Message>) -> Result<ChatResponse, MotosanError> {
@@ -163,12 +173,18 @@ impl Client {
 
     #[cfg(feature = "openai")]
     fn build_openai_provider(&self) -> crate::providers::openai::OpenAIProvider {
-        crate::providers::openai::OpenAIProvider::new(
-            self.api_key.clone(),
-            self.model.clone(),
-            None,
-        )
-        .with_retry_policy(self.retry_policy.clone())
+        use crate::providers::openai::{OpenAIAuthStyle, OpenAIProvider};
+
+        let auth_style = match self.openai_auth_header.as_deref() {
+            None => OpenAIAuthStyle::Bearer,
+            Some(header) if header.eq_ignore_ascii_case("x-api-key") => OpenAIAuthStyle::XApiKey,
+            Some(header) => OpenAIAuthStyle::Custom(header.to_string()),
+        };
+
+        OpenAIProvider::new(self.api_key.clone(), self.model.clone(), None)
+            .with_auth_style(auth_style)
+            .with_responses_fallback(self.openai_responses_fallback)
+            .with_retry_policy(self.retry_policy.clone())
     }
 
     #[cfg(feature = "minimax")]
@@ -188,6 +204,8 @@ pub struct ClientBuilder {
     provider: Option<Provider>,
     api_key: Option<String>,
     model: Option<String>,
+    openai_auth_header: Option<String>,
+    openai_responses_fallback: Option<bool>,
     minimax_expose_reasoning: Option<bool>,
     retry_policy: Option<RetryPolicy>,
 }
@@ -213,6 +231,26 @@ impl ClientBuilder {
         self
     }
 
+    pub fn openai_auth_bearer(mut self) -> Self {
+        self.openai_auth_header = None;
+        self
+    }
+
+    pub fn openai_auth_x_api_key(mut self) -> Self {
+        self.openai_auth_header = Some("x-api-key".to_string());
+        self
+    }
+
+    pub fn openai_auth_custom_header(mut self, header_name: impl Into<String>) -> Self {
+        self.openai_auth_header = Some(header_name.into());
+        self
+    }
+
+    pub fn openai_responses_fallback(mut self, enabled: bool) -> Self {
+        self.openai_responses_fallback = Some(enabled);
+        self
+    }
+
     pub fn minimax_expose_reasoning(mut self, minimax_expose_reasoning: bool) -> Self {
         self.minimax_expose_reasoning = Some(minimax_expose_reasoning);
         self
@@ -230,6 +268,8 @@ impl ClientBuilder {
             provider,
             api_key,
             model: self.model,
+            openai_auth_header: self.openai_auth_header,
+            openai_responses_fallback: self.openai_responses_fallback.unwrap_or(false),
             minimax_expose_reasoning: self.minimax_expose_reasoning.unwrap_or(false),
             retry_policy: self.retry_policy.unwrap_or_default(),
         })

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -69,6 +69,47 @@ fn builder_defaults_minimax_expose_reasoning_to_false_and_allows_override() {
     assert!(custom_client.minimax_expose_reasoning());
 }
 
+#[test]
+fn builder_defaults_openai_options_and_allows_override() {
+    let default_client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .build()
+        .expect("build client");
+    assert_eq!(default_client.openai_auth_header(), None);
+    assert!(!default_client.openai_responses_fallback());
+
+    let custom_client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .openai_auth_x_api_key()
+        .openai_responses_fallback(true)
+        .build()
+        .expect("build client");
+    assert_eq!(custom_client.openai_auth_header(), Some("x-api-key"));
+    assert!(custom_client.openai_responses_fallback());
+
+    let custom_header_client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .openai_auth_custom_header("X-Auth-Token")
+        .build()
+        .expect("build client");
+    assert_eq!(
+        custom_header_client.openai_auth_header(),
+        Some("X-Auth-Token")
+    );
+
+    let reset_to_bearer_client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .openai_auth_custom_header("X-Auth-Token")
+        .openai_auth_bearer()
+        .build()
+        .expect("build client");
+    assert_eq!(reset_to_bearer_client.openai_auth_header(), None);
+}
+
 #[tokio::test]
 async fn chat_and_stream_exist_and_dispatch() {
     let client = Client::builder()


### PR DESCRIPTION
## Summary
- expose OpenAI-specific options in `Client::builder()`:
  - auth header mode (`openai_auth_bearer`, `openai_auth_x_api_key`, `openai_auth_custom_header`)
  - `openai_responses_fallback(bool)`
- plumb new client options into OpenAI provider construction
- add client getters for effective OpenAI options
- add builder tests for default/override behavior
- update README with `Client::builder()` OpenAI option example

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features

Closes #60
