### PR TITLE
docs: add llms.txt + AGENTS.md update + OpenClaw skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ Read this before writing any code.
 
 **motosan-ai** is a multi-language, multi-provider AI SDK. Each language is an independent idiomatic implementation — no FFI, no shared runtime.
 
-Current status:
-- ✅ Rust SDK v0.1.3 (`sdks/rust/`) — production ready, published to crates.io
-- 🔄 Python SDK (`sdks/python/`) — in progress (M2)
+Current versions:
+- ✅ Python SDK v0.4.2 (`sdks/python/`) — published to PyPI
+- ✅ Rust SDK v0.3.3 (`sdks/rust/`) — published to crates.io
 - ⏳ TypeScript SDK (`sdks/typescript/`) — planned (M3)
 
 ---
@@ -20,272 +20,67 @@ Current status:
 ```
 motosan-ai/
 ├── sdks/
-│   ├── rust/                   # Rust SDK (published: motosan-ai on crates.io)
-│   │   ├── Cargo.toml
-│   │   ├── src/
-│   │   │   ├── lib.rs
-│   │   │   ├── types.rs        # Message, ChatRequest, ChatResponse, ToolCall, Role
-│   │   │   ├── client.rs       # Client, ClientBuilder
-│   │   │   ├── models.rs       # Model catalog + defaults
-│   │   │   ├── retry.rs        # RetryPolicy
-│   │   │   ├── stream.rs       # BoxStream, StreamEvent
-│   │   │   ├── error.rs        # MotosanError
-│   │   │   └── providers/
-│   │   │       ├── anthropic.rs
-│   │   │       ├── openai.rs
-│   │   │       └── minimax.rs
-│   │   └── tests/              # Integration tests (require real API keys, use #[ignore])
-│   ├── python/                 # Python SDK (in progress)
-│   └── typescript/             # TypeScript SDK (planned)
-├── docs/plans/                 # Architecture decisions
-└── specs/types.md              # Cross-language type spec
+│   ├── python/                 # Python SDK (PyPI: motosan-ai)
+│   │   ├── pyproject.toml
+│   │   ├── motosan_ai/
+│   │   │   ├── client.py       # Client, Provider
+│   │   │   ├── types.py        # Message, ChatRequest, ChatResponse, StreamEvent, Tool
+│   │   │   ├── retry.py        # RetryPolicy
+│   │   │   ├── think_stripper.py  # ThinkStripper
+│   │   │   └── providers/      # anthropic.py, openai.py, minimax.py, ollama.py
+│   │   └── tests/
+│   └── rust/                   # Rust SDK (crates.io: motosan-ai)
+│       ├── Cargo.toml
+│       ├── src/
+│       │   ├── lib.rs
+│       │   ├── client.rs       # Client, ClientBuilder
+│       │   ├── types.rs        # Message, ChatRequest, ChatResponse, StreamEvent, Tool
+│       │   ├── stream.rs       # BoxStream, StreamEvent
+│       │   ├── retry.rs        # RetryPolicy
+│       │   └── think_stripper.rs
+│       └── tests/
+├── specs/types.md              # Canonical type definitions (source of truth)
+└── docs/
 ```
 
 ---
 
-## Rust SDK
+## Key Design Decisions
 
-### Feature Flags
-```toml
-motosan-ai = { version = "0.1.3", features = ["anthropic"] }
-# Options: "anthropic" | "openai" | "minimax" | "full"
-```
-
-### Core Types
-```rust
-pub struct Message {
-    pub role: Role,                      // System | User | Assistant | Tool
-    pub content: String,
-    pub tool_call_id: Option<String>,    // for Role::Tool
-    pub tool_calls: Vec<ToolCall>,       // for Role::Assistant with tool use
-}
-
-pub struct ToolCall {
-    pub id: String,
-    pub name: String,
-    pub input: Value,   // serde_json::Value — NOT args, NOT params
-}
-
-pub struct Tool {
-    pub name: String,
-    pub description: Option<String>,
-    pub input_schema: Option<Value>,
-}
-
-pub struct ChatResponse {
-    pub content: String,
-    pub tool_calls: Vec<ToolCall>,
-    pub model: String,
-    pub usage: Usage,
-    pub stop_reason: StopReason,
-}
-```
-
-### Provider Serialization Rules (CRITICAL)
-Each provider has different wire format. DO NOT mix them up:
-
-**Anthropic:**
-- Assistant + tool calls → `content: [{"type":"tool_use","id":...,"name":...,"input":...}]`
-- Tool result → `role:"user", content:[{"type":"tool_result","tool_use_id":...,"content":...}]`
-- System prompt → top-level `"system"` field, NOT in messages array
-
-**OpenAI / MiniMax:**
-- Assistant + tool calls → top-level `"tool_calls":[{"id":...,"type":"function","function":{"name":...,"arguments":"<JSON string>"}}]`
-- Note: `arguments` is a **JSON string**, not an object
-- Tool result → `role:"tool", tool_call_id:..., content:...`
-
-### Coding Standards
-- All `pub` items must have doc comments
-- Use `thiserror` for `MotosanError` — no anyhow in lib
-- Feature-gate provider code: `#[cfg(feature = "anthropic")]`
-- Integration tests: `#[ignore]` unless `ANTHROPIC_API_KEY` etc. are set
-- `cargo fmt + cargo clippy --all-features -- -D warnings` must pass
+- **Provider parity** — all providers must implement `chat()`, `stream()`, `chat_with()`, `stream_with()`
+- **ThinkStripper** — stateful, applied at `Client.stream()` level; cross-chunk safe
+- **Anthropic tool_call_id** — must track `current_tool_id` in state; `content_block_start` carries id, deltas don't
+- **No premature abstraction** — keep per-language idiomatic; no shared core
 
 ---
 
