### PR TITLE
chore: bump versions — Rust v0.2.0, Python v0.2.1 (Ollama release)

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to `motosan-ai` Python SDK are documented in this file.
+
+## [0.2.1] - 2026-03-15
+
+### Added
+- **Ollama provider** (`Provider.Ollama`): connect to local or remote Ollama instances
+  - Phase 1: OpenAI-compatible endpoint (`/v1/chat/completions`) — zero new dependencies
+  - Phase 2: `OllamaProvider` native via `POST /api/chat` with NDJSON streaming
+  - `think=True`: enable reasoning mode (qwen3-thinking, deepseek-r1, etc.)
+  - `keep_alive`: control VRAM retention after request
+  - `num_ctx`: override context window size
+  - `ollama_base_url()`: point to remote Ollama instance (default: `http://localhost:11434`)
+  - `ollama_native(True)`: switch to native `/api/chat` endpoint
+  - `ollama_think()`, `ollama_keep_alive()`, `ollama_num_ctx()` builder methods
+  - Tool calls: auto-generates uuid when Ollama native omits `id`
+  - Default model: `llama3.2`
+
+## [0.2.0] - 2026-03-12
+
+### Added
+- Initial Python SDK release
+- `Provider.Anthropic`, `Provider.OpenAI`, `Provider.Minimax`
+- Async `chat()`, `chat_with()`, `stream()` with full `ChatRequest` parameters
+- `Message.assistant_with_tool_calls()`, `Message.tool_result()` for multi-turn tool use
+- `ToolCall`, `StreamEvent`, `Usage`, `StopReason` types
+- Pydantic-free implementation (dataclasses + TypedDict)
+- `ClientBuilder` with provider, model, api_key, system, max_tokens, temperature

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motosan-ai"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python SDK for Anthropic, OpenAI, and MiniMax AI providers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
+## [0.2.0] - 2026-03-15
+
+### Added
+- **Ollama provider** (`ollama` feature): connect to local or remote Ollama instances
+  - Phase 1: `Provider::Ollama` via OpenAI-compatible endpoint (`/v1/chat/completions`)
+  - Phase 2: `OllamaProvider` native implementation using `POST /api/chat` with NDJSON streaming
+  - `think` mode: enable reasoning on qwen3-thinking, deepseek-r1 and other thinking models
+  - `keep_alive`: control how long the model stays loaded in VRAM
+  - `num_ctx`: override context window size via Modelfile options
+  - `ollama_base_url()` builder: point to remote Ollama instance
+  - `ollama_native(true)` builder: switch to native `/api/chat` endpoint
+  - `ollama_think()`, `ollama_keep_alive()`, `ollama_num_ctx()` builder methods
+  - `NdjsonStream`: custom `futures::Stream` adapter for NDJSON line parsing
+  - Tool calls: auto-generates `call_{idx}` id when Ollama native omits it
+  - `DEFAULT_OLLAMA_MODEL = "llama3.2"` in `models.rs`
+- `feature = "full"` now includes `ollama`
+
+## [0.1.4] - 2026-03-15
+
+### Added
+- `Client::stream_with(request: ChatRequest)` — stream with full `ChatRequest` (system, max_tokens, tools, temperature)
+
+### Fixed
+- Anthropic provider: `max_tokens` now defaults to `4096` when not set (Anthropic API requires this field; previously caused HTTP 400)
+
+
 ## [0.1.3] - 2026-03-11
 
 ### Added

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"


### PR DESCRIPTION
## Version bumps

| SDK | Before | After |
|-----|--------|-------|
| Rust | 0.1.4 | **0.2.0** |
| Python | 0.2.0 | **0.2.1** |

## Rust v0.2.0 CHANGELOG
- `Provider::Ollama` via OpenAI compat endpoint
- `OllamaProvider` native (NDJSON streaming, think mode, keep_alive, num_ctx)
- `ollama` feature flag + `full` updated
- Backfilled `v0.1.4` entry (stream_with + Anthropic max_tokens fix)

## Python v0.2.1 CHANGELOG
- `Provider.Ollama` via OpenAI compat + native OllamaProvider
- think, keep_alive, num_ctx builder methods
- uuid tool call id generation

## After merge
```bash
# Rust — tag triggers crates.io publish (if CI configured)
git tag rust-v0.2.0 && git push origin rust-v0.2.0

# Python — tag triggers PyPI publish
git tag python-v0.2.1 && git push origin python-v0.2.1
```