### PR TITLE
feat(rust): Provider::Ollama via OpenAI compat endpoint

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -17,7 +17,8 @@ default = []
 anthropic = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream", "dep:tokio"]
 openai = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream", "dep:tokio"]
 minimax = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream", "dep:tokio"]
-full = ["anthropic", "openai", "minimax"]
+ollama = ["openai"]
+full = ["anthropic", "openai", "minimax", "ollama"]
 
 [dependencies]
 async-trait = "0.1"

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -237,9 +237,13 @@ impl Client {
             .clone()
             .unwrap_or_else(|| crate::models::DEFAULT_OLLAMA_MODEL.to_string());
 
-        OpenAIProvider::new("".to_string(), Some(model), Some(self.ollama_base_url.clone()))
-            .with_auth_style(OpenAIAuthStyle::Bearer)
-            .with_retry_policy(self.retry_policy.clone())
+        OpenAIProvider::new(
+            "".to_string(),
+            Some(model),
+            Some(self.ollama_base_url.clone()),
+        )
+        .with_auth_style(OpenAIAuthStyle::Bearer)
+        .with_retry_policy(self.retry_policy.clone())
     }
 }
 

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -12,6 +12,7 @@ pub struct Client {
     openai_auth_header: Option<String>,
     openai_responses_fallback: bool,
     minimax_expose_reasoning: bool,
+    ollama_base_url: String,
     retry_policy: RetryPolicy,
 }
 
@@ -112,6 +113,18 @@ impl Client {
                     return Err(Self::feature_not_enabled("minimax"));
                 }
             }
+            Provider::Ollama => {
+                #[cfg(feature = "ollama")]
+                {
+                    use crate::providers::ProviderImpl;
+                    return self.build_ollama_provider().chat(request).await;
+                }
+                #[cfg(not(feature = "ollama"))]
+                {
+                    let _ = request;
+                    return Err(Self::feature_not_enabled("ollama"));
+                }
+            }
         }
     }
 
@@ -153,13 +166,26 @@ impl Client {
                     return Err(Self::feature_not_enabled("minimax"));
                 }
             }
+            Provider::Ollama => {
+                #[cfg(feature = "ollama")]
+                {
+                    use crate::providers::ProviderImpl;
+                    return self.build_ollama_provider().stream(request).await;
+                }
+                #[cfg(not(feature = "ollama"))]
+                {
+                    let _ = request;
+                    return Err(Self::feature_not_enabled("ollama"));
+                }
+            }
         }
     }
 
     #[cfg(any(
         not(feature = "anthropic"),
         not(feature = "openai"),
-        not(feature = "minimax")
+        not(feature = "minimax"),
+        not(feature = "ollama")
     ))]
     fn feature_not_enabled(provider: &str) -> MotosanError {
         MotosanError::Config(format!("{provider} feature is not enabled"))
@@ -201,6 +227,20 @@ impl Client {
         .with_expose_reasoning(self.minimax_expose_reasoning)
         .with_retry_policy(self.retry_policy.clone())
     }
+
+    #[cfg(feature = "ollama")]
+    fn build_ollama_provider(&self) -> crate::providers::openai::OpenAIProvider {
+        use crate::providers::openai::{OpenAIAuthStyle, OpenAIProvider};
+
+        let model = self
+            .model
+            .clone()
+            .unwrap_or_else(|| crate::models::DEFAULT_OLLAMA_MODEL.to_string());
+
+        OpenAIProvider::new("".to_string(), Some(model), Some(self.ollama_base_url.clone()))
+            .with_auth_style(OpenAIAuthStyle::Bearer)
+            .with_retry_policy(self.retry_policy.clone())
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -211,6 +251,7 @@ pub struct ClientBuilder {
     openai_auth_header: Option<String>,
     openai_responses_fallback: Option<bool>,
     minimax_expose_reasoning: Option<bool>,
+    ollama_base_url: Option<String>,
     retry_policy: Option<RetryPolicy>,
 }
 
@@ -260,6 +301,11 @@ impl ClientBuilder {
         self
     }
 
+    pub fn ollama_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.ollama_base_url = Some(base_url.into());
+        self
+    }
+
     pub fn build(self) -> Result<Client, MotosanError> {
         let provider = self
             .provider
@@ -275,6 +321,9 @@ impl ClientBuilder {
             openai_auth_header: self.openai_auth_header,
             openai_responses_fallback: self.openai_responses_fallback.unwrap_or(false),
             minimax_expose_reasoning: self.minimax_expose_reasoning.unwrap_or(false),
+            ollama_base_url: self
+                .ollama_base_url
+                .unwrap_or_else(|| "http://localhost:11434".to_string()),
             retry_policy: self.retry_policy.unwrap_or_default(),
         })
     }

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -9,8 +9,8 @@ pub mod types;
 pub use client::{Client, ClientBuilder};
 pub use error::MotosanError;
 pub use models::{
-    ANTHROPIC_MODELS, DEFAULT_ANTHROPIC_MODEL, DEFAULT_MINIMAX_MODEL, DEFAULT_OPENAI_MODEL,
-    MINIMAX_MODELS, OPENAI_MODELS,
+    ANTHROPIC_MODELS, DEFAULT_ANTHROPIC_MODEL, DEFAULT_MINIMAX_MODEL, DEFAULT_OLLAMA_MODEL,
+    DEFAULT_OPENAI_MODEL, MINIMAX_MODELS, OPENAI_MODELS,
 };
 pub use providers::Provider;
 pub use retry::RetryPolicy;