-## Python SDK (in progress — M2)
+## Coding Standards
 
-### Structure
-```
-sdks/python/
-├── pyproject.toml      # name=motosan-ai, optional deps per provider
-├── motosan_ai/
-│   ├── __init__.py     # re-export Client, Message, ChatRequest, ChatResponse
-│   ├── types.py
-│   ├── client.py
-│   ├── error.py
-│   └── providers/
-│       ├── anthropic.py   # uses anthropic>=0.49 (optional dep)
-│       ├── openai.py      # uses openai>=1.70 (optional dep)
-│       └── minimax.py     # uses httpx (optional dep)
-└── tests/
-```
-
-### Python Coding Standards
-- Python 3.11+, type hints on all public functions
-- `async`-first: `Client.chat()` and `Client.stream()` are async
-- Sync wrapper: `Client.chat_sync()` via `asyncio.run()`
-- All providers use `httpx` directly — **no official provider SDKs** (`anthropic`, `openai`)
-- Tests: pytest + pytest-asyncio, mock HTTP calls with `respx`
-- Live integration tests in `tests/integration/` — require real API keys
+- Python: type hints required, `dataclass`, `async/await`, `AsyncGenerator`
+- Rust: `async-trait`, `thiserror`, feature flags per provider
+- Tests: unit tests for all public API; integration tests gated behind feature flags or env vars
 
 ---
 
-## TypeScript SDK (planned — M3)
-
-### Package name
-`@motosan-ai/sdk` (npm)
-
-### Key types (aligned with Rust)
-```typescript
-type Role = 'user' | 'assistant' | 'system' | 'tool'
-
-interface ToolCall {
-  id: string
-  name: string
-  input: Record<string, unknown>  // NOT args, NOT params — must match Rust
-}
-```
-
----
-
-## Cross-language Consistency Rules
-
-1. Field name `input` (not `args`, not `params`) for tool call payloads — everywhere
-2. `tool_call_id` (snake_case in Rust/Python), `toolCallId` (camelCase in TypeScript)
-3. `ChatResponse.tool_calls` is always a `Vec`/`list`/`array` — never optional
-4. `Message::tool_result(id, content)` constructor must exist in all languages
-
----
-
-## Before Committing
+## Common Commands
 
 ```bash
-# Rust
-cd sdks/rust
-cargo fmt
-cargo clippy --all-features -- -D warnings
-cargo test --all-features  # unit tests (mock, no API needed)
-
 # Python
 cd sdks/python
-uv run ruff check .
-uv run pytest tests/ --ignore=tests/integration/
-```
+uv run pytest tests/ -q
 
