### PR TITLE
feat(rust): implement v0.2 tool-use support across providers

### DIFF
--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -16,5 +16,5 @@ pub use providers::Provider;
 pub use retry::RetryPolicy;
 pub use stream::{BoxStream, StreamEvent};
 pub use types::{
-    ChatRequest, ChatRequestBuilder, ChatResponse, Message, Role, StopReason, Tool, Usage,
+    ChatRequest, ChatRequestBuilder, ChatResponse, Message, Role, StopReason, Tool, ToolCall, Usage,
 };

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -6,7 +6,7 @@ use crate::providers::{
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason, ToolCall};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use reqwest::Client;
@@ -113,6 +113,18 @@ impl AnthropicRequestBuilder {
                 Role::Assistant => {
                     messages.push(json!({"role": "assistant", "content": message.content}))
                 }
+                Role::Tool => {
+                    if let Some(tool_use_id) = &message.tool_call_id {
+                        messages.push(json!({
+                            "role": "user",
+                            "content": [{
+                                "type": "tool_result",
+                                "tool_use_id": tool_use_id,
+                                "content": message.content,
+                            }],
+                        }));
+                    }
+                }
             }
         }
 
@@ -140,6 +152,21 @@ impl AnthropicRequestBuilder {
         }
         if let Some(max_tokens) = self.req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
