### PR TITLE
fix: Anthropic stream tool_call_id + ThinkStripper

### DIFF
--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterator, Iterable
 
 from motosan_ai.error import ConfigError
 from motosan_ai.providers import AnthropicProvider, MinimaxProvider, OpenAIProvider
+from motosan_ai.think_stripper import ThinkStripper
 from motosan_ai.types import ChatRequest, ChatResponse, Message, StreamEvent, Tool
 
 
@@ -187,8 +188,18 @@ class Client:
             max_tokens=max_tokens,
             provider_options=provider_options,
         )
+        stripper = ThinkStripper()
         async for event in self._provider.stream(request):
-            yield event
+            if event.event_type == "text" and event.content:
+                clean = stripper.feed(event.content)
+                if clean:
+                    yield StreamEvent(content=clean, done=False)
+            else:
+                if event.done:
+                    remaining = stripper.flush()
+                    if remaining:
+                        yield StreamEvent(content=remaining, done=False)
+                yield event
 
     def chat_sync(
         self,

--- a/sdks/python/motosan_ai/providers/anthropic.py
+++ b/sdks/python/motosan_ai/providers/anthropic.py
@@ -156,6 +156,8 @@ class AnthropicProvider:
         except Exception as exc:
             raise ProviderError(str(exc)) from exc
 
+        current_tool_id: str | None = None
+
         async for event in events:
             payload = event if isinstance(event, dict) else event.model_dump()
             event_type = payload.get("type")
@@ -163,10 +165,11 @@ class AnthropicProvider:
             if event_type == "content_block_start":
                 block = payload.get("content_block") or {}
                 if block.get("type") == "tool_use":
+                    current_tool_id = block.get("id", "")
                     yield StreamEvent(
                         content="",
                         done=False,
-                        tool_call_id=block.get("id", ""),
+                        tool_call_id=current_tool_id,
                         tool_call_name=block.get("name", ""),
                         event_type="tool_call_start",
                     )
@@ -184,12 +187,20 @@ class AnthropicProvider:
                         yield StreamEvent(
                             content="",
                             done=False,
+                            tool_call_id=current_tool_id,
                             tool_call_args_delta=partial,
                             event_type="tool_call_args",
                         )
 
             elif event_type == "content_block_stop":
-                yield StreamEvent(content="", done=False, event_type="tool_call_end")
+                if current_tool_id is not None:
+                    yield StreamEvent(
+                        content="",
+                        done=False,
+                        tool_call_id=current_tool_id,
+                        event_type="tool_call_end",
+                    )
+                    current_tool_id = None
 
             elif event_type == "message_stop":
                 yield StreamEvent(content="", done=True)

--- a/sdks/python/motosan_ai/think_stripper.py
+++ b/sdks/python/motosan_ai/think_stripper.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+
+class ThinkStripper:
+    """Stateful streamer that buffers and removes <think>...</think> across chunks."""
+
+    def __init__(self) -> None:
+        self._buf = ""
+        self._in_think = False
+
+    def flush(self) -> str:
+        """Flush any remaining buffered text. Call when the stream ends."""
+        remaining = self._buf
+        self._buf = ""
+        if self._in_think:
+            self._in_think = False
+            return ""
+        return remaining
+
+    def feed(self, chunk: str) -> str:
+        """Returns clean text to emit; may return empty string while buffering."""
+        self._buf += chunk
+        output: list[str] = []
+
+        while self._buf:
+            if self._in_think:
+                end = self._buf.find("</think>")
+                if end == -1:
+                    # Keep just enough to detect a split </think>
+                    keep = len("</think>") - 1
+                    if len(self._buf) > keep:
+                        self._buf = self._buf[-keep:]
+                    break
+                self._buf = self._buf[end + len("</think>"):]
+                self._in_think = False
+            else:
+                start = self._buf.find("<think>")
+                if start == -1:
+                    # Safe to emit, but hold tail in case tag is split
+                    safe = len(self._buf) - (len("<think>") - 1)
+                    if safe > 0:
+                        output.append(self._buf[:safe])
+                        self._buf = self._buf[safe:]
+                    break
+                output.append(self._buf[:start])
+                self._buf = self._buf[start + len("<think>"):]
+                self._in_think = True
+
+        return "".join(output)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motosan-ai"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python SDK for Anthropic, OpenAI, and MiniMax AI providers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdks/python/tests/test_anthropic.py
+++ b/sdks/python/tests/test_anthropic.py
@@ -87,15 +87,18 @@ async def test_anthropic_stream_tool_use(provider):
     assert starts[0].tool_call_id == "toolu_1"
     assert starts[0].tool_call_name == "get_weather"
 
-    # Should have tool_call_args
+    # Should have tool_call_args — with correct id
     args_events = [e for e in events if e.event_type == "tool_call_args"]
     assert len(args_events) == 2
     full_args = "".join(e.tool_call_args_delta for e in args_events)
     assert full_args == '{"city":"Taipei"}'
+    assert args_events[0].tool_call_id == "toolu_1"
+    assert args_events[1].tool_call_id == "toolu_1"
 
-    # Should have tool_call_end
+    # Should have tool_call_end — with correct id
     ends = [e for e in events if e.event_type == "tool_call_end"]
-    assert len(ends) >= 1
+    assert len(ends) == 1
+    assert ends[0].tool_call_id == "toolu_1"
 
     # Should end with done=True
     assert events[-1].done is True

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -2,7 +2,8 @@ use crate::error::MotosanError;
 use crate::providers::Provider;
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Message};
+use crate::think_stripper::ThinkStripper;
+use crate::types::{ChatRequest, ChatResponse, Message, StreamEvent, StreamEventType};
 
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -72,11 +73,20 @@ impl Client {
             request_builder = request_builder.model(model.clone());
         }
 