-## Before Pushing (pre-push gate)
-
-A pre-push hook (`scripts/pre-push-gate.sh`) runs automatically and blocks push on failure:
-
-1. Python unit tests (mock)
-2. Rust unit tests (mock)
-3. Python live Anthropic integration tests (7 tests, ~50s)
-4. Rust live Anthropic integration tests (7 tests, ~46s)
-
-Live tests require `ANTHROPIC_API_KEY` — auto-reads from macOS Keychain if not set.
-Skip with `git push --no-verify` in emergencies.
-
-```bash
-# Run live tests manually
-ANTHROPIC_API_KEY=... uv run pytest sdks/python/tests/integration/test_anthropic_live.py -v
-ANTHROPIC_API_KEY=... cargo test --features full --test anthropic_live -- --test-threads=1
-```
-
-## Before Releasing
-
-Every release **must** include documentation and changelog updates. This is a hard gate — do not tag or publish without completing all items.
-
-### Release Checklist
-
-1. **Update CHANGELOGs** — both SDKs:
-   - `sdks/rust/CHANGELOG.md` — add new version section with Added/Changed/Fixed
-   - `sdks/python/CHANGELOG.md` — add new version section with Added/Changed/Fixed
-   - Follow [Keep a Changelog](https://keepachangelog.com/) format
-   - Include PR/issue numbers where applicable
-
-2. **Bump versions**:
-   - `sdks/rust/Cargo.toml` → `version = "X.Y.Z"`
-   - `sdks/python/pyproject.toml` → `version = "X.Y.Z"`
-
-3. **Update documentation** — any file affected by this release:
-   - `sdks/rust/README.md` — new features, API changes, examples
-   - `sdks/python/README.md` — new features, API changes, examples
-   - `AGENTS.md` — coding standards, provider notes, milestones
-   - `docs/plans/2026-03-10-architecture.md` — architecture changes, provider notes, milestones
-
-4. **Run full test suite** (pre-push gate handles this, but verify manually if needed):
-   ```bash
-   # Unit tests
-   cargo test --manifest-path sdks/rust/Cargo.toml --all-features
-   uv run pytest sdks/python/tests/ --ignore=sdks/python/tests/integration/
-
-   # Live integration tests
-   ANTHROPIC_API_KEY=... cargo test --features full --test anthropic_live -- --test-threads=1
-   ANTHROPIC_API_KEY=... uv run pytest sdks/python/tests/integration/test_anthropic_live.py -v
-   ```
-
-5. **Commit, tag, and push**:
-   ```bash
-   git add -p  # review each change
-   git commit -m "chore: release rust-vX.Y.Z / python-vX.Y.Z"
-   # Tag each SDK independently
-   git tag -a rust-vX.Y.Z -m "rust-vX.Y.Z — summary"
-   git tag -a python-vX.Y.Z -m "python-vX.Y.Z — summary"
-   git push origin main --tags
-   ```
-
-### Tag Convention
-
-| SDK | Tag format | Triggers |
-|-----|-----------|----------|
-| Rust | `rust-v0.3.3` | `publish-rust.yml` → crates.io |
-| Python | `python-v0.3.3` | `publish-python.yml` → PyPI |
-
-Rust and Python are versioned independently — tag each separately.
-Can release only one SDK if the other has no changes.
-
-### What Goes in the CHANGELOG
-
-| Category | When to use |
-|----------|-------------|
-| **Added** | New features, new providers, new API methods |
-| **Changed** | Breaking changes, dependency swaps, behavior changes |
-| **Fixed** | Bug fixes, OAuth fixes, error handling improvements |
-| **Removed** | Deprecated features, removed dependencies |
-
-### What Docs to Update
-
-| Change type | Files to update |
-|-------------|----------------|
-| New provider | Both READMEs + AGENTS.md provider table + architecture doc |
-| New API method | Both READMEs (examples) + AGENTS.md (types) |
-| Auth change | Both READMEs (Auth Matrix) + architecture doc (Provider Notes) |
-| Dependency change | AGENTS.md (coding standards) + architecture doc (optional deps) |
-| Test infrastructure | AGENTS.md (Before Pushing) + architecture doc (Testing Strategy) |
-
----
-
-## Publishing
-
-Publish is automated via GitHub Actions on tag push:
-- `rust-v*` → `publish-rust.yml` → crates.io (fmt + clippy + test + publish)
-- `python-v*` → `publish-python.yml` → PyPI (trusted publishing)
-
-Manual publish (emergency):
-```bash
 # Rust
-cd sdks/rust && cargo publish
-
-# Python
-cd sdks/python && uv build --out-dir dist && uv publish dist/*
+cd sdks/rust
+cargo test
+cargo test --features full
+cargo clippy --features full -- -D warnings
 ```
 
 ---
 
-## Milestones
+## What NOT to Do
 
-| SDK | Version | Status |
-|-----|---------|--------|
-| Rust | rust-v0.3.3 | ✅ Current (crates.io) |
-| Python | python-v0.4.2 | ✅ Current (PyPI) |
-| TypeScript | ts-v0.1.0 | ⏳ Planned |
+- Do not add sync wrappers to Python (use `asyncio.run()` at the call site)
+- Do not share code between Python and Rust via FFI or subprocess
+- Do not add provider-specific logic outside `providers/` (Python) or per-provider modules (Rust)
+- Do not break the `LlmClient` Protocol in motosan-chat compatibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,72 @@ cargo clippy --features full -- -D warnings
 
 ---
 
+## Cross-language Consistency Rules
+
+1. Field name `input` (not `args`, not `params`) for tool call payloads — everywhere
+2. `tool_call_id` (snake_case in Rust/Python), `toolCallId` (camelCase in TypeScript)
+3. `ChatResponse.tool_calls` is always a `Vec`/`list`/`array` — never optional
+4. `Message::tool_result(id, content)` constructor must exist in all languages
+
+---
+
+## Provider Serialization (CRITICAL — do not mix up)
+
+**Anthropic:**
+- Assistant + tool calls → `content: [{"type":"tool_use","id":...,"name":...,"input":...}]`
+- Tool result → `role:"user", content:[{"type":"tool_result","tool_use_id":...,"content":...}]`
+- System prompt → top-level `"system"` field, NOT in messages array
+
+**OpenAI / MiniMax:**
+- Assistant + tool calls → top-level `"tool_calls":[{"id":...,"type":"function","function":{"name":...,"arguments":"<JSON string>"}}]`
+- Note: `arguments` is a **JSON string**, not an object
+- Tool result → `role:"tool", tool_call_id:..., content:...`
+
+---
+
 ## What NOT to Do
 
 - Do not add sync wrappers to Python (use `asyncio.run()` at the call site)
 - Do not share code between Python and Rust via FFI or subprocess
 - Do not add provider-specific logic outside `providers/` (Python) or per-provider modules (Rust)
 - Do not break the `LlmClient` Protocol in motosan-chat compatibility
+
+---
+
+## Before Committing
+
+```bash
+# Rust
+cd sdks/rust
+cargo fmt
+cargo clippy --all-features -- -D warnings
+cargo test --all-features
+
+# Python
+cd sdks/python
+uv run ruff check .
+uv run pytest tests/ --ignore=tests/integration/
+```
+
+## Pre-push Gate
+
+A pre-push hook (`scripts/pre-push-gate.sh`) runs automatically:
+1. Python unit tests (mock)
+2. Rust unit tests (mock)
+3. Python live Anthropic integration tests
+4. Rust live Anthropic integration tests
+
+Live tests require `ANTHROPIC_API_KEY`. Skip with `git push --no-verify` in emergencies.
+
+## Releasing
+
+| SDK | Tag format | Triggers |
+|-----|-----------|----------|
+| Rust | `rust-v0.3.3` | `publish-rust.yml` → crates.io |
+| Python | `python-v0.4.2` | `publish-python.yml` → PyPI |
+
+Checklist:
+1. Update CHANGELOGs (`sdks/rust/CHANGELOG.md`, `sdks/python/CHANGELOG.md`)
+2. Bump version in `Cargo.toml` / `pyproject.toml`
+3. Update `AGENTS.md` + `llms.txt` + `skills/motosan-ai/SKILL.md` version numbers
+4. Commit, tag (`rust-vX.Y.Z` / `python-vX.Y.Z`), push with tags

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,66 @@
+# motosan-ai
+
+Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, and MiniMax — with streaming, tool use, and ThinkStripper built in.
+
+Current versions: Python 0.4.2 / Rust 0.3.3
+
+## Install
+
+```bash
+# Python — pick your providers
+pip install "motosan-ai[anthropic]"
+pip install "motosan-ai[openai]"
+pip install "motosan-ai[anthropic,openai,ollama,minimax]"
+
+# Rust — pick features in Cargo.toml
+motosan-ai = { version = "0.3.3", features = ["anthropic"] }
+# features: anthropic | openai | minimax | ollama | full
+```
+
+## Environment Variables
+
+| Provider | Env var |
+|----------|---------|
+| Anthropic | `ANTHROPIC_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| MiniMax | `MINIMAX_API_KEY` |
+| Ollama | (none — local) |
+
+## Quick Start (Python)
+
+```python
+from motosan_ai import Client, Provider, Message
+
+client = Client.anthropic()  # reads ANTHROPIC_API_KEY
+# or: Client.openai() / Client.ollama() / Client.minimax()
+
+resp = await client.chat([Message.user("Hello!")])
+print(resp.content)
+```
+
+## Quick Start (Rust)
+
+```rust
+use motosan_ai::{Client, Provider, Message};
+
+let client = Client::builder()
+    .provider(Provider::Anthropic)
+    .api_key(std::env::var("ANTHROPIC_API_KEY").unwrap())
+    .build();
+
+let resp = client.chat(vec![Message::user("Hello!")]).await?;
+println!("{}", resp.content);
+```
+
+## Guides
+
+- [Python API reference](https://raw.githubusercontent.com/motosan-dev/motosan-ai/main/skills/motosan-ai/references/python-api.md)
+- [Rust API reference](https://raw.githubusercontent.com/motosan-dev/motosan-ai/main/skills/motosan-ai/references/rust-api.md)
+- [Tool use & multi-turn](https://raw.githubusercontent.com/motosan-dev/motosan-ai/main/skills/motosan-ai/references/tool-use.md)
+- [Streaming & ThinkStripper](https://raw.githubusercontent.com/motosan-dev/motosan-ai/main/skills/motosan-ai/references/streaming.md)
+
+## Source
+
+- GitHub: https://github.com/motosan-dev/motosan-ai
+- PyPI: https://pypi.org/project/motosan-ai/
+- crates.io: https://crates.io/crates/motosan-ai

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: motosan-ai
+description: Help developers use the motosan-ai SDK (Python and Rust) — LLM chat, streaming, tool use, ThinkStripper, and multi-provider setup. Use when a user asks how to use motosan-ai, integrate an LLM provider (Anthropic, OpenAI, Ollama, MiniMax), implement streaming responses, handle tool calls, or filter <think> tags in LLM output.
+---
+
+# motosan-ai SDK
+
+Multi-provider LLM SDK — Python 0.4.2 / Rust 0.3.3
+
+## Install
+
+```bash
+# Python
+pip install "motosan-ai[anthropic]"          # Anthropic only
+pip install "motosan-ai[anthropic,openai]"   # Multiple providers
+
+# Rust (Cargo.toml)
+motosan-ai = { version = "0.3.3", features = ["anthropic"] }
+# features: anthropic | openai | minimax | ollama | ollama_native | full
+```
+
+## Environment Variables
+
+| Provider   | Env var              |
+|------------|----------------------|
+| Anthropic  | `ANTHROPIC_API_KEY`  |
+| OpenAI     | `OPENAI_API_KEY`     |
+| MiniMax    | `MINIMAX_API_KEY`    |
+| Ollama     | (none — local)       |
+
+## Minimal Example
+
+**Python:**
+```python
+from motosan_ai import Client, Message
+
+client = Client.anthropic()                    # reads ANTHROPIC_API_KEY
+resp = await client.chat([Message.user("Hi")]) # returns ChatResponse
+print(resp.content)                            # str
+```
+
+**Rust:**
+```rust
+use motosan_ai::{Client, Provider, Message};
+let client = Client::builder()
+    .provider(Provider::Anthropic)
+    .api_key(std::env::var("ANTHROPIC_API_KEY")?)
+    .build();
+let resp = client.chat(vec![Message::user("Hi")]).await?;
+println!("{}", resp.content);
+```
+
+## When to Read References
+
+| Task | File |
+|------|------|
+| Full Python API (`chat_with`, `stream`, `ChatRequest`, `Message` helpers, `RetryPolicy`) | `references/python-api.md` |
+| Full Rust API (`ClientBuilder`, `stream_with`, `BoxStream`, feature flags) | `references/rust-api.md` |
+| Tool calling, multi-turn tool loop | `references/tool-use.md` |
+| Streaming events, ThinkStripper | `references/streaming.md` |

--- a/skills/motosan-ai/references/python-api.md
+++ b/skills/motosan-ai/references/python-api.md
@@ -1,0 +1,117 @@
+# motosan-ai Python API Reference
+
+## Client Construction
+
+```python
+from motosan_ai import Client, Provider
+
+# Factory methods (read env var automatically)
+client = Client.anthropic(model="claude-3-5-sonnet-20241022")
+client = Client.openai(model="gpt-4o")
+client = Client.minimax(model="MiniMax-Text-01")
+client = Client.ollama(model="llama3.2", base_url="http://localhost:11434")
+```
+
+## Core Methods
+
+### `chat()` — single-turn
+
+```python
+resp = await client.chat([Message.user("Hello")])
+# resp.content: str
+# resp.usage.input_tokens: int
+# resp.usage.output_tokens: int
+# resp.stop_reason: StopReason
+```
+
+### `chat_with()` — full control
+
+```python
+from motosan_ai import ChatRequest, Message
+
+req = ChatRequest(
+    messages=[Message.user("Hello")],
+    model="claude-3-5-sonnet-20241022",   # override default
+    system="You are a helpful assistant.",
+    temperature=0.7,
+    max_tokens=1024,
+    tools=[...],                           # see tool-use.md
+    provider_options={"extra_key": "val"}, # escape hatch
+)
+resp = await client.chat_with(req)
+```
+
+### `stream()` — streaming text
+
+```python
+async for event in await client.stream([Message.user("Tell me a story")]):
+    if event.event_type == "text":
+        print(event.content, end="", flush=True)
+    if event.done:
+        break
+```
+
+### `stream_with()` — streaming + tools + full control
+
+```python
+async for event in await client.stream_with(ChatRequest(
+    messages=messages,
+    tools=tools,
+    system="...",
+)):
+    # handle events — see streaming.md
+```
+
+## Message Helpers
+
+```python
+from motosan_ai import Message, Role
+
+Message.user("Hello")
+Message.assistant("Hi there")
+Message.system("You are a helpful assistant")
+Message.assistant_with_tool_calls("", tool_calls=[...])
+Message.tool_result(tool_call_id="call_123", content='{"result": 42}')
+
+# Manual construction
+Message(role=Role.user, content="Hello")
+```
+
+## StreamEvent Fields
+
+```python
+event.event_type   # "text" | "tool_call_start" | "tool_call_args" | "tool_call_end"
+event.content      # str — text delta or empty
+event.done         # bool — True on last event
+event.tool_call_id    # str | None
+event.tool_call_name  # str | None (on tool_call_start)
+event.tool_call_args_delta  # str | None (on tool_call_args)
+```
+
+## RetryPolicy
+
+```python
+from motosan_ai import RetryPolicy
+
+client = Client.anthropic(
+    retry_policy=RetryPolicy(
+        max_retries=3,
+        base_delay_ms=500,
+        max_delay_ms=10000,
+        jitter=True,
+    )
+)
+```
+
+## ThinkStripper
+
+Applied automatically at `client.stream()` level — `<think>` blocks are stripped transparently.
+
+Manual use:
+```python
+from motosan_ai import ThinkStripper
+
+stripper = ThinkStripper()
+clean = stripper.feed("<think>reasoning...</think>Hello")  # → "Hello"
+tail  = stripper.flush()  # call at stream end to flush buffer
+```

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -1,0 +1,122 @@
+# motosan-ai Rust API Reference
+
+## Cargo.toml
+
+```toml
+[dependencies]
+motosan-ai = { version = "0.3.3", features = ["anthropic"] }
+# features: anthropic | openai | minimax | ollama | ollama_native | full
+```
+
+## ClientBuilder
+
+```rust
+use motosan_ai::{Client, Provider, RetryPolicy};
+
+let client = Client::builder()
+    .provider(Provider::Anthropic)
+    .api_key(std::env::var("ANTHROPIC_API_KEY")?)
+    .model("claude-3-5-sonnet-20241022")           // optional
+    .retry_policy(RetryPolicy::new())              // optional
+    .build();
+```
+
+Provider variants: `Provider::Anthropic` | `Provider::OpenAI` | `Provider::MiniMax` | `Provider::Ollama`
+
+## Core Methods
+
+### `chat()` — single-turn
+
+```rust
+use motosan_ai::Message;
+
+let resp = client.chat(vec![Message::user("Hello")]).await?;
+println!("{}", resp.content);
+println!("tokens: {}+{}", resp.usage.input_tokens, resp.usage.output_tokens);
+```
+
+### `chat_with()` — full control
+
+```rust
+use motosan_ai::{ChatRequest, Message};
+
+let resp = client.chat_with(ChatRequest {
+    messages: vec![Message::user("Hello")],
+    model: Some("claude-3-5-sonnet-20241022".into()),
+    system: Some("You are a helpful assistant.".into()),
+    temperature: Some(0.7),
+    max_tokens: Some(1024),
+    tools: Some(vec![...]),           // see tool-use.md
+    provider_options: None,
+}).await?;
+```
+
+### `stream()` — streaming
+
+```rust
+use futures_util::StreamExt;
+
+let mut stream = client.stream(vec![Message::user("Tell me a story")]).await?;
+while let Some(event) = stream.next().await {
+    let event = event?;
+    if event.is_text() {
+        print!("{}", event.content);
+    }
+    if event.done { break; }
+}
+```
+
+### `stream_with()` — streaming + tools
+
+```rust
+let mut stream = client.stream_with(ChatRequest {
+    messages,
+    tools: Some(tools),
+    ..Default::default()
+}).await?;
+```
+
+## StreamEvent
+
+```rust
+event.event_type           // StreamEventType enum
+event.content              // String
+event.done                 // bool
+event.tool_call_id         // Option<String>
+event.tool_call_name       // Option<String>
+event.tool_call_args_delta // Option<String>
+
+// Convenience
+event.is_text()            // event_type == Text
+event.is_tool_call_start()
+event.is_tool_call_end()
+```
+
+## Message Helpers
+
+```rust
+Message::user("Hello")
+Message::assistant("Hi")
+Message::system("You are helpful")
+Message::tool_result("call_id", json_string)
+```
+
+## RetryPolicy
+
+```rust
+use motosan_ai::RetryPolicy;
+
+RetryPolicy {
+    max_retries: 3,
+    base_delay_ms: 500,
+    max_delay_ms: 10_000,
+    jitter: true,
+    respect_retry_after: true,
+}
+```
+
+## BoxStream Type
+
+`stream()` and `stream_with()` return `Result<BoxStream, MotosanError>` where `BoxStream = Pin<Box<dyn Stream<Item = Result<StreamEvent, MotosanError>> + Send>>`.
+
+Consume with `futures_util::StreamExt::next()` in a loop.

--- a/skills/motosan-ai/references/streaming.md
+++ b/skills/motosan-ai/references/streaming.md
@@ -1,0 +1,108 @@
+# Streaming & ThinkStripper
+
+## Basic Streaming (Python)
+
+```python
+from motosan_ai import Client, Message
+
+client = Client.anthropic()
+stream = await client.stream([Message.user("Tell me a story")])
+
+full_text = ""
+async for event in stream:
+    if event.event_type == "text" and event.content:
+        print(event.content, end="", flush=True)
+        full_text += event.content
+    if event.done:
+        break
+
+print()  # newline after stream
+```
+
+## event_type Values
+
+| event_type | Meaning | Fields set |
+|------------|---------|-----------|
+| `"text"` | Text delta | `content` |
+| `"tool_call_start"` | Tool call begins | `tool_call_id`, `tool_call_name` |
+| `"tool_call_args"` | Tool args delta | `tool_call_args_delta`, `tool_call_id` |
+| `"tool_call_end"` | Tool call complete | `tool_call_id` |
+
+## Streaming with Tools (Python)
+
+```python
+pending_args: dict[str, str] = {}  # tool_call_id → accumulated args
+pending_name: dict[str, str] = {}
+
+async for event in await client.stream_with(req):
+    match event.event_type:
+        case "text":
+            print(event.content, end="", flush=True)
+        case "tool_call_start":
+            pending_name[event.tool_call_id] = event.tool_call_name
+            pending_args[event.tool_call_id] = ""
+        case "tool_call_args":
+            pending_args[event.tool_call_id] += event.tool_call_args_delta
+        case "tool_call_end":
+            call_id = event.tool_call_id
+            args = json.loads(pending_args[call_id])
+            result = await execute_tool(pending_name[call_id], args)
+            # append to messages and continue loop
+    if event.done:
+        break
+```
+
+## Basic Streaming (Rust)
+
+```rust
+use futures_util::StreamExt;
+
+let mut stream = client.stream(vec![Message::user("Tell me a story")]).await?;
+let mut full_text = String::new();
+
+while let Some(event) = stream.next().await {
+    let event = event?;
+    if event.is_text() && !event.content.is_empty() {
+        print!("{}", event.content);
+        full_text.push_str(&event.content);
+    }
+    if event.done { break; }
+}
+```
+
+## ThinkStripper
+
+`<think>` blocks in LLM output (e.g. from DeepSeek, QwQ) are stripped **automatically** at `client.stream()` level.
+
+If you need manual control:
+
+```python
+from motosan_ai import ThinkStripper
+
+stripper = ThinkStripper()
+
+async for event in stream:
+    if event.event_type == "text":
+        clean = stripper.feed(event.content)  # strips <think>...</think>
+        if clean:
+            print(clean, end="")
+
+# After stream ends — flush any remaining buffer
+tail = stripper.flush()
+if tail:
+    print(tail)
+```
+
+**Why stateful?** `<think>` tags can span multiple chunks:
+```
+chunk 1: "<thi"
+chunk 2: "nk>reasoning"
+chunk 3: "...</think>actual reply"
+```
+Per-chunk regex fails here. `ThinkStripper` buffers internally and only emits safe text.
+
+## Ollama / MiniMax Notes
+
+- **Ollama**: streaming uses NDJSON (not SSE). SDK handles automatically.
+- **MiniMax**: may emit reasoning text before tool calls — ThinkStripper handles this.
+- **Anthropic**: `tool_call_id` comes on `content_block_start`, NOT on `content_block_delta` — SDK normalizes this.

--- a/skills/motosan-ai/references/tool-use.md
+++ b/skills/motosan-ai/references/tool-use.md
@@ -1,0 +1,129 @@
+# Tool Use & Multi-turn Loop
+
+## Define a Tool
+
+**Python:**
+```python
+from motosan_ai import Tool
+
+tools = [
+    Tool(
+        name="get_weather",
+        description="Get current weather for a city",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name"}
+            },
+            "required": ["city"]
+        }
+    )
+]
+```
+
+**Rust:**
+```rust
+use motosan_ai::{Tool, serde_json::json};
+
+let tools = vec![Tool {
+    name: "get_weather".into(),
+    description: Some("Get current weather for a city".into()),
+    input_schema: Some(json!({
+        "type": "object",
+        "properties": {
+            "city": {"type": "string"}
+        },
+        "required": ["city"]
+    })),
+}];
+```
+
+## Multi-turn Tool Loop (Python)
+
+```python
+from motosan_ai import Client, Message, ChatRequest
+import json
+
+async def run_with_tools(client, user_input: str, tools):
+    messages = [Message.user(user_input)]
+
+    while True:
+        resp = await client.chat_with(ChatRequest(
+            messages=messages,
+            tools=tools,
+        ))
+
+        if resp.stop_reason != "tool_use" or not resp.tool_calls:
+            return resp.content   # done
+
+        # Append assistant message with tool calls
+        messages.append(Message.assistant_with_tool_calls(
+            content=resp.content,
+            tool_calls=resp.tool_calls,
+        ))
+
+        # Execute each tool and append results
+        for tool_call in resp.tool_calls:
+            result = await execute_tool(tool_call.name, tool_call.input)
+            messages.append(Message.tool_result(
+                tool_call_id=tool_call.id,
+                content=json.dumps(result),
+            ))
+
+async def execute_tool(name: str, input: dict):
+    if name == "get_weather":
+        return {"temp": "22°C", "condition": "sunny", "city": input["city"]}
+    raise ValueError(f"Unknown tool: {name}")
+```
+
+## Multi-turn Tool Loop (Rust)
+
+```rust
+use motosan_ai::{Client, Message, ChatRequest, StopReason};
+use serde_json::json;
+
+async fn run_with_tools(client: &Client, user_input: &str, tools: Vec<Tool>)
+    -> Result<String, Box<dyn std::error::Error>>
+{
+    let mut messages = vec![Message::user(user_input)];
+
+    loop {
+        let resp = client.chat_with(ChatRequest {
+            messages: messages.clone(),
+            tools: Some(tools.clone()),
+            ..Default::default()
+        }).await?;
+
+        if resp.stop_reason != StopReason::ToolUse || resp.tool_calls.is_empty() {
+            return Ok(resp.content);
+        }
+
+        // Append assistant turn
+        messages.push(Message::assistant_with_tool_calls(&resp.content, resp.tool_calls.clone()));
+
+        // Execute tools and append results
+        for tool_call in &resp.tool_calls {
+            let result = execute_tool(&tool_call.name, &tool_call.input).await?;
+            messages.push(Message::tool_result(&tool_call.id, &result.to_string()));
+        }
+    }
+}
+```
+
+## ToolCall Fields
+
+```python
+tool_call.id      # str — unique call id (required for tool_result)
+tool_call.name    # str — which tool to call
+tool_call.input   # dict[str, Any] — parsed arguments
+```
+
+## Streaming Tool Events (event_type sequence)
+
+```
+tool_call_start  → event.tool_call_id, event.tool_call_name set
+tool_call_args   → event.tool_call_args_delta accumulates JSON string
+tool_call_end    → full args received, tool_call_id set
+```
+
+Buffer `tool_call_args_delta` until `tool_call_end`, then `json.loads()`.


### PR DESCRIPTION
## Summary

三種 agent 整合方式一次到位：

### 1. `llms.txt` — 通用（Stripe 風格）
- 任何有 web access 的 agent 都能 `fetch_url("https://raw.githubusercontent.com/motosan-dev/motosan-ai/main/llms.txt")`
- 包含安裝指令、環境變數、Provider 一覽、guides 連結

### 2. `AGENTS.md` — 貢獻者用（Vercel AI SDK 風格）
- 更新版本（Python 0.4.2 / Rust 0.3.3）
- 加入 repo 結構、設計決策、常用指令、禁忌

### 3. `skills/motosan-ai/` — OpenClaw Skill
- `SKILL.md`：觸發 description + 快速上手
- `references/python-api.md`：完整 Python API
- `references/rust-api.md`：完整 Rust API + feature flags
- `references/tool-use.md`：Tool 定義 + multi-turn loop（Python + Rust）
- `references/streaming.md`：event_type 處理 + ThinkStripper

## 使用方式

**Claude Code / Cursor（引用這個 repo 的開發者）：**
```
fetch_url 取 llms.txt → 按需取 references/*.md
```

**OpenClaw 用戶：**
```bash
clawhub install motosan-ai   # 之後自動觸發
```

**在 repo 裡工作的貢獻者：**
Claude Code 自動讀 `AGENTS.md`