### PR TITLE
feat(python): native OllamaProvider — NDJSON + think + keep_alive

### DIFF
--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -41,6 +41,11 @@ class Client:
         api_key: str | None = None,
         model: str | None = None,
         base_url: str | None = None,
+        *,
+        ollama_native: bool = False,
+        ollama_think: bool = False,
+        ollama_keep_alive: str | None = None,
+        ollama_num_ctx: int | None = None,
     ) -> None:
         provider_value = Provider(provider)
         self.provider = provider_value
@@ -48,11 +53,22 @@ class Client:
 
         if provider_value == Provider.ollama:
             self.api_key = api_key or ""
-            self._provider = OpenAIProvider(
-                api_key=self.api_key,
-                model=model or "llama3.2",
-                base_url=base_url or "http://localhost:11434/v1",
-            )
+            if ollama_native:
+                from motosan_ai.providers.ollama import OllamaProvider as NativeOllamaProvider
+
+                self._provider = NativeOllamaProvider(
+                    model=model or "llama3.2",
+                    base_url=base_url or "http://localhost:11434",
+                    think=ollama_think,
+                    keep_alive=ollama_keep_alive,
+                    num_ctx=ollama_num_ctx,
+                )
+            else:
+                self._provider = OpenAIProvider(
+                    api_key=self.api_key,
+                    model=model or "llama3.2",
+                    base_url=base_url or "http://localhost:11434/v1",
+                )
         else:
             self.api_key = api_key or self._load_api_key(provider_value)
             if not self.api_key:
@@ -87,8 +103,21 @@ class Client:
         cls,
         model: str | None = None,
         base_url: str | None = None,
+        *,
+        native: bool = False,
+        think: bool = False,
+        keep_alive: str | None = None,
+        num_ctx: int | None = None,
     ) -> "Client":
-        return cls(provider=Provider.ollama, model=model, base_url=base_url)
+        return cls(
+            provider=Provider.ollama,
+            model=model,
+            base_url=base_url,
+            ollama_native=native,
+            ollama_think=think,
+            ollama_keep_alive=keep_alive,
+            ollama_num_ctx=num_ctx,
+        )
 
     @staticmethod
     def _load_api_key(provider: Provider) -> str | None:

--- a/sdks/python/motosan_ai/providers/__init__.py
+++ b/sdks/python/motosan_ai/providers/__init__.py
@@ -1,5 +1,6 @@
 from .anthropic import AnthropicProvider
 from .minimax import MinimaxProvider
+from .ollama import OllamaProvider
 from .openai import OpenAIProvider
 
-__all__ = ["AnthropicProvider", "OpenAIProvider", "MinimaxProvider"]
+__all__ = ["AnthropicProvider", "OpenAIProvider", "MinimaxProvider", "OllamaProvider"]