-        self.dispatch_stream(request_builder.build()).await
+        let raw = self.dispatch_stream(request_builder.build()).await?;
+        Ok(Self::wrap_with_think_stripper(raw))
     }
 
     pub async fn stream_with(&self, request: ChatRequest) -> Result<BoxStream, MotosanError> {
-        self.dispatch_stream(request).await
+        let raw = self.dispatch_stream(request).await?;
+        Ok(Self::wrap_with_think_stripper(raw))
+    }
+
+    fn wrap_with_think_stripper(raw: BoxStream) -> BoxStream {
+        Box::pin(ThinkStripperStream {
+            inner: raw,
+            stripper: ThinkStripper::new(),
+        })
     }
 
     async fn dispatch_chat(&self, request: ChatRequest) -> Result<ChatResponse, MotosanError> {
@@ -390,5 +400,44 @@ impl ClientBuilder {
             ollama_num_ctx: self.ollama_num_ctx,
             retry_policy: self.retry_policy.unwrap_or_default(),
         })
+    }
+}
+
+/// Stream wrapper that filters `<think>...</think>` tags from text events.
+struct ThinkStripperStream {
+    inner: BoxStream,
+    stripper: ThinkStripper,
+}
+
+impl futures_core::Stream for ThinkStripperStream {
+    type Item = StreamEvent;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::task::Poll;
+        loop {
+            match self.inner.as_mut().poll_next(cx) {
+                Poll::Ready(Some(event)) => {
+                    if event.event_type == StreamEventType::Text && !event.content.is_empty() {
+                        let clean = self.stripper.feed(&event.content);
+                        if clean.is_empty() {
+                            continue; // buffering, skip this event
+                        }
+                        return Poll::Ready(Some(StreamEvent::text(clean)));
+                    }
+                    return Poll::Ready(Some(event));
+                }
+                Poll::Ready(None) => {
+                    let remaining = self.stripper.flush();
+                    if !remaining.is_empty() {
+                        return Poll::Ready(Some(StreamEvent::text(remaining)));
+                    }
+                    return Poll::Ready(None);
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
     }
 }

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -4,6 +4,7 @@ pub mod models;
 pub mod providers;
 pub mod retry;
 pub mod stream;
+pub mod think_stripper;
 pub mod types;
 
 pub use client::{Client, ClientBuilder};

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -374,6 +374,7 @@ impl ProviderImpl for AnthropicProvider {
         let adapter = AnthropicStreamAdapter {
             inner: Box::pin(raw_stream),
             pending: std::collections::VecDeque::new(),
+            current_tool_id: None,
         };
 
         Ok(Box::pin(adapter))
@@ -393,6 +394,7 @@ struct AnthropicStreamAdapter {
         >,
     >,
     pending: std::collections::VecDeque<StreamEvent>,
+    current_tool_id: Option<String>,
 }
 
 impl Stream for AnthropicStreamAdapter {
@@ -430,6 +432,7 @@ impl Stream for AnthropicStreamAdapter {
                                         .get("name")
                                         .and_then(Value::as_str)
                                         .unwrap_or_default();
+                                    self.current_tool_id = Some(id.to_string());
                                     return Poll::Ready(Some(StreamEvent::tool_call_start(
                                         id, name,
                                     )));
@@ -451,9 +454,11 @@ impl Stream for AnthropicStreamAdapter {
                                         .and_then(Value::as_str)
                                         .unwrap_or_default();
                                     if !partial.is_empty() {
-                                        return Poll::Ready(Some(StreamEvent::tool_call_args(
-                                            partial,
-                                        )));
+                                        let id =
+                                            self.current_tool_id.as_deref().unwrap_or_default();
+                                        return Poll::Ready(Some(
+                                            StreamEvent::tool_call_args_with_id(id, partial),
+                                        ));
                                     }
                                     continue;
                                 }
@@ -471,7 +476,10 @@ impl Stream for AnthropicStreamAdapter {
                             }
                         }
                         "content_block_stop" => {
-                            return Poll::Ready(Some(StreamEvent::tool_call_end()));
+                            if let Some(id) = self.current_tool_id.take() {
+                                return Poll::Ready(Some(StreamEvent::tool_call_end_with_id(id)));
+                            }
+                            continue;
                         }
                         "message_stop" => {
                             return Poll::Ready(Some(StreamEvent::done()));

--- a/sdks/rust/src/think_stripper.rs
+++ b/sdks/rust/src/think_stripper.rs
@@ -1,0 +1,138 @@
+/// Stateful filter that buffers and removes `<think>...</think>` tags
+/// across streaming chunks.
+#[derive(Default)]
+pub struct ThinkStripper {
+    buf: String,
+    in_think: bool,
+}
+
+impl ThinkStripper {
+    pub fn new() -> Self {
+        Self {
+            buf: String::new(),
+            in_think: false,
+        }
+    }
+
+    /// Flush any remaining buffered text. Call when the stream ends.
+    pub fn flush(&mut self) -> String {
+        let remaining = std::mem::take(&mut self.buf);
+        if self.in_think {
+            self.in_think = false;
+            String::new()
+        } else {
+            remaining
+        }
+    }
+
+    pub fn feed(&mut self, chunk: &str) -> String {
+        self.buf.push_str(chunk);
+        let mut output = String::new();
+        loop {
+            if self.in_think {
+                match self.buf.find("</think>") {
+                    None => {
+                        let keep = "</think>".len() - 1;
+                        if self.buf.len() > keep {
+                            self.buf = self.buf[self.buf.len() - keep..].to_string();
+                        }
+                        break;
+                    }
+                    Some(end) => {
+                        self.buf = self.buf[end + "</think>".len()..].to_string();
+                        self.in_think = false;
+                    }
+                }
+            } else {
+                match self.buf.find("<think>") {
+                    None => {
+                        let keep = "<think>".len() - 1;
+                        let safe = self.buf.len().saturating_sub(keep);
+                        output.push_str(&self.buf[..safe]);
+                        self.buf = self.buf[safe..].to_string();
+                        break;
+                    }
+                    Some(start) => {
+                        output.push_str(&self.buf[..start]);
+                        self.buf = self.buf[start + "<think>".len()..].to_string();
+                        self.in_think = true;
+                    }
+                }
+            }
+        }
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_complete_think_block() {
+        let mut s = ThinkStripper::new();
+        let mut out = s.feed("<think>reasoning</think>answer is here");
+        out.push_str(&s.flush());
+        assert_eq!(out, "answer is here");
+    }
+
+    #[test]
+    fn strips_think_block_across_chunks() {
+        let mut s = ThinkStripper::new();
+        assert_eq!(s.feed("<think>reas"), "");
+        let mut out = s.feed("oning</think>answer is here");
+        out.push_str(&s.flush());
+        assert_eq!(out, "answer is here");
+    }
+
+    #[test]
+    fn strips_split_open_tag() {
+        let mut s = ThinkStripper::new();
+        let mut out = String::new();
+        out.push_str(&s.feed("hello<thi"));
+        out.push_str(&s.feed("nk>hidden</think>world!"));
+        out.push_str(&s.flush());
+        assert_eq!(out, "helloworld!");
+    }
+
+    #[test]
+    fn strips_split_close_tag() {
+        let mut s = ThinkStripper::new();
+        assert_eq!(s.feed("<think>hidden</thi"), "");
+        let mut out = s.feed("nk>visible text");
+        out.push_str(&s.flush());
+        assert_eq!(out, "visible text");
+    }
+
+    #[test]
+    fn passes_through_without_tags() {
+        let mut s = ThinkStripper::new();
+        let mut out = String::new();
+        out.push_str(&s.feed("hello "));
+        out.push_str(&s.feed("world"));
+        out.push_str(&s.flush());
+        assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn strips_multiple_think_blocks() {
+        let mut s = ThinkStripper::new();
+        let mut out = s.feed("<think>a</think>between<think>c</think>after!");
+        out.push_str(&s.flush());
+        assert_eq!(out, "betweenafter!");
+    }
+
+    #[test]
+    fn handles_empty_input() {
+        let mut s = ThinkStripper::new();
+        assert_eq!(s.feed(""), "");
+        assert_eq!(s.flush(), "");
+    }
+
+    #[test]
+    fn flush_while_in_think_returns_empty() {
+        let mut s = ThinkStripper::new();
+        s.feed("<think>still thinking");
+        assert_eq!(s.flush(), "");
+    }
+}

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -317,7 +317,7 @@ async fn anthropic_stream_emits_tool_use_events() {
     assert_eq!(starts[0].tool_call_id.as_deref(), Some("toolu_1"));
     assert_eq!(starts[0].tool_call_name.as_deref(), Some("get_weather"));
 
-    // Tool call args
+    // Tool call args — must carry same id
     let args_events: Vec<_> = received
         .iter()
         .filter(|e| e.event_type == StreamEventType::ToolCallArgs)
@@ -328,13 +328,16 @@ async fn anthropic_stream_emits_tool_use_events() {
         .filter_map(|e| e.tool_call_args_delta.as_deref())
         .collect();
     assert_eq!(full_args, "{\"city\":\"Taipei\"}");
+    assert_eq!(args_events[0].tool_call_id.as_deref(), Some("toolu_1"));
+    assert_eq!(args_events[1].tool_call_id.as_deref(), Some("toolu_1"));
 
-    // Tool call end
+    // Tool call end — must carry same id
     let ends: Vec<_> = received
         .iter()
         .filter(|e| e.event_type == StreamEventType::ToolCallEnd)
         .collect();
-    assert!(!ends.is_empty());
+    assert_eq!(ends.len(), 1);
+    assert_eq!(ends[0].tool_call_id.as_deref(), Some("toolu_1"));
 
     // Done
     assert!(received.last().unwrap().done);


### PR DESCRIPTION
## Summary

### Anthropic stream tool_call_id (#110, #111)
- Python + Rust: track `current_tool_id` across `content_block_start` → `content_block_delta` → `content_block_stop` so `tool_call_args` and `tool_call_end` events carry the correct id
- Previously id was `None` on args/end → broke downstream `AgentLoop` pending tool assembly

### ThinkStripper (#112)
- Stateful `<think>...</think>` tag removal that works across chunk boundaries
- Applied at `Client.stream()` level — all providers benefit automatically
- Handles split tags, multiple blocks, `flush()` on stream end
- 8 Rust unit tests, Python impl with matching behavior

Closes #110, closes #111, closes #112

## Test plan
- [x] Anthropic stream tests verify args/end events carry `tool_call_id == "toolu_1"`
- [x] ThinkStripper unit tests: complete/split/multi-block/empty/flush
- [x] All 108 Rust tests pass, all 35 Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)