### PR TITLE
feat: add ContentBlock and ImageSource types

### DIFF
--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -17,6 +17,6 @@ pub use providers::Provider;
 pub use retry::RetryPolicy;
 pub use stream::{BoxStream, StreamEvent};
 pub use types::{
-    ChatRequest, ChatRequestBuilder, ChatResponse, Message, Role, StopReason, StreamEventType,
-    Tool, ToolCall, Usage,
+    ChatRequest, ChatRequestBuilder, ChatResponse, ContentBlock, ImageSource, Message, Role,
+    StopReason, StreamEventType, Tool, ToolCall, Usage,
 };

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -203,6 +203,20 @@ pub enum StreamEventType {
     ToolCallEnd,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlock {
+    Text { text: String },
+    Image { source: ImageSource },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ImageSource {
+    Base64 { media_type: String, data: String },
+    Url { url: String },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StreamEvent {
     pub content: String,

--- a/sdks/rust/tests/vision_types.rs
+++ b/sdks/rust/tests/vision_types.rs
@@ -1,0 +1,59 @@
+use motosan_ai::{ContentBlock, ImageSource};
+
+#[test]
+fn content_block_text_serialization() {
+    let block = ContentBlock::Text {
+        text: "hello".to_string(),
+    };
+    let json = serde_json::to_value(&block).unwrap();
+    assert_eq!(json["type"], "text");
+    assert_eq!(json["text"], "hello");
+}
+
+#[test]
+fn content_block_image_base64_serialization() {
+    let block = ContentBlock::Image {
+        source: ImageSource::Base64 {
+            media_type: "image/png".to_string(),
+            data: "iVBOR...".to_string(),
+        },
+    };
+    let json = serde_json::to_value(&block).unwrap();
+    assert_eq!(json["type"], "image");
+    assert_eq!(json["source"]["type"], "base64");
+    assert_eq!(json["source"]["media_type"], "image/png");
+}
+
+#[test]
+fn content_block_image_url_serialization() {
+    let block = ContentBlock::Image {
+        source: ImageSource::Url {
+            url: "https://example.com/image.png".to_string(),
+        },
+    };
+    let json = serde_json::to_value(&block).unwrap();
+    assert_eq!(json["type"], "image");
+    assert_eq!(json["source"]["type"], "url");
+    assert_eq!(json["source"]["url"], "https://example.com/image.png");
+}
+
+#[test]
+fn content_block_roundtrip() {
+    let block = ContentBlock::Text {
+        text: "test".to_string(),
+    };
+    let json = serde_json::to_string(&block).unwrap();
+    let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed, block);
+}
+
+#[test]
+fn image_source_roundtrip() {
+    let source = ImageSource::Base64 {
+        media_type: "image/jpeg".to_string(),
+        data: "abc123".to_string(),
+    };
+    let json = serde_json::to_string(&source).unwrap();
+    let parsed: ImageSource = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed, source);
+}


### PR DESCRIPTION
## Summary
- Add `ContentBlock` enum (`Text`, `Image`) with `#[serde(tag = "type")]` for Anthropic-compatible JSON
- Add `ImageSource` enum (`Base64`, `Url`) for image content
- Export both types from lib.rs
- Add 5 serialization/roundtrip tests

Closes #116

## Test plan
- [x] `cargo test --test vision_types` (5/5 pass)
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)