+        }
+        if let Some(tools) = self.req.tools {
+            let mapped_tools: Vec<Value> = tools
+                .into_iter()
+                .map(|tool| {
+                    json!({
+                        "name": tool.name,
+                        "description": tool.description.unwrap_or_default(),
+                        "input_schema": tool.input_schema.unwrap_or_else(|| json!({"type":"object","properties":{}})),
+                    })
+                })
+                .collect();
+            if !mapped_tools.is_empty() {
+                body["tools"] = json!(mapped_tools);
+            }
         }
         if let Some(provider_options) = self.req.provider_options {
             if let Some(map) = provider_options.as_object() {
@@ -217,6 +244,31 @@ impl ProviderImpl for AnthropicProvider {
             })
             .unwrap_or_default();
 
+        let tool_calls = payload
+            .get("content")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"))
+                    .map(|item| ToolCall {
+                        id: item
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        name: item
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        input: item.get("input").cloned().unwrap_or_else(|| json!({})),
+                    })
+                    .filter(|call| !call.id.is_empty() && !call.name.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
         let model = payload
             .get("model")
             .and_then(Value::as_str)
@@ -244,6 +296,7 @@ impl ProviderImpl for AnthropicProvider {
 
         Ok(ChatResponseBuilder::new(DEFAULT_ANTHROPIC_MODEL)
             .content(content)
+            .tool_calls(tool_calls)
             .model(model)
             .usage(input_tokens, output_tokens)
             .stop_reason(stop_reason)

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -6,7 +6,7 @@ use crate::providers::{
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason, ToolCall};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use reqwest::Client;
@@ -208,7 +208,7 @@ impl MinimaxRequestBuilder {
             }
         }
 
-        let mut messages: Vec<(String, String)> = Vec::new();
+        let mut messages: Vec<(String, String, Option<String>)> = Vec::new();
         for message in &self.req.messages {
             match message.role {
                 Role::System => {
@@ -217,25 +217,40 @@ impl MinimaxRequestBuilder {
                         system_parts.push(trimmed.to_string());
                     }
                 }
-                Role::User => messages.push(("user".to_string(), message.content.clone())),
+                Role::User => messages.push(("user".to_string(), message.content.clone(), None)),
                 Role::Assistant => {
-                    messages.push(("assistant".to_string(), message.content.clone()))
+                    messages.push(("assistant".to_string(), message.content.clone(), None))
+                }
+                Role::Tool => {
+                    if let Some(tool_call_id) = &message.tool_call_id {
+                        messages.push((
+                            "tool".to_string(),
+                            message.content.clone(),
+                            Some(tool_call_id.clone()),
+                        ));
+                    }
                 }
             }
         }
 
         if !system_parts.is_empty() {
             let merged_system = system_parts.join("\n\n");
-            if let Some((_, content)) = messages.iter_mut().find(|(role, _)| role == "user") {
+            if let Some((_, content, _)) = messages.iter_mut().find(|(role, _, _)| role == "user") {
                 *content = format!("{}\n\n{}", merged_system, content);
             } else {
-                messages.insert(0, ("user".to_string(), merged_system));
+                messages.insert(0, ("user".to_string(), merged_system, None));
             }
         }
 
         let messages: Vec<Value> = messages
             .into_iter()
-            .map(|(role, content)| json!({"role": role, "content": content}))
+            .map(|(role, content, tool_call_id)| {
+                let mut message = json!({"role": role, "content": content});
+                if let Some(tool_call_id) = tool_call_id {
+                    message["tool_call_id"] = json!(tool_call_id);
+                }
+                message
+            })
             .collect();
 
         let mut body = json!({
@@ -251,6 +266,24 @@ impl MinimaxRequestBuilder {
         }
         if let Some(max_tokens) = self.req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
+        }
+        if let Some(tools) = self.req.tools {
+            let mapped_tools: Vec<Value> = tools
+                .into_iter()
+                .map(|tool| {
+                    json!({
+                        "type": "function",
+                        "function": {
+                            "name": tool.name,
+                            "description": tool.description.unwrap_or_default(),
+                            "parameters": tool.input_schema.unwrap_or_else(|| json!({"type":"object","properties":{}})),
+                        }
+                    })
+                })
+                .collect();
+            if !mapped_tools.is_empty() {
+                body["tools"] = json!(mapped_tools);
+            }
         }
         if let Some(provider_options) = self.req.provider_options {
             if let Some(map) = provider_options.as_object() {
@@ -324,6 +357,32 @@ impl ProviderImpl for MinimaxProvider {
 
         let content = Self::extract_chat_content(&payload, expose_reasoning);
 
+        let tool_calls = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"))
+            .and_then(|message| message.get("tool_calls"))
+            .and_then(Value::as_array)
+            .map(|calls| {
+                calls
+                    .iter()
+                    .filter_map(|call| {
+                        let id = call.get("id").and_then(Value::as_str)?.to_string();
+                        let function = call.get("function")?;
+                        let name = function.get("name").and_then(Value::as_str)?.to_string();
+                        let arguments = function
+                            .get("arguments")
+                            .and_then(Value::as_str)
+                            .unwrap_or("{}");
+                        let input = serde_json::from_str(arguments)
+                            .unwrap_or_else(|_| Value::String(arguments.to_string()));
+                        Some(ToolCall { id, name, input })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
         let stop_reason = match payload
             .get("choices")
             .and_then(Value::as_array)
@@ -355,6 +414,7 @@ impl ProviderImpl for MinimaxProvider {
 
         Ok(ChatResponseBuilder::new(DEFAULT_MINIMAX_MODEL)
             .content(content)
+            .tool_calls(tool_calls)
             .model(model)
             .usage(input_tokens, output_tokens)
             .stop_reason(stop_reason)

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -4,7 +4,7 @@ use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse};
 #[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
-use crate::types::{StopReason, Usage};
+use crate::types::{StopReason, ToolCall, Usage};
 use async_trait::async_trait;
 #[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 use reqwest::header::HeaderMap;
@@ -29,6 +29,7 @@ pub trait ProviderImpl: Send + Sync {
 #[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 pub(crate) struct ChatResponseBuilder {
     content: String,
+    tool_calls: Vec<ToolCall>,
     model: String,
     usage: Usage,
     stop_reason: StopReason,
@@ -39,6 +40,7 @@ impl ChatResponseBuilder {
     pub(crate) fn new(default_model: impl Into<String>) -> Self {
         Self {
             content: String::new(),
+            tool_calls: Vec::new(),
             model: default_model.into(),
             usage: Usage {
                 input_tokens: 0,
@@ -58,6 +60,11 @@ impl ChatResponseBuilder {
         self
     }
 
+    pub(crate) fn tool_calls(mut self, tool_calls: Vec<ToolCall>) -> Self {
+        self.tool_calls = tool_calls;
+        self
+    }
+
     pub(crate) fn usage(mut self, input_tokens: u32, output_tokens: u32) -> Self {
         self.usage = Usage {
             input_tokens,
@@ -74,6 +81,7 @@ impl ChatResponseBuilder {
     pub(crate) fn build(self) -> ChatResponse {
         ChatResponse {
             content: self.content,
+            tool_calls: self.tool_calls,
             model: self.model,
             usage: self.usage,
             stop_reason: self.stop_reason,

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -6,7 +6,7 @@ use crate::providers::{
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason, ToolCall};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use reqwest::Client;
@@ -174,6 +174,15 @@ impl OpenAIProvider {
                     input.push(json!({"role": "assistant", "content": message.content}))
                 }
                 Role::User => input.push(json!({"role": "user", "content": message.content})),
+                Role::Tool => {
+                    if let Some(tool_call_id) = &message.tool_call_id {
+                        input.push(json!({
+                            "role": "tool",
+                            "tool_call_id": tool_call_id,
+                            "content": message.content,
+                        }));
+                    }
+                }
             }
         }
 
@@ -278,12 +287,24 @@ impl OpenAIRequestBuilder {
         }
 
         for message in &self.req.messages {
-            let role = match message.role {
-                Role::User => "user",
-                Role::Assistant => "assistant",
-                Role::System => "system",
-            };
-            messages.push(json!({"role": role, "content": message.content}));
+            match message.role {
+                Role::User => messages.push(json!({"role": "user", "content": message.content})),
+                Role::Assistant => {
+                    messages.push(json!({"role": "assistant", "content": message.content}))
+                }
+                Role::System => {
+                    messages.push(json!({"role": "system", "content": message.content}))
+                }
+                Role::Tool => {
+                    if let Some(tool_call_id) = &message.tool_call_id {
+                        messages.push(json!({
+                            "role": "tool",
+                            "tool_call_id": tool_call_id,
+                            "content": message.content,
+                        }));
+                    }
+                }
+            }
         }
 
         let mut body = json!({
@@ -299,6 +320,24 @@ impl OpenAIRequestBuilder {
         }
         if let Some(max_tokens) = self.req.max_tokens {
             body["max_tokens"] = json!(max_tokens);
+        }
+        if let Some(tools) = self.req.tools {
+            let mapped_tools: Vec<Value> = tools
+                .into_iter()
+                .map(|tool| {
+                    json!({
+                        "type": "function",
+                        "function": {
+                            "name": tool.name,
+                            "description": tool.description.unwrap_or_default(),
+                            "parameters": tool.input_schema.unwrap_or_else(|| json!({"type":"object","properties":{}})),
+                        }
+                    })
+                })
+                .collect();
+            if !mapped_tools.is_empty() {
+                body["tools"] = json!(mapped_tools);
+            }
         }
         if let Some(provider_options) = self.req.provider_options {
             if let Some(map) = provider_options.as_object() {
@@ -366,6 +405,32 @@ impl ProviderImpl for OpenAIProvider {
 
         let content = Self::extract_chat_content(&payload);
 
+        let tool_calls = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"))
+            .and_then(|message| message.get("tool_calls"))
+            .and_then(Value::as_array)
+            .map(|calls| {
+                calls
+                    .iter()
+                    .filter_map(|call| {
+                        let id = call.get("id").and_then(Value::as_str)?.to_string();
+                        let function = call.get("function")?;
+                        let name = function.get("name").and_then(Value::as_str)?.to_string();
+                        let arguments = function
+                            .get("arguments")
+                            .and_then(Value::as_str)
+                            .unwrap_or("{}");
+                        let input = serde_json::from_str(arguments)
+                            .unwrap_or_else(|_| Value::String(arguments.to_string()));
+                        Some(ToolCall { id, name, input })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
         let stop_reason = match payload
             .get("choices")
             .and_then(Value::as_array)
@@ -397,6 +462,7 @@ impl ProviderImpl for OpenAIProvider {
 
         Ok(ChatResponseBuilder::new(DEFAULT_OPENAI_MODEL)
             .content(content)
+            .tool_calls(tool_calls)
             .model(model)
             .usage(input_tokens, output_tokens)
             .stop_reason(stop_reason)

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -7,12 +7,14 @@ pub enum Role {
     User,
     Assistant,
     System,
+    Tool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Message {
     pub role: Role,
     pub content: String,
+    pub tool_call_id: Option<String>,
 }
 
 impl Message {
@@ -20,6 +22,7 @@ impl Message {
         Self {
             role: Role::User,
             content: content.into(),
+            tool_call_id: None,
         }
     }
 
@@ -27,6 +30,7 @@ impl Message {
         Self {
             role: Role::Assistant,
             content: content.into(),
+            tool_call_id: None,
         }
     }
 
@@ -34,6 +38,15 @@ impl Message {
         Self {
             role: Role::System,
             content: content.into(),
+            tool_call_id: None,
+        }
+    }
+
+    pub fn tool(content: impl Into<String>, tool_call_id: impl Into<String>) -> Self {
+        Self {
+            role: Role::Tool,
+            content: content.into(),
+            tool_call_id: Some(tool_call_id.into()),
         }
     }
 }
@@ -130,9 +143,17 @@ impl ChatRequestBuilder {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatResponse {
     pub content: String,
+    pub tool_calls: Vec<ToolCall>,
     pub model: String,
     pub usage: Usage,
     pub stop_reason: StopReason,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub input: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/sdks/rust/tests/core_types.rs
+++ b/sdks/rust/tests/core_types.rs
@@ -5,11 +5,14 @@ fn message_constructors_set_role_and_content() {
     let user = Message::user("hello");
     let assistant = Message::assistant("world");
     let system = Message::system("policy");
+    let tool = Message::tool("{}", "call_1");
 
     assert!(matches!(user.role, Role::User));
     assert!(matches!(assistant.role, Role::Assistant));
     assert!(matches!(system.role, Role::System));
+    assert!(matches!(tool.role, Role::Tool));
     assert_eq!(user.content, "hello");
+    assert_eq!(tool.tool_call_id.as_deref(), Some("call_1"));
 }
 
 #[test]

--- a/sdks/rust/tests/tool_use_integration.rs
+++ b/sdks/rust/tests/tool_use_integration.rs
@@ -1,0 +1,162 @@
+#![cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+
+use mockito::Matcher;
+use motosan_ai::{ChatRequest, Message, Tool};
+use serde_json::json;
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_serializes_tools_and_extracts_tool_use() {
+    use motosan_ai::providers::anthropic::AnthropicProvider;
+    use motosan_ai::providers::ProviderImpl;
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_body(Matcher::Regex(r#"\"tools\"\s*:\s*\["#.to_string()))
+        .match_body(Matcher::Regex(
+            r#"\"name\"\s*:\s*\"get_weather\""#.to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 11, "output_tokens": 7},
+                "content": [
+                    {"type": "text", "text": "calling tool"},
+                    {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Taipei"}}
+                ]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("weather?"))
+        .tools(vec![Tool {
+            name: "get_weather".to_string(),
+            description: Some("Get weather by city".to_string()),
+            input_schema: Some(json!({"type":"object","properties":{"city":{"type":"string"}}})),
+        }])
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].id, "toolu_1");
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+    assert_eq!(response.tool_calls[0].input["city"], "Taipei");
+    mock.assert_async().await;
+}
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_serializes_tools_and_extracts_tool_calls() {
+    use motosan_ai::providers::openai::OpenAIProvider;
+    use motosan_ai::providers::ProviderImpl;
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(r#"\"tools\"\s*:\s*\["#.to_string()))
+        .match_body(Matcher::Regex(
+            r#"\"name\"\s*:\s*\"get_weather\""#.to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{
+                    "message": {
+                        "content": "",
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{\"city\":\"Taipei\"}"}
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 4}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("weather?"))
+        .tools(vec![Tool {
+            name: "get_weather".to_string(),
+            description: Some("Get weather by city".to_string()),
+            input_schema: Some(json!({"type":"object","properties":{"city":{"type":"string"}}})),
+        }])
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].id, "call_1");
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+    assert_eq!(response.tool_calls[0].input["city"], "Taipei");
+    mock.assert_async().await;
+}
+
+#[cfg(feature = "minimax")]
+#[tokio::test]
+async fn minimax_serializes_tools_and_extracts_tool_calls() {
+    use motosan_ai::providers::minimax::MinimaxProvider;
+    use motosan_ai::providers::ProviderImpl;
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(r#"\"tools\"\s*:\s*\["#.to_string()))
+        .match_body(Matcher::Regex(
+            r#"\"name\"\s*:\s*\"get_weather\""#.to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-M2.5-highspeed",
+                "choices": [{
+                    "message": {
+                        "content": "",
+                        "tool_calls": [{
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{\"city\":\"Taipei\"}"}
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 4},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("weather?"))
+        .tools(vec![Tool {
+            name: "get_weather".to_string(),
+            description: Some("Get weather by city".to_string()),
+            input_schema: Some(json!({"type":"object","properties":{"city":{"type":"string"}}})),
+        }])
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].id, "call_2");
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+    assert_eq!(response.tool_calls[0].input["city"], "Taipei");
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- add core tool-use types to Rust SDK:
  - `Role::Tool`
  - `Message.tool_call_id`
  - `Message::tool(...)`
  - `ToolCall`
  - `ChatResponse.tool_calls`
- Anthropic provider:
  - serialize request tools
  - map tool result messages from `Role::Tool`
  - extract `tool_use` blocks into `ChatResponse.tool_calls`
- OpenAI provider:
  - serialize request tools
  - serialize tool-role request messages (`tool_call_id`)
  - extract `message.tool_calls` into `ChatResponse.tool_calls`
- MiniMax provider:
  - serialize request tools
  - serialize tool-role request messages (`tool_call_id`)
  - extract tool calls from OpenAI-compatible response payload
- add cross-provider integration tests for tool serialization + extraction

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features`
- `pytest -x -q` is not available in this Rust repo environment (`pytest: command not found`), so Rust test suite was used as the gating check.

Closes #63
Closes #64
Closes #65
Closes #66
Closes #67
