### PR TITLE
fix(minimax): parse structured errors in stream failure path

### DIFF
--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -460,10 +460,25 @@ impl ProviderImpl for MinimaxProvider {
                 continue;
             }
 
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "minimax stream request failed".to_string());
+            let body_bytes = response.bytes().await.ok();
+
+            if let Some(payload) = body_bytes
+                .as_deref()
+                .and_then(|bytes| serde_json::from_slice::<Value>(bytes).ok())
+            {
+                if let Some((mapped_status, message)) = Self::minimax_payload_error(&payload) {
+                    return Err(map_http_error(mapped_status, message));
+                }
+
+                let message = extract_error_message(&payload, "minimax stream request failed");
+                return Err(map_http_error(status.as_u16(), message));
+            }
+
+            let message = body_bytes
+                .as_deref()
+                .map(|bytes| String::from_utf8_lossy(bytes).trim().to_string())
+                .filter(|message| !message.is_empty())
+                .unwrap_or_else(|| "minimax stream request failed".to_string());
             return Err(map_http_error(status.as_u16(), message));
         };
 

--- a/sdks/rust/tests/minimax_provider.rs
+++ b/sdks/rust/tests/minimax_provider.rs
@@ -344,6 +344,70 @@ async fn minimax_maps_payload_level_4xxx_to_invalid_request_error() {
 }
 
 #[tokio::test]
+async fn minimax_stream_parses_structured_error_message_payload() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer bad-key")
+        .with_status(401)
+        .with_body(
+            json!({
+                "error": {
+                    "message": "invalid api key from structured payload"
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("bad-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let result = provider.stream(request).await;
+    assert!(matches!(result, Err(MotosanError::Auth(_))));
+    let message = match result {
+        Err(MotosanError::Auth(message)) => message,
+        _ => panic!("unexpected stream result variant"),
+    };
+    assert!(message.contains("structured payload"));
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn minimax_stream_maps_base_resp_payload_errors() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer bad-key")
+        .with_status(400)
+        .with_body(
+            json!({
+                "base_resp": {
+                    "status_code": 2049,
+                    "status_msg": "invalid api key"
+                }
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("bad-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let result = provider.stream(request).await;
+    assert!(matches!(result, Err(MotosanError::Auth(_))));
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn minimax_chat_strips_think_blocks_by_default() {
     let mut server = mockito::Server::new_async().await;
     let mock = server


### PR DESCRIPTION
## Summary
- parse structured JSON payloads for MiniMax stream failures
- reuse shared `extract_error_message` and existing `base_resp` mapping
- fallback to non-empty raw body text when payload is not JSON
- add stream error tests for `error.message` and `base_resp`

Closes #51
