### PR TITLE
fix: streaming tool call event completeness (Ollama + MiniMax + OpenAI)

### DIFF
--- a/sdks/python/motosan_ai/providers/ollama.py
+++ b/sdks/python/motosan_ai/providers/ollama.py
@@ -165,13 +165,26 @@ class OllamaProvider:
                             args_str = raw_args
                         else:
                             args_str = json.dumps(raw_args, ensure_ascii=False)
+                        tc_id = str(uuid.uuid4())
                         yield StreamEvent(
                             content="",
                             done=False,
-                            tool_call_id=str(uuid.uuid4()),
+                            tool_call_id=tc_id,
                             tool_call_name=fn.get("name", ""),
-                            tool_call_args_delta=args_str,
                             event_type="tool_call_start",
+                        )
+                        yield StreamEvent(
+                            content="",
+                            done=False,
+                            tool_call_id=tc_id,
+                            tool_call_args_delta=args_str,
+                            event_type="tool_call_args",
+                        )
+                        yield StreamEvent(
+                            content="",
+                            done=False,
+                            tool_call_id=tc_id,
+                            event_type="tool_call_end",
                         )
         except Exception as exc:
             if isinstance(exc, ProviderError):

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motosan-ai"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python SDK for Anthropic, OpenAI, and MiniMax AI providers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdks/python/tests/test_ollama_native.py
+++ b/sdks/python/tests/test_ollama_native.py
@@ -286,6 +286,72 @@ def test_client_ollama_compat_still_works(monkeypatch):
     assert isinstance(client._provider, OpenAIProvider)
 
 
+# --- Stream tool call tests ---
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_single_tool_call_emits_3_events(provider):
+    ndjson = (
+        '{"message":{"content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Taipei"}}}]},"done":false}\n'
+        '{"done":true}\n'
+    )
+    respx.post(CHAT_URL).mock(return_value=httpx.Response(200, text=ndjson))
+    events = [e async for e in provider.stream(ChatRequest(messages=[Message.user("weather?")]))]
+
+    starts = [e for e in events if e.event_type == "tool_call_start"]
+    args = [e for e in events if e.event_type == "tool_call_args"]
+    ends = [e for e in events if e.event_type == "tool_call_end"]
+
+    assert len(starts) == 1
+    assert len(args) == 1
+    assert len(ends) == 1
+
+    # All 3 events share the same tool_call_id
+    tc_id = starts[0].tool_call_id
+    assert tc_id is not None
+    assert args[0].tool_call_id == tc_id
+    assert ends[0].tool_call_id == tc_id
+
+    assert starts[0].tool_call_name == "get_weather"
+    assert "Taipei" in args[0].tool_call_args_delta
+    assert events[-1].done is True
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_two_tool_calls_emits_6_events(provider):
+    ndjson = (
+        '{"message":{"content":"","tool_calls":['
+        '{"function":{"name":"get_weather","arguments":{"city":"Taipei"}}},'
+        '{"function":{"name":"get_time","arguments":{"tz":"Asia/Taipei"}}}'
+        ']},"done":false}\n'
+        '{"done":true}\n'
+    )
+    respx.post(CHAT_URL).mock(return_value=httpx.Response(200, text=ndjson))
+    events = [e async for e in provider.stream(ChatRequest(messages=[Message.user("weather and time?")]))]
+
+    starts = [e for e in events if e.event_type == "tool_call_start"]
+    args = [e for e in events if e.event_type == "tool_call_args"]
+    ends = [e for e in events if e.event_type == "tool_call_end"]
+
+    assert len(starts) == 2
+    assert len(args) == 2
+    assert len(ends) == 2
+
+    assert starts[0].tool_call_name == "get_weather"
+    assert starts[1].tool_call_name == "get_time"
+
+    # Each tool call has unique id, shared across its 3 events
+    id0 = starts[0].tool_call_id
+    id1 = starts[1].tool_call_id
+    assert id0 != id1
+    assert args[0].tool_call_id == id0
+    assert ends[0].tool_call_id == id0
+    assert args[1].tool_call_id == id1
+    assert ends[1].tool_call_id == id1
+
+
 # --- Error handling ---
 
 

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -509,6 +509,7 @@ impl ProviderImpl for MinimaxProvider {
             inner: Box::pin(raw_stream),
             pending: std::collections::VecDeque::new(),
             expose_reasoning,
+            seen_tool_ids: Vec::new(),
         };
 
         Ok(Box::pin(adapter))