--- a/sdks/python/motosan_ai/providers/ollama.py
+++ b/sdks/python/motosan_ai/providers/ollama.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, AsyncIterator
+
+import httpx
+
+from motosan_ai.error import NetworkError, ProviderError
+from motosan_ai.types import ChatRequest, ChatResponse, Message, Role, StopReason, StreamEvent, ToolCall, Usage
+
+
+class OllamaProvider:
+    def __init__(
+        self,
+        model: str = "llama3.2",
+        base_url: str = "http://localhost:11434",
+        think: bool = False,
+        keep_alive: str | None = None,
+        num_ctx: int | None = None,
+    ) -> None:
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.think = think
+        self.keep_alive = keep_alive
+        self.num_ctx = num_ctx
+        self._http = httpx.AsyncClient(timeout=120.0)
+
+    @staticmethod
+    def _serialize_messages(messages: list[Message], system: str | None = None) -> list[dict[str, Any]]:
+        outgoing: list[dict[str, Any]] = []
+        if system:
+            outgoing.append({"role": "system", "content": system})
+        for message in messages:
+            if message.role == Role.system:
+                outgoing.append({"role": "system", "content": message.content})
+            elif message.role == Role.user:
+                outgoing.append({"role": "user", "content": message.content})
+            elif message.role == Role.assistant:
+                msg: dict[str, Any] = {"role": "assistant", "content": message.content}
+                if message.tool_calls:
+                    msg["tool_calls"] = [
+                        {
+                            "function": {
+                                "name": tc.name,
+                                "arguments": tc.input,
+                            },
+                        }
+                        for tc in message.tool_calls
+                    ]
+                outgoing.append(msg)
+            elif message.role == Role.tool and message.tool_call_id:
+                outgoing.append({"role": "tool", "content": message.content})
+        return outgoing
+
+    def _build_body(self, request: ChatRequest, *, stream: bool = False) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "model": request.model or self.model,
+            "messages": self._serialize_messages(request.messages, request.system),
+            "stream": stream,
+        }
+        if self.think:
+            body["think"] = True
+        if self.keep_alive is not None:
+            body["keep_alive"] = self.keep_alive
+        options: dict[str, Any] = {}
+        if request.temperature is not None:
+            options["temperature"] = request.temperature
+        if self.num_ctx is not None:
+            options["num_ctx"] = self.num_ctx
+        if options:
+            body["options"] = options
+        if request.tools:
+            body["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": t.name,
+                        "description": t.description or "",
+                        "parameters": t.input_schema or {"type": "object", "properties": {}},
+                    },
+                }
+                for t in request.tools
+            ]
+        if request.provider_options:
+            body.update(request.provider_options)
+        return body
+
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        body = self._build_body(request, stream=False)
+        try:
+            resp = await self._http.post(f"{self.base_url}/api/chat", json=body)
+        except Exception as exc:
+            raise NetworkError(str(exc)) from exc
+
+        if resp.status_code >= 400:
+            raise ProviderError(f"Ollama error {resp.status_code}: {resp.text}")
+
+        data = resp.json()
+        msg = data.get("message") or {}
+        content = msg.get("content") or ""
+
+        tool_calls: list[ToolCall] = []
+        for tc in msg.get("tool_calls") or []:
+            fn = tc.get("function") or {}
+            raw_args = fn.get("arguments", {})
+            if isinstance(raw_args, str):
+                try:
+                    parsed_input = json.loads(raw_args)
+                except json.JSONDecodeError:
+                    parsed_input = {}
+            else:
+                parsed_input = raw_args
+            tool_calls.append(
+                ToolCall(
+                    id=str(uuid.uuid4()),
+                    name=fn.get("name", ""),
+                    input=parsed_input,
+                )
+            )
+
+        stop_reason = StopReason.tool_use if tool_calls else StopReason.stop
+
+        usage_data = data.get("usage") or {}
+        prompt_tokens = int(usage_data.get("prompt_tokens", data.get("prompt_eval_count", 0)))
+        completion_tokens = int(usage_data.get("completion_tokens", data.get("eval_count", 0)))
+
+        return ChatResponse(
+            content=content,
+            tool_calls=tool_calls,
+            model=data.get("model", self.model),
+            usage=Usage(prompt_tokens, completion_tokens),
+            stop_reason=stop_reason,
+        )
+
+    async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:
+        body = self._build_body(request, stream=True)
+        try:
+            async with self._http.stream("POST", f"{self.base_url}/api/chat", json=body) as resp:
+                if resp.status_code >= 400:
+                    text = await resp.aread()
+                    raise ProviderError(f"Ollama error {resp.status_code}: {text.decode('utf-8', errors='ignore')}")
+
+                async for line in resp.aiter_lines():
+                    if not line:
+                        continue
+                    try:
+                        chunk = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if chunk.get("done"):
+                        yield StreamEvent(content="", done=True)
+                        return
+                    msg = chunk.get("message", {})
+                    content = msg.get("content", "")
+                    thinking = msg.get("thinking", "")
+                    text = content or thinking
+                    if text:
+                        yield StreamEvent(content=text, done=False)
+        except Exception as exc:
+            if isinstance(exc, ProviderError):
+                raise
+            raise NetworkError(str(exc)) from exc

