### PR TITLE
fix(python): close #84 #85 #86 (README, metadata, lint/publish CI)

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -25,5 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
       - name: Sync deps
         run: uv sync --extra full --extra dev
+      - name: Lint
+        run: uv run ruff check motosan_ai/
       - name: Test
         run: uv run pytest -q

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,22 @@
+name: publish-python
+
+on:
+  push:
+    tags: ["python-v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/python
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv build --out-dir dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdks/python/dist/

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,3 +1,152 @@
 # motosan-ai (Python SDK)
 
-Python SDK for Anthropic, OpenAI, and MiniMax providers.
+Multi-provider Python SDK for Anthropic, OpenAI, and MiniMax.
+
+## Installation
+
+```bash
+pip install motosan-ai
+pip install "motosan-ai[anthropic]"
+pip install "motosan-ai[openai]"
+pip install "motosan-ai[minimax]"
+pip install "motosan-ai[full]"
+```
+
+## Quick Start
+
+```python
+import asyncio
+
+from motosan_ai import Client
+
+
+async def main() -> None:
+    client = Client.anthropic(api_key="sk-ant-...", model="claude-3-5-sonnet-latest")
+    response = await client.chat([
+        {"role": "user", "content": "Hello"},
+    ])
+    print(response.content)
+
+
+asyncio.run(main())
+```
+
+## Tool Use (Multi-turn)
+
+```python
+import asyncio
+
+from motosan_ai import Client, Message, Tool
+
+
+def get_weather(city: str) -> str:
+    return f"Sunny in {city}"
+
+
+async def main() -> None:
+    client = Client.anthropic(api_key="sk-ant-...")
+
+    tools = [
+        Tool(
+            name="get_weather",
+            description="Get current weather",
+            input_schema={
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        )
+    ]
+
+    messages = [Message.user("What's the weather in Tokyo?")]
+    response = await client.chat(messages, tools=tools)
+
+    if response.tool_calls:
+        tc = response.tool_calls[0]
+        result = get_weather(tc.input["city"])
+
+        messages += [
+            Message.assistant_with_tool_calls("", response.tool_calls),
+            Message.tool_result(tc.id, result),
+        ]
+        final = await client.chat(messages, tools=tools)
+        print(final.content)
+
+
+asyncio.run(main())
+```
+
+## Streaming
+
+```python
+import asyncio
+
+from motosan_ai import Client, Message
+
+
+async def main() -> None:
+    client = Client.openai(api_key="sk-...", model="gpt-4.1-mini")
+
+    async for event in client.stream([Message.user("Write a haiku about rain")]):
+        if event.content:
+            print(event.content, end="")
+        if event.done:
+            break
+
+
+asyncio.run(main())
+```
+
+## Sync Wrapper
+
+```python
+from motosan_ai import Client, Message
+
+client = Client.minimax(api_key="...")
+response = client.chat_sync([Message.user("Hello from sync")])
+print(response.content)
+```
+
+## Providers
+
+### Anthropic
+
+```python
+from motosan_ai import Client
+
+client = Client.anthropic(api_key="sk-ant-...", model="claude-3-5-sonnet-latest")
+```
+
+### OpenAI
+
+```python
+from motosan_ai import Client
+
+client = Client.openai(api_key="sk-...", model="gpt-4.1-mini")
+```
+
+### MiniMax
+
+```python
+from motosan_ai import Client
+
+client = Client.minimax(api_key="...", model="MiniMax-M1")
+```
+
+## Requirements
+
+- Python 3.11+
+- One provider API key:
+  - `ANTHROPIC_API_KEY`
+  - `OPENAI_API_KEY`
+  - `MINIMAX_API_KEY`
+
+## Development
+
+```bash
+uv sync --extra full --extra dev
+uv run ruff check motosan_ai/
+uv run pytest -q
+uv build --out-dir dist
+uv publish --dry-run dist/*
+```

--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -7,7 +7,7 @@ from typing import Any, AsyncIterator, Iterable
 
 from motosan_ai.error import ConfigError
 from motosan_ai.providers import AnthropicProvider, MinimaxProvider, OpenAIProvider
-from motosan_ai.types import ChatRequest, ChatResponse, Message, StreamEvent
+from motosan_ai.types import ChatRequest, ChatResponse, Message, StreamEvent, Tool
 
 
 class Provider(StrEnum):
@@ -55,6 +55,23 @@ class Client:
         else:
             self._provider = MinimaxProvider(api_key=self.api_key, model=model, base_url=base_url)
 
+    @classmethod
+    def anthropic(cls, api_key: str | None = None, model: str | None = None) -> "Client":
+        return cls(provider=Provider.anthropic, api_key=api_key, model=model)
+
+    @classmethod
+    def openai(cls, api_key: str | None = None, model: str | None = None) -> "Client":
+        return cls(provider=Provider.openai, api_key=api_key, model=model)
+
+    @classmethod
+    def minimax(
+        cls,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+    ) -> "Client":
+        return cls(provider=Provider.minimax, api_key=api_key, model=model, base_url=base_url)
+
     @staticmethod
     def _load_api_key(provider: Provider) -> str | None:
         env_map = {
@@ -68,6 +85,7 @@ class Client:
         self,
         messages: Iterable[Message | dict[str, Any]],
         *,
+        tools: list[Tool] | None = None,
         system: str | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
@@ -77,6 +95,7 @@ class Client:
         return ChatRequest(
             messages=normalized,
             model=self.model,
+            tools=tools,
             system=system,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -87,6 +106,7 @@ class Client:
         self,
         messages: Iterable[Message | dict[str, Any]],
         *,
+        tools: list[Tool] | None = None,
         system: str | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
@@ -94,6 +114,7 @@ class Client:
     ) -> ChatResponse:
         request = self._build_request(
             messages,
+            tools=tools,
             system=system,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -105,6 +126,7 @@ class Client:
         self,
         messages: Iterable[Message | dict[str, Any]],
         *,
+        tools: list[Tool] | None = None,
         system: str | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
@@ -112,6 +134,7 @@ class Client:
     ) -> AsyncIterator[StreamEvent]:
         request = self._build_request(
             messages,
+            tools=tools,
             system=system,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -124,6 +147,7 @@ class Client:
         self,
         messages: Iterable[Message | dict[str, Any]],
         *,
+        tools: list[Tool] | None = None,
         system: str | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
@@ -132,6 +156,7 @@ class Client:
         return asyncio.run(
             self.chat(
                 messages,
+                tools=tools,
                 system=system,
                 temperature=temperature,
                 max_tokens=max_tokens,

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,12 +1,27 @@
 [project]
 name = "motosan-ai"
 version = "0.2.0"
-description = "Python SDK for Motosan AI providers"
+description = "Python SDK for Anthropic, OpenAI, and MiniMax AI providers"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "MIT"
+authors = [{ name = "motosan-dev" }]
+keywords = ["ai", "llm", "anthropic", "openai", "minimax", "tool-use"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+]
 dependencies = [
   "httpx>=0.27",
 ]
+
+[project.urls]
+Homepage = "https://github.com/motosan-dev/motosan-ai"
+Repository = "https://github.com/motosan-dev/motosan-ai"
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.49"]
@@ -18,6 +33,7 @@ dev = [
   "pytest>=8.0",
   "pytest-asyncio>=0.23",
   "respx>=0.21",
+  "ruff>=0.9",
 ]
 
 [tool.pytest.ini_options]

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from motosan_ai import ChatResponse, Client, Message, Provider, StopReason, Usage
+from motosan_ai import ChatResponse, Client, Message, Provider, StopReason, Tool, Usage
 
 
 class FakeProvider:
@@ -31,6 +31,25 @@ async def test_client_accepts_dict_messages(monkeypatch):
     assert fake.last_request.messages[0] == Message.user("hello")
 
 
+@pytest.mark.asyncio
+async def test_client_passes_tools(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-anthropic")
+    client = Client(Provider.anthropic)
+    fake = FakeProvider()
+    client._provider = fake
+
+    tools = [
+        Tool(
+            name="get_weather",
+            description="Get current weather",
+            input_schema={"type": "object", "properties": {"city": {"type": "string"}}},
+        )
+    ]
+
+    await client.chat([Message.user("weather in Tokyo")], tools=tools)
+    assert fake.last_request.tools == tools
+
+
 def test_client_env_fallback(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "env-anthropic")
     client = Client(Provider.anthropic)
@@ -44,6 +63,16 @@ def test_chat_sync(monkeypatch):
     client._provider = fake
     response = client.chat_sync([Message.user("hi")])
     assert response.content == "ok"
+
+
+def test_provider_factory_methods(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "a")
+    monkeypatch.setenv("OPENAI_API_KEY", "o")
+    monkeypatch.setenv("MINIMAX_API_KEY", "m")
+
+    assert Client.anthropic().provider == Provider.anthropic
+    assert Client.openai().provider == Provider.openai
+    assert Client.minimax().provider == Provider.minimax
 
 
 def test_missing_key_raises(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -240,6 +240,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "respx" },
+    { name = "ruff" },
 ]
 full = [
     { name = "anthropic" },
@@ -263,6 +264,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
 ]
 provides-extras = ["anthropic", "openai", "minimax", "full", "dev"]
 
@@ -463,6 +465,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9b/840e0039e65fcf12758adf684d2289024d6140cde9268cc59887dc55189c/ruff-0.15.5.tar.gz", hash = "sha256:7c3601d3b6d76dce18c5c824fc8d06f4eef33d6df0c21ec7799510cde0f159a2", size = 4574214, upload-time = "2026-03-05T20:06:34.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/20/5369c3ce21588c708bcbe517a8fbe1a8dfdb5dfd5137e14790b1da71612c/ruff-0.15.5-py3-none-linux_armv6l.whl", hash = "sha256:4ae44c42281f42e3b06b988e442d344a5b9b72450ff3c892e30d11b29a96a57c", size = 10478185, upload-time = "2026-03-05T20:06:29.093Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ed/e81dd668547da281e5dce710cf0bc60193f8d3d43833e8241d006720e42b/ruff-0.15.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6edd3792d408ebcf61adabc01822da687579a1a023f297618ac27a5b51ef0080", size = 10859201, upload-time = "2026-03-05T20:06:32.632Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:89f463f7c8205a9f8dea9d658d59eff49db05f88f89cc3047fb1a02d9f344010", size = 10184752, upload-time = "2026-03-05T20:06:40.312Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0e/ba49e2c3fa0395b3152bad634c7432f7edfc509c133b8f4529053ff024fb/ruff-0.15.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba786a8295c6574c1116704cf0b9e6563de3432ac888d8f83685654fe528fd65", size = 10534857, upload-time = "2026-03-05T20:06:19.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/71/39234440f27a226475a0659561adb0d784b4d247dfe7f43ffc12dd02e288/ruff-0.15.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd4b801e57955fe9f02b31d20375ab3a5c4415f2e5105b79fb94cf2642c91440", size = 10309120, upload-time = "2026-03-05T20:06:00.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/4140aa86a93df032156982b726f4952aaec4a883bb98cb6ef73c347da253/ruff-0.15.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:391f7c73388f3d8c11b794dbbc2959a5b5afe66642c142a6effa90b45f6f5204", size = 11047428, upload-time = "2026-03-05T20:05:51.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f7/4953e7e3287676f78fbe85e3a0ca414c5ca81237b7575bdadc00229ac240/ruff-0.15.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8dc18f30302e379fe1e998548b0f5e9f4dff907f52f73ad6da419ea9c19d66c8", size = 11914251, upload-time = "2026-03-05T20:06:22.887Z" },
+    { url = "https://files.pythonhosted.org/packages/77/46/0f7c865c10cf896ccf5a939c3e84e1cfaeed608ff5249584799a74d33835/ruff-0.15.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc6e7f90087e2d27f98dc34ed1b3ab7c8f0d273cc5431415454e22c0bd2a681", size = 11333801, upload-time = "2026-03-05T20:05:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/01/a10fe54b653061585e655f5286c2662ebddb68831ed3eaebfb0eb08c0a16/ruff-0.15.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1cb7169f53c1ddb06e71a9aebd7e98fc0fea936b39afb36d8e86d36ecc2636a", size = 11206821, upload-time = "2026-03-05T20:06:03.441Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0d/2132ceaf20c5e8699aa83da2706ecb5c5dcdf78b453f77edca7fb70f8a93/ruff-0.15.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9b037924500a31ee17389b5c8c4d88874cc6ea8e42f12e9c61a3d754ff72f1ca", size = 11133326, upload-time = "2026-03-05T20:06:25.655Z" },
+    { url = "https://files.pythonhosted.org/packages/72/cb/2e5259a7eb2a0f87c08c0fe5bf5825a1e4b90883a52685524596bfc93072/ruff-0.15.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:65bb414e5b4eadd95a8c1e4804f6772bbe8995889f203a01f77ddf2d790929dd", size = 10510820, upload-time = "2026-03-05T20:06:37.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/20/b67ce78f9e6c59ffbdb5b4503d0090e749b5f2d31b599b554698a80d861c/ruff-0.15.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d20aa469ae3b57033519c559e9bc9cd9e782842e39be05b50e852c7c981fa01d", size = 10302395, upload-time = "2026-03-05T20:05:54.504Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e5/719f1acccd31b720d477751558ed74e9c88134adcc377e5e886af89d3072/ruff-0.15.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:15388dd28c9161cdb8eda68993533acc870aa4e646a0a277aa166de9ad5a8752", size = 10754069, upload-time = "2026-03-05T20:06:06.422Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/d1db14469e32d98f3ca27079dbd30b7b44dbb5317d06ab36718dee3baf03/ruff-0.15.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b30da330cbd03bed0c21420b6b953158f60c74c54c5f4c1dabbdf3a57bf355d2", size = 11304315, upload-time = "2026-03-05T20:06:10.867Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3a/950367aee7c69027f4f422059227b290ed780366b6aecee5de5039d50fa8/ruff-0.15.5-py3-none-win32.whl", hash = "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74", size = 10551676, upload-time = "2026-03-05T20:06:13.705Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/00/bf077a505b4e649bdd3c47ff8ec967735ce2544c8e4a43aba42ee9bf935d/ruff-0.15.5-py3-none-win_amd64.whl", hash = "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe", size = 11678972, upload-time = "2026-03-05T20:06:45.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/4e/cd76eca6db6115604b7626668e891c9dd03330384082e33662fb0f113614/ruff-0.15.5-py3-none-win_arm64.whl", hash = "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b", size = 10965572, upload-time = "2026-03-05T20:06:16.984Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- expand `sdks/python/README.md` for a complete PyPI-friendly package page
- add Python package metadata in `sdks/python/pyproject.toml` (license, authors, keywords, classifiers, urls)
- add `ruff` to Python dev dependencies and run lint in `.github/workflows/ci-python.yml`
- add `.github/workflows/publish-python.yml` for tag-based trusted publishing (`python-v*`)
- align README examples with SDK API by adding provider factory methods and `tools` support on `Client`

## Verification
- `uv run ruff check motosan_ai/`
- `uv run pytest -x -q`
- `uv build --out-dir dist --clear`
- `uv publish --dry-run dist/*`

Closes #84
Closes #85
Closes #86