--- a/sdks/rust/src/models.rs
+++ b/sdks/rust/src/models.rs
@@ -1,6 +1,7 @@
 pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-6";
 pub const DEFAULT_OPENAI_MODEL: &str = "gpt-5.3-codex";
 pub const DEFAULT_MINIMAX_MODEL: &str = "MiniMax-M2.5-highspeed";
+pub const DEFAULT_OLLAMA_MODEL: &str = "llama3.2";
 
 pub const ANTHROPIC_MODELS: &[&str] = &[
     "claude-opus-4-6",

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -18,6 +18,7 @@ pub enum Provider {
     Anthropic,
     OpenAI,
     Minimax,
+    Ollama,
 }
 
 #[async_trait]

--- a/sdks/rust/tests/ollama_integration.rs
+++ b/sdks/rust/tests/ollama_integration.rs
@@ -1,0 +1,28 @@
+#![cfg(feature = "ollama")]
+
+use motosan_ai::{Client, Message, Provider};
+
+#[tokio::test]
+async fn ollama_integration_chat() {
+    let host = match std::env::var("OLLAMA_HOST") {
+        Ok(h) => h,
+        Err(_) => {
+            eprintln!("OLLAMA_HOST not set, skipping integration test");
+            return;
+        }
+    };
+
+    let client = Client::builder()
+        .provider(Provider::Ollama)
+        .api_key("")
+        .ollama_base_url(host)
+        .build()
+        .expect("client build");
+
+    let response = client
+        .chat(vec![Message::user("Say hello in one word.")])
+        .await
+        .expect("ollama chat");
+
+    assert!(!response.content.is_empty());
+}

--- a/sdks/rust/tests/ollama_provider.rs
+++ b/sdks/rust/tests/ollama_provider.rs
@@ -1,0 +1,182 @@
+#![cfg(feature = "ollama")]
+
+use mockito::Matcher;
+use motosan_ai::providers::openai::{OpenAIAuthStyle, OpenAIProvider};
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, Message, StopReason, Tool, DEFAULT_OLLAMA_MODEL};
+use serde_json::json;
+use tokio_stream::StreamExt;
+
+fn build_ollama_provider(base_url: String) -> OpenAIProvider {
+    OpenAIProvider::new("", Some(DEFAULT_OLLAMA_MODEL.to_string()), Some(base_url))
+        .with_auth_style(OpenAIAuthStyle::Bearer)
+}
+
+#[tokio::test]
+async fn ollama_chat_maps_response() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "model": "llama3.2",
+                "choices": [{"message": {"content": "hello from ollama"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = build_ollama_provider(server.url());
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "hello from ollama");
+    assert_eq!(response.model, "llama3.2");
+    assert_eq!(response.usage.input_tokens, 10);
+    assert_eq!(response.usage.output_tokens, 5);
+    assert!(matches!(response.stop_reason, StopReason::Stop));
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn ollama_stream_emits_deltas_and_done() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"hel\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = build_ollama_provider(server.url());
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut events = Vec::new();
+
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].content, "hel");
+    assert_eq!(events[1].content, "lo");
+    assert!(events[2].done);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn ollama_chat_with_tool_calls() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "model": "llama3.2",
+                "choices": [{
+                    "message": {
+                        "content": "",
+                        "tool_calls": [{
+                            "id": "call_ollama_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{\"city\":\"Taipei\"}"}
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 4}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = build_ollama_provider(server.url());
+    let request = ChatRequest::builder()
+        .message(Message::user("weather?"))
+        .tools(vec![Tool {
+            name: "get_weather".to_string(),
+            description: Some("Get weather by city".to_string()),
+            input_schema: Some(json!({"type":"object","properties":{"city":{"type":"string"}}})),
+        }])
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].id, "call_ollama_1");
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+    assert_eq!(response.tool_calls[0].input["city"], "Taipei");
+    assert!(matches!(response.stop_reason, StopReason::ToolUse));
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn ollama_uses_default_model() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", Matcher::Any)
+        .match_body(Matcher::Regex(format!(
+            r#"\"model\"\s*:\s*\"{}\""#,
+            DEFAULT_OLLAMA_MODEL
+        )))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "model": DEFAULT_OLLAMA_MODEL,
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = build_ollama_provider(server.url());
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.model, DEFAULT_OLLAMA_MODEL);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn ollama_client_builder_sets_base_url() {
+    use motosan_ai::{Client, Provider};
+
+    let client = Client::builder()
+        .provider(Provider::Ollama)
+        .api_key("")
+        .ollama_base_url("http://my-ollama:11434")
+        .build()
+        .expect("client build");
+
+    assert!(matches!(client.provider(), Provider::Ollama));
+}


### PR DESCRIPTION
## Summary
- Adds `Provider::Ollama` to Rust SDK, reusing `OpenAIProvider` with custom `base_url` (`http://localhost:11434`)
- Feature-gated: `ollama = ["openai"]`, included in `full`
- Zero new provider logic — Bearer auth, empty API key, default model `llama3.2`

## Changes
- `Cargo.toml`: new `ollama` feature
- `providers/mod.rs`: `Ollama` variant
- `models.rs`: `DEFAULT_OLLAMA_MODEL`
- `client.rs`: `ollama_base_url` field/builder, dispatch, `build_ollama_provider()`
- Tests: 5 unit tests (mockito) + 1 integration test (gated on `OLLAMA_HOST`)

## Test plan
- [x] `cargo test --features ollama` — all pass
- [x] `cargo test --features full` — no regressions
- [ ] Manual: run against local Ollama instance

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)