--- a/sdks/python/tests/test_ollama_native.py
+++ b/sdks/python/tests/test_ollama_native.py
@@ -1,0 +1,299 @@
+import json
+
+import httpx
+import pytest
+import respx
+
+from motosan_ai import Client, Provider
+from motosan_ai.providers.ollama import OllamaProvider
+from motosan_ai.types import ChatRequest, Message, StopReason, StreamEvent, Tool, ToolCall
+
+
+BASE_URL = "http://localhost:11434"
+CHAT_URL = f"{BASE_URL}/api/chat"
+
+
+@pytest.fixture
+def provider():
+    return OllamaProvider(model="llama3.2", base_url=BASE_URL)
+
+
+@pytest.fixture
+def think_provider():
+    return OllamaProvider(model="llama3.2", base_url=BASE_URL, think=True)
+
+
+# --- Chat tests ---
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_chat_basic(provider):
+    respx.post(CHAT_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": "Hello from Ollama!"},
+                "done": True,
+                "prompt_eval_count": 10,
+                "eval_count": 20,
+            },
+        )
+    )
+    resp = await provider.chat(ChatRequest(messages=[Message.user("hello")]))
+    assert resp.content == "Hello from Ollama!"
+    assert resp.model == "llama3.2"
+    assert resp.stop_reason == StopReason.stop
+    assert resp.usage.input_tokens == 10
+    assert resp.usage.output_tokens == 20
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_chat_with_system(provider):
+    route = respx.post(CHAT_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": "I am helpful."},
+                "done": True,
+            },
+        )
+    )
+    await provider.chat(
+        ChatRequest(messages=[Message.user("hi")], system="You are helpful.")
+    )
+    body = json.loads(route.calls[0].request.content)
+    assert body["messages"][0] == {"role": "system", "content": "You are helpful."}
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_chat_tool_calls(provider):
+    respx.post(CHAT_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "model": "llama3.2",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": {"city": "Taipei"},
+                            }
+                        }
+                    ],
+                },
+                "done": True,
+            },
+        )
+    )
+    tools = [
+        Tool(
+            name="get_weather",
+            description="Get weather",
+            input_schema={"type": "object", "properties": {"city": {"type": "string"}}},
+        )
+    ]
+    resp = await provider.chat(ChatRequest(messages=[Message.user("weather?")], tools=tools))
+    assert resp.stop_reason == StopReason.tool_use
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0].name == "get_weather"
+    assert resp.tool_calls[0].input == {"city": "Taipei"}
+    # Ollama has no id — we generate uuid
+    assert len(resp.tool_calls[0].id) > 0
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_chat_tool_calls_string_arguments(provider):
+    """Tool call arguments may come as a JSON string."""
+    respx.post(CHAT_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "model": "llama3.2",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "search",
+                                "arguments": '{"q": "test"}',
+                            }
+                        }
+                    ],
+                },
+                "done": True,
+            },
+        )
+    )
+    resp = await provider.chat(ChatRequest(messages=[Message.user("search")]))
+    assert resp.tool_calls[0].input == {"q": "test"}
+
+
+# --- Think mode tests ---
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_think_mode_request_body(think_provider):
+    route = respx.post(CHAT_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": "result"},
+                "done": True,
+            },
+        )
+    )
+    await think_provider.chat(ChatRequest(messages=[Message.user("think")]))
+    body = json.loads(route.calls[0].request.content)
+    assert body["think"] is True
+
+
+# --- Stream tests ---
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_basic(provider):
+    ndjson = (
+        '{"message":{"content":"hel"},"done":false}\n'
+        '{"message":{"content":"lo"},"done":false}\n'
+        '{"done":true}\n'
+    )
+    respx.post(CHAT_URL).mock(
+        return_value=httpx.Response(200, text=ndjson)
+    )
+    events = [e async for e in provider.stream(ChatRequest(messages=[Message.user("hi")]))]
+    texts = [e.content for e in events if not e.done]
+    assert texts == ["hel", "lo"]
+    assert events[-1].done is True
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_thinking(think_provider):
+    ndjson = (
+        '{"message":{"thinking":"let me think..."},"done":false}\n'
+        '{"message":{"content":"answer"},"done":false}\n'
+        '{"done":true}\n'
+    )
+    respx.post(CHAT_URL).mock(
+        return_value=httpx.Response(200, text=ndjson)
+    )
+    events = [e async for e in think_provider.stream(ChatRequest(messages=[Message.user("hi")]))]
+    texts = [e.content for e in events if not e.done]
+    assert texts == ["let me think...", "answer"]
+
+
+# --- Build body tests ---
+
+
+def test_build_body_keep_alive():
+    p = OllamaProvider(keep_alive="5m")
+    body = p._build_body(ChatRequest(messages=[Message.user("hi")]))
+    assert body["keep_alive"] == "5m"
+
+
+def test_build_body_num_ctx():
+    p = OllamaProvider(num_ctx=4096)
+    body = p._build_body(ChatRequest(messages=[Message.user("hi")]))
+    assert body["options"]["num_ctx"] == 4096
+
+
+def test_build_body_temperature():
+    p = OllamaProvider()
+    body = p._build_body(ChatRequest(messages=[Message.user("hi")], temperature=0.5))
+    assert body["options"]["temperature"] == 0.5
+
+
+def test_build_body_tools():
+    p = OllamaProvider()
+    tools = [Tool(name="fn", description="desc", input_schema={"type": "object"})]
+    body = p._build_body(ChatRequest(messages=[Message.user("hi")], tools=tools))
+    assert len(body["tools"]) == 1
+    assert body["tools"][0]["function"]["name"] == "fn"
+
+
+# --- Message serialization tests ---
+
+
+def test_serialize_messages_with_tool_calls():
+    tc = ToolCall(id="123", name="fn", input={"a": 1})
+    msgs = [
+        Message.user("hi"),
+        Message.assistant_with_tool_calls("", [tc]),
+        Message.tool_result("123", "result"),
+    ]
+    out = OllamaProvider._serialize_messages(msgs)
+    assert out[0] == {"role": "user", "content": "hi"}
+    # Ollama native: no "id" or "type" in tool_calls, arguments is dict not JSON string
+    assert out[1]["tool_calls"][0]["function"]["arguments"] == {"a": 1}
+    # Ollama native: tool result has no tool_call_id
+    assert "tool_call_id" not in out[2]
+    assert out[2] == {"role": "tool", "content": "result"}
+
+
+# --- Client factory tests ---
+
+
+def test_client_ollama_native_factory():
+    client = Client.ollama(native=True)
+    assert client.provider == Provider.ollama
+    assert isinstance(client._provider, OllamaProvider)
+
+
+def test_client_ollama_native_with_options():
+    client = Client.ollama(
+        native=True,
+        model="mistral",
+        base_url="http://remote:11434",
+        think=True,
+        keep_alive="10m",
+        num_ctx=8192,
+    )
+    assert isinstance(client._provider, OllamaProvider)
+    assert client._provider.model == "mistral"
+    assert client._provider.base_url == "http://remote:11434"
+    assert client._provider.think is True
+    assert client._provider.keep_alive == "10m"
+    assert client._provider.num_ctx == 8192
+
+
+def test_client_ollama_compat_still_works(monkeypatch):
+    """native=False (default) should still use OpenAIProvider."""
+    import motosan_ai.providers.openai as m
+
+    class FakeAsyncOpenAI:
+        def __init__(self, api_key, base_url=None):
+            self.chat = type("x", (), {"completions": type("c", (), {"create": None})})
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "openai", type("x", (), {"AsyncOpenAI": FakeAsyncOpenAI})
+    )
+
+    from motosan_ai.providers.openai import OpenAIProvider
+    client = Client.ollama()
+    assert isinstance(client._provider, OpenAIProvider)
+
+
+# --- Error handling ---
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_chat_error_response(provider):
+    respx.post(CHAT_URL).mock(
+        return_value=httpx.Response(500, text="internal error")
+    )
+    with pytest.raises(Exception, match="Ollama error 500"):
+        await provider.chat(ChatRequest(messages=[Message.user("hi")]))


### PR DESCRIPTION
## Summary
- Implements native `OllamaProvider` using httpx against `POST /api/chat`
- NDJSON streaming via `aiter_lines()`, think mode, keep_alive, num_ctx
- Tool call UUID generation (Ollama native omits IDs)
- `Client.ollama(native=True)` enables native provider, default stays compat

## Changes
- New: `providers/ollama.py` — native provider with httpx
- New: `tests/test_ollama_native.py` — 16 tests with respx mocks
- Modified: `providers/__init__.py`, `client.py`

## Test plan
- [x] `pytest tests/test_ollama_native.py` — 16/16 pass
- [x] `pytest tests/test_ollama.py tests/test_openai.py tests/test_minimax.py` — no regressions
- [ ] Manual: test think mode with qwen3 on local Ollama

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)