### PR TITLE
fix(rust): multi-turn assistant tool_calls across Anthropic/OpenAI/MiniMax

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -111,7 +111,23 @@ impl AnthropicRequestBuilder {
                 Role::System => extracted_systems.push(message.content.clone()),
                 Role::User => messages.push(json!({"role": "user", "content": message.content})),
                 Role::Assistant => {
-                    messages.push(json!({"role": "assistant", "content": message.content}))
+                    if message.tool_calls.is_empty() {
+                        messages.push(json!({"role": "assistant", "content": message.content}));
+                    } else {
+                        let mut blocks = Vec::new();
+                        if !message.content.is_empty() {
+                            blocks.push(json!({"type": "text", "text": message.content}));
+                        }
+                        for tool_call in &message.tool_calls {
+                            blocks.push(json!({
+                                "type": "tool_use",
+                                "id": tool_call.id,
+                                "name": tool_call.name,
+                                "input": tool_call.input,
+                            }));
+                        }
+                        messages.push(json!({"role": "assistant", "content": blocks}));
+                    }
                 }
                 Role::Tool => {
                     if let Some(tool_use_id) = &message.tool_call_id {

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -208,7 +208,7 @@ impl MinimaxRequestBuilder {
             }
         }
 
-        let mut messages: Vec<(String, String, Option<String>)> = Vec::new();
+        let mut messages: Vec<Value> = Vec::new();
         for message in &self.req.messages {
             match message.role {
                 Role::System => {
@@ -217,17 +217,41 @@ impl MinimaxRequestBuilder {
                         system_parts.push(trimmed.to_string());
                     }
                 }
-                Role::User => messages.push(("user".to_string(), message.content.clone(), None)),
+                Role::User => {
+                    messages.push(json!({"role": "user", "content": message.content}));
+                }
                 Role::Assistant => {
-                    messages.push(("assistant".to_string(), message.content.clone(), None))
+                    if message.tool_calls.is_empty() {
+                        messages.push(json!({"role": "assistant", "content": message.content}));
+                    } else {
+                        let tool_calls = message
+                            .tool_calls
+                            .iter()
+                            .map(|tool_call| {
+                                json!({
+                                    "id": tool_call.id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tool_call.name,
+                                        "arguments": serde_json::to_string(&tool_call.input).unwrap_or_default(),
+                                    }
+                                })
+                            })
+                            .collect::<Vec<_>>();
+                        messages.push(json!({
+                            "role": "assistant",
+                            "content": message.content,
+                            "tool_calls": tool_calls,
+                        }));
+                    }
                 }
                 Role::Tool => {
                     if let Some(tool_call_id) = &message.tool_call_id {
-                        messages.push((
-                            "tool".to_string(),
-                            message.content.clone(),
-                            Some(tool_call_id.clone()),
-                        ));
+                        messages.push(json!({
+                            "role": "tool",
+                            "content": message.content,
+                            "tool_call_id": tool_call_id,
+                        }));
                     }
                 }
             }
@@ -235,23 +259,19 @@ impl MinimaxRequestBuilder {
 
         if !system_parts.is_empty() {
             let merged_system = system_parts.join("\n\n");
-            if let Some((_, content, _)) = messages.iter_mut().find(|(role, _, _)| role == "user") {
-                *content = format!("{}\n\n{}", merged_system, content);
+            if let Some(first_user) = messages
+                .iter_mut()
+                .find(|message| message.get("role").and_then(Value::as_str) == Some("user"))
+            {
+                let content = first_user
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                first_user["content"] = json!(format!("{}\n\n{}", merged_system, content));
             } else {
-                messages.insert(0, ("user".to_string(), merged_system, None));
+                messages.insert(0, json!({"role": "user", "content": merged_system}));
             }
         }
-
-        let messages: Vec<Value> = messages
-            .into_iter()
-            .map(|(role, content, tool_call_id)| {
-                let mut message = json!({"role": role, "content": content});
-                if let Some(tool_call_id) = tool_call_id {
-                    message["tool_call_id"] = json!(tool_call_id);
-                }
-                message
-            })
-            .collect();
 
         let mut body = json!({
             "model": model,

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -171,7 +171,29 @@ impl OpenAIProvider {
                     }
                 }
                 Role::Assistant => {
-                    input.push(json!({"role": "assistant", "content": message.content}))
+                    if message.tool_calls.is_empty() {
+                        input.push(json!({"role": "assistant", "content": message.content}));
+                    } else {
+                        let tool_calls = message
+                            .tool_calls
+                            .iter()
+                            .map(|tool_call| {
+                                json!({
+                                    "id": tool_call.id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tool_call.name,
+                                        "arguments": serde_json::to_string(&tool_call.input).unwrap_or_default(),
+                                    }
+                                })
+                            })
+                            .collect::<Vec<_>>();
+                        input.push(json!({
+                            "role": "assistant",
+                            "content": message.content,
+                            "tool_calls": tool_calls,
+                        }));
+                    }
                 }
                 Role::User => input.push(json!({"role": "user", "content": message.content})),
                 Role::Tool => {
@@ -290,7 +312,29 @@ impl OpenAIRequestBuilder {
             match message.role {
                 Role::User => messages.push(json!({"role": "user", "content": message.content})),
                 Role::Assistant => {
-                    messages.push(json!({"role": "assistant", "content": message.content}))
+                    if message.tool_calls.is_empty() {
+                        messages.push(json!({"role": "assistant", "content": message.content}));
+                    } else {
+                        let tool_calls = message
+                            .tool_calls
+                            .iter()
+                            .map(|tool_call| {
+                                json!({
+                                    "id": tool_call.id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tool_call.name,
+                                        "arguments": serde_json::to_string(&tool_call.input).unwrap_or_default(),
+                                    }
+                                })
+                            })
+                            .collect::<Vec<_>>();
+                        messages.push(json!({
+                            "role": "assistant",
+                            "content": message.content,
+                            "tool_calls": tool_calls,
+                        }));
+                    }
                 }
                 Role::System => {
                     messages.push(json!({"role": "system", "content": message.content}))

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -15,6 +15,7 @@ pub struct Message {
     pub role: Role,
     pub content: String,
     pub tool_call_id: Option<String>,
+    pub tool_calls: Vec<ToolCall>,
 }
 
 impl Message {
@@ -23,6 +24,7 @@ impl Message {
             role: Role::User,
             content: content.into(),
             tool_call_id: None,
+            tool_calls: Vec::new(),
         }
     }
 
@@ -31,6 +33,19 @@ impl Message {
             role: Role::Assistant,
             content: content.into(),
             tool_call_id: None,
+            tool_calls: Vec::new(),
+        }
+    }
+
+    pub fn assistant_with_tool_calls(
+        content: impl Into<String>,
+        tool_calls: Vec<ToolCall>,
+    ) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: content.into(),
+            tool_call_id: None,
+            tool_calls,
         }
     }
 
@@ -39,14 +54,20 @@ impl Message {
             role: Role::System,
             content: content.into(),
             tool_call_id: None,
+            tool_calls: Vec::new(),
         }
     }
 
     pub fn tool(content: impl Into<String>, tool_call_id: impl Into<String>) -> Self {
+        Self::tool_result(tool_call_id, content)
+    }
+
+    pub fn tool_result(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
         Self {
             role: Role::Tool,
             content: content.into(),
             tool_call_id: Some(tool_call_id.into()),
+            tool_calls: Vec::new(),
         }
     }
 }
@@ -149,7 +170,7 @@ pub struct ChatResponse {
     pub stop_reason: StopReason,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ToolCall {
     pub id: String,
     pub name: String,

--- a/sdks/rust/tests/core_types.rs
+++ b/sdks/rust/tests/core_types.rs
@@ -1,4 +1,4 @@
-use motosan_ai::{ChatRequest, Message, Role, StopReason};
+use motosan_ai::{ChatRequest, Message, Role, StopReason, ToolCall};
 
 #[test]
 fn message_constructors_set_role_and_content() {
@@ -13,6 +13,30 @@ fn message_constructors_set_role_and_content() {
     assert!(matches!(tool.role, Role::Tool));
     assert_eq!(user.content, "hello");
     assert_eq!(tool.tool_call_id.as_deref(), Some("call_1"));
+    assert!(user.tool_calls.is_empty());
+    assert!(assistant.tool_calls.is_empty());
+    assert!(system.tool_calls.is_empty());
+    assert!(tool.tool_calls.is_empty());
+}
+
+#[test]
+fn assistant_with_tool_calls_constructor_sets_values() {
+    let tool_calls = vec![ToolCall {
+        id: "call_1".to_string(),
+        name: "get_weather".to_string(),
+        input: serde_json::json!({"city": "Taipei"}),
+    }];
+
+    let assistant = Message::assistant_with_tool_calls("Let me check", tool_calls.clone());
+    let tool_result = Message::tool_result("call_1", "25°C");
+
+    assert!(matches!(assistant.role, Role::Assistant));
+    assert_eq!(assistant.content, "Let me check");
+    assert_eq!(assistant.tool_calls, tool_calls);
+    assert!(assistant.tool_call_id.is_none());
+
+    assert!(matches!(tool_result.role, Role::Tool));
+    assert_eq!(tool_result.tool_call_id.as_deref(), Some("call_1"));
 }
 
 #[test]

--- a/sdks/rust/tests/tool_use_integration.rs
+++ b/sdks/rust/tests/tool_use_integration.rs
@@ -1,7 +1,7 @@
 #![cfg(any(feature = "anthropic", feature = "openai", feature = "minimax"))]
 
 use mockito::Matcher;
-use motosan_ai::{ChatRequest, Message, Tool};
+use motosan_ai::{ChatRequest, Message, StopReason, Tool};
 use serde_json::json;
 
 #[cfg(feature = "anthropic")]
@@ -159,4 +159,274 @@ async fn minimax_serializes_tools_and_extracts_tool_calls() {
     assert_eq!(response.tool_calls[0].name, "get_weather");
     assert_eq!(response.tool_calls[0].input["city"], "Taipei");
     mock.assert_async().await;
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_multi_turn_tool_use_roundtrip() {
+    use motosan_ai::providers::anthropic::AnthropicProvider;
+    use motosan_ai::providers::ProviderImpl;
+
+    let mut server = mockito::Server::new_async().await;
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+
+    let turn1_mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 11, "output_tokens": 7},
+                "content": [
+                    {"type": "text", "text": "Let me check"},
+                    {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Taipei"}}
+                ]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let resp1 = provider
+        .chat(
+            ChatRequest::builder()
+                .message(Message::user("what's the weather?"))
+                .tools(vec![Tool {
+                    name: "get_weather".to_string(),
+                    description: Some("Get weather by city".to_string()),
+                    input_schema: Some(
+                        json!({"type":"object","properties":{"city":{"type":"string"}}}),
+                    ),
+                }])
+                .build(),
+        )
+        .await
+        .expect("turn1 response");
+    assert!(matches!(resp1.stop_reason, StopReason::ToolUse));
+    turn1_mock.assert_async().await;
+
+    server.reset();
+    let turn2_mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_body(Matcher::Regex(r#"\"type\"\s*:\s*\"tool_use\""#.to_string()))
+        .match_body(Matcher::Regex(
+            r#"\"tool_use_id\"\s*:\s*\"toolu_1\""#.to_string(),
+        ))
+        .match_body(Matcher::Regex(
+            r#"\"type\"\s*:\s*\"tool_result\""#.to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 15, "output_tokens": 9},
+                "content": [{"type": "text", "text": "It is 25°C and cloudy."}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let turn2_messages = vec![
+        Message::user("what's the weather?"),
+        Message::assistant_with_tool_calls("Let me check", resp1.tool_calls.clone()),
+        Message::tool_result(resp1.tool_calls[0].id.clone(), "25°C, cloudy"),
+    ];
+    let resp2 = provider
+        .chat(ChatRequest::builder().messages(turn2_messages).build())
+        .await
+        .expect("turn2 response");
+    assert!(matches!(resp2.stop_reason, StopReason::EndTurn));
+    assert!(resp2.content.contains("25"));
+    turn2_mock.assert_async().await;
+}
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_multi_turn_tool_use_roundtrip() {
+    use motosan_ai::providers::openai::OpenAIProvider;
+    use motosan_ai::providers::ProviderImpl;
+
+    let mut server = mockito::Server::new_async().await;
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+
+    let turn1_mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{
+                    "message": {
+                        "content": "",
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{\"city\":\"Taipei\"}"}
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 4}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let resp1 = provider
+        .chat(
+            ChatRequest::builder()
+                .message(Message::user("what's the weather?"))
+                .tools(vec![Tool {
+                    name: "get_weather".to_string(),
+                    description: Some("Get weather by city".to_string()),
+                    input_schema: Some(
+                        json!({"type":"object","properties":{"city":{"type":"string"}}}),
+                    ),
+                }])
+                .build(),
+        )
+        .await
+        .expect("turn1 response");
+    assert!(matches!(resp1.stop_reason, StopReason::ToolUse));
+    turn1_mock.assert_async().await;
+
+    server.reset();
+    let turn2_mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(r#"\"tool_calls\"\s*:\s*\["#.to_string()))
+        .match_body(Matcher::Regex(
+            r#"\"arguments\"\s*:\s*\"\{\\\"city\\\":\\\"Taipei\\\"\}\""#.to_string(),
+        ))
+        .match_body(Matcher::Regex(
+            r#"\"tool_call_id\"\s*:\s*\"call_1\""#.to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{
+                    "message": {"content": "It is 25°C and cloudy."},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 15, "completion_tokens": 9}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let turn2_messages = vec![
+        Message::user("what's the weather?"),
+        Message::assistant_with_tool_calls("Let me check", resp1.tool_calls.clone()),
+        Message::tool_result(resp1.tool_calls[0].id.clone(), "25°C, cloudy"),
+    ];
+    let resp2 = provider
+        .chat(ChatRequest::builder().messages(turn2_messages).build())
+        .await
+        .expect("turn2 response");
+    assert!(matches!(resp2.stop_reason, StopReason::Stop));
+    assert!(resp2.content.contains("25"));
+    turn2_mock.assert_async().await;
+}
+
+#[cfg(feature = "minimax")]
+#[tokio::test]
+async fn minimax_multi_turn_tool_use_roundtrip() {
+    use motosan_ai::providers::minimax::MinimaxProvider;
+    use motosan_ai::providers::ProviderImpl;
+
+    let mut server = mockito::Server::new_async().await;
+    let provider = MinimaxProvider::new("test-key", None, Some(server.url()));
+
+    let turn1_mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-M2.5-highspeed",
+                "choices": [{
+                    "message": {
+                        "content": "",
+                        "tool_calls": [{
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{\"city\":\"Taipei\"}"}
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 4},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let resp1 = provider
+        .chat(
+            ChatRequest::builder()
+                .message(Message::user("what's the weather?"))
+                .tools(vec![Tool {
+                    name: "get_weather".to_string(),
+                    description: Some("Get weather by city".to_string()),
+                    input_schema: Some(
+                        json!({"type":"object","properties":{"city":{"type":"string"}}}),
+                    ),
+                }])
+                .build(),
+        )
+        .await
+        .expect("turn1 response");
+    assert!(matches!(resp1.stop_reason, StopReason::ToolUse));
+    turn1_mock.assert_async().await;
+
+    server.reset();
+    let turn2_mock = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_body(Matcher::Regex(r#"\"tool_calls\"\s*:\s*\["#.to_string()))
+        .match_body(Matcher::Regex(
+            r#"\"arguments\"\s*:\s*\"\{\\\"city\\\":\\\"Taipei\\\"\}\""#.to_string(),
+        ))
+        .match_body(Matcher::Regex(
+            r#"\"tool_call_id\"\s*:\s*\"call_2\""#.to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "MiniMax-M2.5-highspeed",
+                "choices": [{
+                    "message": {"content": "It is 25°C and cloudy."},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 15, "completion_tokens": 9},
+                "base_resp": {"status_code": 0, "status_msg": ""}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let turn2_messages = vec![
+        Message::user("what's the weather?"),
+        Message::assistant_with_tool_calls("Let me check", resp1.tool_calls.clone()),
+        Message::tool_result(resp1.tool_calls[0].id.clone(), "25°C, cloudy"),
+    ];
+    let resp2 = provider
+        .chat(ChatRequest::builder().messages(turn2_messages).build())
+        .await
+        .expect("turn2 response");
+    assert!(matches!(resp2.stop_reason, StopReason::Stop));
+    assert!(resp2.content.contains("25"));
+    turn2_mock.assert_async().await;
 }


### PR DESCRIPTION
## Summary
- add `Message.tool_calls` and `Message::assistant_with_tool_calls()` for multi-turn tool use
- add `Message::tool_result()` constructor (keep `Message::tool()` as alias)
- serialize assistant tool calls correctly for:
  - Anthropic (`tool_use` content blocks)
  - OpenAI (`tool_calls` with JSON-string arguments)
  - MiniMax (same `tool_calls` format as OpenAI)
- add multi-turn integration tests for all three providers

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features -q

Closes #72
Closes #73
Closes #74
Closes #75