@@ -529,6 +530,7 @@ struct MinimaxStreamAdapter {
     >,
     pending: std::collections::VecDeque<StreamEvent>,
     expose_reasoning: bool,
+    seen_tool_ids: Vec<String>,
 }
 
 impl Stream for MinimaxStreamAdapter {
@@ -587,13 +589,16 @@ impl Stream for MinimaxStreamAdapter {
                                         .and_then(Value::as_str);
 
                                     if let (Some(id), Some(name)) = (tc_id, tc_name) {
+                                        self.seen_tool_ids.push(id.to_string());
                                         self.pending
                                             .push_back(StreamEvent::tool_call_start(id, name));
                                     }
                                     if let Some(args) = tc_args {
                                         if !args.is_empty() {
-                                            self.pending
-                                                .push_back(StreamEvent::tool_call_args(args));
+                                            let id = tc_id.unwrap_or("");
+                                            self.pending.push_back(
+                                                StreamEvent::tool_call_args_with_id(id, args),
+                                            );
                                         }
                                     }
                                 }
@@ -604,7 +609,11 @@ impl Stream for MinimaxStreamAdapter {
                         let finish_reason = choice.get("finish_reason").and_then(Value::as_str);
                         if let Some(reason) = finish_reason {
                             if reason == "tool_calls" {
-                                self.pending.push_back(StreamEvent::tool_call_end());
+                                let ids: Vec<String> = self.seen_tool_ids.drain(..).collect();
+                                for id in &ids {
+                                    self.pending
+                                        .push_back(StreamEvent::tool_call_end_with_id(id));
+                                }
                             }
                             self.pending.push_back(StreamEvent::done());
                         }

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -6,11 +6,13 @@ use crate::providers::{
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Role, StopReason, ToolCall};
+use crate::types::{ChatRequest, ChatResponse, Role, StopReason, StreamEvent, ToolCall};
 use async_trait::async_trait;
+use futures_core::Stream;
 use reqwest::Client;
 use serde_json::{json, Value};
-use tokio_stream::StreamExt;
+use std::pin::Pin;
+use std::task::Poll;
 
 pub struct OllamaProvider {
     http: Client,
@@ -367,67 +369,95 @@ impl ProviderImpl for OllamaProvider {
             buffer: Vec::new(),
         };
 
-        let parsed_stream = ndjson_stream.filter_map(|line_result| match line_result {
-            Ok(line) => {
-                let payload: Value = match serde_json::from_str(&line) {
-                    Ok(v) => v,
-                    Err(_) => return None,
-                };
+        let adapter = OllamaStreamAdapter {
+            inner: Box::pin(ndjson_stream),
+            pending: std::collections::VecDeque::new(),
+        };
 
-                let done = payload
-                    .get("done")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false);
-                if done {
-                    return Some(crate::types::StreamEvent::done());
+        Ok(Box::pin(adapter))
+    }
+}
+
+/// Stream adapter that parses Ollama NDJSON events and emits proper
+/// 3-event sequences (Start + Args + End) for each tool call.
+struct OllamaStreamAdapter {
+    inner: Pin<Box<dyn Stream<Item = Result<String, MotosanError>> + Send>>,
+    pending: std::collections::VecDeque<StreamEvent>,
+}
+
+impl Stream for OllamaStreamAdapter {
+    type Item = StreamEvent;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if let Some(event) = self.pending.pop_front() {
+            return Poll::Ready(Some(event));
+        }
+
+        loop {
+            match self.inner.as_mut().poll_next(cx) {
+                Poll::Ready(Some(Ok(line))) => {
+                    let payload: Value = match serde_json::from_str(&line) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+
+                    let done = payload
+                        .get("done")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    if done {
+                        return Poll::Ready(Some(StreamEvent::done()));
+                    }
+
+                    let message = payload.get("message");
+                    let content = message
+                        .and_then(|m| m.get("content"))
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    let thinking = message
+                        .and_then(|m| m.get("thinking"))
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+
+                    let text = if !thinking.is_empty() && content.is_empty() {
+                        thinking.to_string()
+                    } else if !content.is_empty() {
+                        content.to_string()
+                    } else {
+                        String::new()
+                    };
+
+                    if !text.is_empty() {
+                        self.pending.push_back(StreamEvent::text(text));
+                    }
+
+                    // Emit 3-event sequence per tool call
+                    let tool_calls = message
+                        .map(OllamaProvider::extract_tool_calls)
+                        .unwrap_or_default();
+                    for tc in &tool_calls {
+                        let args = serde_json::to_string(&tc.input).unwrap_or_default();
+                        self.pending
+                            .push_back(StreamEvent::tool_call_start(&tc.id, &tc.name));
+                        self.pending
+                            .push_back(StreamEvent::tool_call_args_with_id(&tc.id, args));
+                        self.pending
+                            .push_back(StreamEvent::tool_call_end_with_id(&tc.id));
+                    }
+
+                    if let Some(evt) = self.pending.pop_front() {
+                        return Poll::Ready(Some(evt));
+                    }
+                    continue;
                 }
-
-                let message = payload.get("message");
-                let content = message
-                    .and_then(|m| m.get("content"))
-                    .and_then(Value::as_str)
-                    .unwrap_or_default();
-                let thinking = message
-                    .and_then(|m| m.get("thinking"))
-                    .and_then(Value::as_str)
-                    .unwrap_or_default();
-
-                let text = if !thinking.is_empty() && content.is_empty() {
-                    thinking.to_string()
-                } else if !content.is_empty() {
-                    content.to_string()
-                } else {
-                    String::new()
-                };
-
-                // Check for tool_calls in the message
-                let tool_calls = message.map(Self::extract_tool_calls).unwrap_or_default();
-                if !tool_calls.is_empty() {
-                    // For Ollama, tool calls arrive as complete objects
-                    // Return the first tool_call_start; remaining are lost
-                    // (Ollama streaming rarely sends multiple tool calls in one chunk)
-                    let tc = &tool_calls[0];
-                    let args = serde_json::to_string(&tc.input).unwrap_or_default();
-                    return Some(crate::types::StreamEvent {
-                        content: String::new(),
-                        done: false,
-                        tool_call_id: Some(tc.id.clone()),
-                        tool_call_name: Some(tc.name.clone()),
-                        tool_call_args_delta: Some(args),
-                        event_type: crate::types::StreamEventType::ToolCallStart,
-                    });
-                }
-
-                if text.is_empty() {
-                    return None;
-                }
-
-                Some(crate::types::StreamEvent::text(text))
+                Poll::Ready(Some(Err(_))) => continue,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
             }
-            Err(_) => None,
-        });
-
-        Ok(Box::pin(parsed_stream))
+        }
     }
 }
 

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -549,6 +549,7 @@ impl ProviderImpl for OpenAIProvider {
         let adapter = OpenAIStreamAdapter {
             inner: Box::pin(raw_stream),
             pending: std::collections::VecDeque::new(),
+            seen_tool_ids: Vec::new(),
         };
 
         Ok(Box::pin(adapter))
@@ -568,6 +569,7 @@ struct OpenAIStreamAdapter {
         >,
     >,
     pending: std::collections::VecDeque<StreamEvent>,
+    seen_tool_ids: Vec<String>,
 }
 
 impl OpenAIStreamAdapter {
@@ -622,12 +624,15 @@ impl OpenAIStreamAdapter {
                         .and_then(Value::as_str);
 
                     if let (Some(id), Some(name)) = (tc_id, tc_name) {
+                        self.seen_tool_ids.push(id.to_string());
                         self.pending
                             .push_back(StreamEvent::tool_call_start(id, name));
                     }
                     if let Some(args) = tc_args {
                         if !args.is_empty() {
-                            self.pending.push_back(StreamEvent::tool_call_args(args));
+                            let id = tc_id.unwrap_or("");
+                            self.pending
+                                .push_back(StreamEvent::tool_call_args_with_id(id, args));
                         }
                     }
                 }
@@ -638,7 +643,11 @@ impl OpenAIStreamAdapter {
         let finish_reason = choice.get("finish_reason").and_then(Value::as_str);
         if let Some(reason) = finish_reason {
             if reason == "tool_calls" {
-                self.pending.push_back(StreamEvent::tool_call_end());
+                let ids: Vec<String> = self.seen_tool_ids.drain(..).collect();
+                for id in &ids {
+                    self.pending
+                        .push_back(StreamEvent::tool_call_end_with_id(id));
+                }
             }
             self.pending.push_back(StreamEvent::done());
             return true;

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -262,11 +262,33 @@ impl StreamEvent {
         }
     }
 
+    pub fn tool_call_args_with_id(id: impl Into<String>, delta: impl Into<String>) -> Self {
+        Self {
+            content: String::new(),
+            done: false,
+            tool_call_id: Some(id.into()),
+            tool_call_name: None,
+            tool_call_args_delta: Some(delta.into()),
+            event_type: StreamEventType::ToolCallArgs,
+        }
+    }
+
     pub fn tool_call_end() -> Self {
         Self {
             content: String::new(),
             done: false,
             tool_call_id: None,
+            tool_call_name: None,
+            tool_call_args_delta: None,
+            event_type: StreamEventType::ToolCallEnd,
+        }
+    }
+
+    pub fn tool_call_end_with_id(id: impl Into<String>) -> Self {
+        Self {
+            content: String::new(),
+            done: false,
+            tool_call_id: Some(id.into()),
             tool_call_name: None,
             tool_call_args_delta: None,
             event_type: StreamEventType::ToolCallEnd,

--- a/sdks/rust/tests/ollama_native_provider.rs
+++ b/sdks/rust/tests/ollama_native_provider.rs
@@ -3,7 +3,7 @@
 use mockito::Matcher;
 use motosan_ai::providers::ollama::OllamaProvider;
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, StopReason, Tool, DEFAULT_OLLAMA_MODEL};
+use motosan_ai::{ChatRequest, Message, StopReason, StreamEventType, Tool, DEFAULT_OLLAMA_MODEL};
 use serde_json::json;
 use tokio_stream::StreamExt;
 
@@ -330,4 +330,134 @@ async fn ollama_native_client_builder() {
         .expect("client build");
 
     assert!(matches!(client.provider(), Provider::Ollama));
+}
+
+#[tokio::test]
+async fn ollama_native_stream_single_tool_call_emits_3_events() {
+    let mut server = mockito::Server::new_async().await;
+    let ndjson_body = concat!(
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"\",\"tool_calls\":[{\"function\":{\"name\":\"get_weather\",\"arguments\":{\"city\":\"Taipei\"}}}]},\"done\":false}\n",
+        "{\"done\":true}\n"
+    );
+
+    let mock = server
+        .mock("POST", "/api/chat")
+        .with_status(200)
+        .with_header("content-type", "application/x-ndjson")
+        .with_body(ndjson_body)
+        .create_async()
+        .await;
+
+    let provider = build_provider(server.url());
+    let request = ChatRequest::builder()
+        .message(Message::user("weather?"))
+        .tools(vec![Tool {
+            name: "get_weather".to_string(),
+            description: Some("Get weather".to_string()),
+            input_schema: Some(
+                json!({"type": "object", "properties": {"city": {"type": "string"}}}),
+            ),
+        }])
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    // 3 tool events + done = 4 total
+    let starts: Vec<_> = events
+        .iter()
+        .filter(|e| e.event_type == StreamEventType::ToolCallStart)
+        .collect();
+    let args: Vec<_> = events
+        .iter()
+        .filter(|e| e.event_type == StreamEventType::ToolCallArgs)
+        .collect();
+    let ends: Vec<_> = events
+        .iter()
+        .filter(|e| e.event_type == StreamEventType::ToolCallEnd)
+        .collect();
+
+    assert_eq!(starts.len(), 1);
+    assert_eq!(args.len(), 1);
+    assert_eq!(ends.len(), 1);
+
+    // All 3 events share the same tool_call_id
+    let id = starts[0].tool_call_id.as_ref().unwrap();
+    assert_eq!(args[0].tool_call_id.as_ref().unwrap(), id);
+    assert_eq!(ends[0].tool_call_id.as_ref().unwrap(), id);
+
+    assert_eq!(starts[0].tool_call_name.as_deref(), Some("get_weather"));
+    assert!(args[0]
+        .tool_call_args_delta
+        .as_ref()
+        .unwrap()
+        .contains("Taipei"));
+    assert!(events.last().unwrap().done);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn ollama_native_stream_two_tool_calls_emits_6_events() {
+    let mut server = mockito::Server::new_async().await;
+    let ndjson_body = concat!(
+        "{\"message\":{\"role\":\"assistant\",\"content\":\"\",\"tool_calls\":[",
+        "{\"function\":{\"name\":\"get_weather\",\"arguments\":{\"city\":\"Taipei\"}}},",
+        "{\"function\":{\"name\":\"get_time\",\"arguments\":{\"tz\":\"Asia/Taipei\"}}}",
+        "]},\"done\":false}\n",
+        "{\"done\":true}\n"
+    );
+
+    let mock = server
+        .mock("POST", "/api/chat")
+        .with_status(200)
+        .with_header("content-type", "application/x-ndjson")
+        .with_body(ndjson_body)
+        .create_async()
+        .await;
+
+    let provider = build_provider(server.url());
+    let request = ChatRequest::builder()
+        .message(Message::user("weather and time?"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    let starts: Vec<_> = events
+        .iter()
+        .filter(|e| e.event_type == StreamEventType::ToolCallStart)
+        .collect();
+    let args: Vec<_> = events
+        .iter()
+        .filter(|e| e.event_type == StreamEventType::ToolCallArgs)
+        .collect();
+    let ends: Vec<_> = events
+        .iter()
+        .filter(|e| e.event_type == StreamEventType::ToolCallEnd)
+        .collect();
+
+    assert_eq!(starts.len(), 2);
+    assert_eq!(args.len(), 2);
+    assert_eq!(ends.len(), 2);
+
+    assert_eq!(starts[0].tool_call_name.as_deref(), Some("get_weather"));
+    assert_eq!(starts[1].tool_call_name.as_deref(), Some("get_time"));
+
+    // Each tool call has unique id, shared across its 3 events
+    let id0 = starts[0].tool_call_id.as_ref().unwrap();
+    let id1 = starts[1].tool_call_id.as_ref().unwrap();
+    assert_ne!(id0, id1);
+    assert_eq!(args[0].tool_call_id.as_ref().unwrap(), id0);
+    assert_eq!(ends[0].tool_call_id.as_ref().unwrap(), id0);
+    assert_eq!(args[1].tool_call_id.as_ref().unwrap(), id1);
+    assert_eq!(ends[1].tool_call_id.as_ref().unwrap(), id1);
+
+    mock.assert_async().await;
 }


### PR DESCRIPTION
## Summary

- **Ollama (Rust #106 + Python #107)**: emit proper 3-event sequence (Start → Args → End) per tool call instead of a single ToolCallStart with args crammed in
- **MiniMax + OpenAI (Rust #108)**: `tool_call_args` now carries `tool_call_id`; `tool_call_end` emitted per tool call with its id (not a single global end)
- New Rust constructors: `StreamEvent::tool_call_args_with_id()`, `StreamEvent::tool_call_end_with_id()`
- Version bump: 0.3.0 → 0.3.1

Closes #106, closes #107, closes #108

## Test plan
- [x] Rust: 1 tool call → 3 events (Start + Args + End with matching id)
- [x] Rust: 2 tool calls → 6 events with unique ids per call
- [x] Python: same 1-call and 2-call tests
- [x] All 100 Rust tests pass, all 35 Python tests pass
- [x] Existing stream tests unaffected (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)