### PR TITLE
fix(rust): backport tool_calls response wiring to release/v0.1.0

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -6,7 +6,7 @@ use crate::providers::{
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason, ToolCall};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use reqwest::Client;
@@ -185,6 +185,30 @@ impl ProviderImpl for AnthropicProvider {
             })
             .unwrap_or_default();
 
+        let tool_calls = payload
+            .get("content")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"))
+                    .map(|item| ToolCall {
+                        id: item
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        name: item
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        input: item.get("input").cloned().unwrap_or(Value::Null),
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
         let model = payload
             .get("model")
             .and_then(Value::as_str)
@@ -212,6 +236,7 @@ impl ProviderImpl for AnthropicProvider {
 
         Ok(ChatResponseBuilder::new(DEFAULT_ANTHROPIC_MODEL)
             .content(content)
+            .tool_calls(tool_calls)
             .model(model)
             .usage(input_tokens, output_tokens)
             .stop_reason(stop_reason)

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -6,7 +6,7 @@ use crate::providers::{
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason, ToolCall};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use reqwest::Client;
@@ -172,6 +172,28 @@ impl ProviderImpl for MinimaxProvider {
             .unwrap_or_default()
             .to_string();
 
+        let tool_calls = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"))
+            .and_then(|message| message.get("tool_calls"))
+            .and_then(Value::as_array)
+            .map(|calls| {
+                calls
+                    .iter()
+                    .filter_map(|call| {
+                        let id = call.get("id")?.as_str()?.to_string();
+                        let function = call.get("function")?;
+                        let name = function.get("name")?.as_str()?.to_string();
+                        let arguments_str = function.get("arguments")?.as_str()?;
+                        let input = serde_json::from_str(arguments_str).unwrap_or(Value::Null);
+                        Some(ToolCall { id, name, input })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
         let stop_reason = match payload
             .get("choices")
             .and_then(Value::as_array)
@@ -203,6 +225,7 @@ impl ProviderImpl for MinimaxProvider {
 
         Ok(ChatResponseBuilder::new(DEFAULT_MINIMAX_MODEL)
             .content(content)
+            .tool_calls(tool_calls)
             .model(model)
             .usage(input_tokens, output_tokens)
             .stop_reason(stop_reason)

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -4,7 +4,7 @@ use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse};
 #[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
-use crate::types::{StopReason, Usage};
+use crate::types::{StopReason, ToolCall, Usage};
 use async_trait::async_trait;
 #[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 use reqwest::header::HeaderMap;
@@ -29,6 +29,7 @@ pub trait ProviderImpl: Send + Sync {
 #[cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 pub(crate) struct ChatResponseBuilder {
     content: String,
+    tool_calls: Vec<ToolCall>,
     model: String,
     usage: Usage,
     stop_reason: StopReason,
@@ -39,6 +40,7 @@ impl ChatResponseBuilder {
     pub(crate) fn new(default_model: impl Into<String>) -> Self {
         Self {
             content: String::new(),
+            tool_calls: Vec::new(),
             model: default_model.into(),
             usage: Usage {
                 input_tokens: 0,
@@ -58,6 +60,11 @@ impl ChatResponseBuilder {
         self
     }
 
+    pub(crate) fn tool_calls(mut self, tool_calls: Vec<ToolCall>) -> Self {
+        self.tool_calls = tool_calls;
+        self
+    }
+
     pub(crate) fn usage(mut self, input_tokens: u32, output_tokens: u32) -> Self {
         self.usage = Usage {
             input_tokens,
@@ -74,6 +81,7 @@ impl ChatResponseBuilder {
     pub(crate) fn build(self) -> ChatResponse {
         ChatResponse {
             content: self.content,
+            tool_calls: self.tool_calls,
             model: self.model,
             usage: self.usage,
             stop_reason: self.stop_reason,

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -6,7 +6,7 @@ use crate::providers::{
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Role, StopReason};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason, ToolCall};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use reqwest::Client;
@@ -172,6 +172,28 @@ impl ProviderImpl for OpenAIProvider {
             .unwrap_or_default()
             .to_string();
 
+        let tool_calls = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"))
+            .and_then(|message| message.get("tool_calls"))
+            .and_then(Value::as_array)
+            .map(|calls| {
+                calls
+                    .iter()
+                    .filter_map(|call| {
+                        let id = call.get("id")?.as_str()?.to_string();
+                        let function = call.get("function")?;
+                        let name = function.get("name")?.as_str()?.to_string();
+                        let arguments_str = function.get("arguments")?.as_str()?;
+                        let input = serde_json::from_str(arguments_str).unwrap_or(Value::Null);
+                        Some(ToolCall { id, name, input })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
         let stop_reason = match payload
             .get("choices")
             .and_then(Value::as_array)
@@ -203,6 +225,7 @@ impl ProviderImpl for OpenAIProvider {
 
         Ok(ChatResponseBuilder::new(DEFAULT_OPENAI_MODEL)
             .content(content)
+            .tool_calls(tool_calls)
             .model(model)
             .usage(input_tokens, output_tokens)
             .stop_reason(stop_reason)

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -130,9 +130,17 @@ impl ChatRequestBuilder {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatResponse {
     pub content: String,
+    pub tool_calls: Vec<ToolCall>,
     pub model: String,
     pub usage: Usage,
     pub stop_reason: StopReason,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub input: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/sdks/rust/tests/tool_use_integration.rs
+++ b/sdks/rust/tests/tool_use_integration.rs
@@ -1,0 +1,133 @@
+#![cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
+
+use motosan_ai::{ChatRequest, Message};
+use serde_json::json;
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_extracts_tool_use_from_response() {
+    use motosan_ai::providers::anthropic::AnthropicProvider;
+    use motosan_ai::providers::ProviderImpl;
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 11, "output_tokens": 7},
+                "content": [
+                    {"type": "text", "text": "calling tool"},
+                    {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Taipei"}}
+                ]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("weather?"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].id, "toolu_1");
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+    assert_eq!(response.tool_calls[0].input["city"], "Taipei");
+    mock.assert_async().await;
+}
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_extracts_tool_calls_from_response() {
+    use motosan_ai::providers::openai::OpenAIProvider;
+    use motosan_ai::providers::ProviderImpl;
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{
+                    "message": {
+                        "content": "",
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{\"city\":\"Taipei\"}"}
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 4}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("weather?"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].id, "call_1");
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+    assert_eq!(response.tool_calls[0].input["city"], "Taipei");
+    mock.assert_async().await;
+}
+
+#[cfg(feature = "minimax")]
+#[tokio::test]
+async fn minimax_extracts_tool_calls_from_response() {
+    use motosan_ai::providers::minimax::MinimaxProvider;
+    use motosan_ai::providers::ProviderImpl;
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/text/chatcompletion_v2")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-M2.5-highspeed",
+                "choices": [{
+                    "message": {
+                        "content": "",
+                        "tool_calls": [{
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{\"city\":\"Taipei\"}"}
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 4}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("weather?"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].id, "call_2");
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+    assert_eq!(response.tool_calls[0].input["city"], "Taipei");
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- backport tool_calls support into release/v0.1.0
- fix ChatResponseBuilder to initialize/populate tool_calls
- map tool_calls from Anthropic/OpenAI/MiniMax responses
- add integration tests for tool_calls extraction

This backports the P0/P1/P2 fixes for release branch readiness.