### PR TITLE
fix(anthropic): add default max_tokens to prevent 400

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1,3 +1,5 @@
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+
 use crate::error::MotosanError;
 use crate::models::DEFAULT_ANTHROPIC_MODEL;
 use crate::providers::{
@@ -166,9 +168,8 @@ impl AnthropicRequestBuilder {
         if let Some(temperature) = self.req.temperature {
             body["temperature"] = json!(temperature);
         }
-        if let Some(max_tokens) = self.req.max_tokens {
-            body["max_tokens"] = json!(max_tokens);
-        }
+        let max_tokens = self.req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
+        body["max_tokens"] = json!(max_tokens);
         if let Some(tools) = self.req.tools {
             let mapped_tools: Vec<Value> = tools
                 .into_iter()

--- a/sdks/rust/tests/anthropic_chat.rs
+++ b/sdks/rust/tests/anthropic_chat.rs
@@ -154,3 +154,62 @@ async fn anthropic_setup_token_401_includes_actionable_hint() {
     assert!(format!("{err}").contains("oauth-2025-04-20"));
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn chat_without_max_tokens_uses_default() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_body(Matcher::Regex(r#""max_tokens"\s*:\s*4096"#.to_string()))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": DEFAULT_ANTHROPIC_MODEL,
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "ok");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn chat_with_explicit_max_tokens_overrides_default() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_body(Matcher::Regex(r#""max_tokens"\s*:\s*2000"#.to_string()))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": DEFAULT_ANTHROPIC_MODEL,
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .max_tokens(2000)
+        .build();
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "ok");
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- Adds `DEFAULT_MAX_TOKENS = 4096` constant in `AnthropicRequestBuilder`
- Always sets `max_tokens` in request body using `unwrap_or(4096)` when not explicitly provided
- Prevents Anthropic API HTTP 400 errors when `max_tokens` is omitted
- Provider-specific fix: only affects Anthropic, not OpenAI/Minimax

Closes #89

## Test plan
- [x] `cargo test --features full` passes
- [x] New test `chat_without_max_tokens_uses_default` verifies default 4096
- [x] New test `chat_with_explicit_max_tokens_overrides_default` verifies explicit value wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)