### PR TITLE
feat: add content_blocks field to Message

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -251,8 +251,8 @@ impl ProviderImpl for AnthropicProvider {
                         }
                     }
                     crate::types::StreamEventType::ToolCallEnd => {
-                        let input: serde_json::Value = serde_json::from_str(&current_tc_args)
-                            .unwrap_or_else(|_| json!({}));
+                        let input: serde_json::Value =
+                            serde_json::from_str(&current_tc_args).unwrap_or_else(|_| json!({}));
                         tool_calls.push(ToolCall {
                             id: std::mem::take(&mut current_tc_id),
                             name: std::mem::take(&mut current_tc_name),
@@ -272,7 +272,10 @@ impl ProviderImpl for AnthropicProvider {
             return Ok(ChatResponse {
                 content,
                 model: self.model.clone(),
-                usage: crate::types::Usage { input_tokens: 0, output_tokens: 0 },
+                usage: crate::types::Usage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                },
                 stop_reason,
                 tool_calls,
             });
@@ -432,12 +435,18 @@ impl ProviderImpl for AnthropicProvider {
                         }
                     }
                 }
-                let sys = if sys_parts.is_empty() { None } else { Some(sys_parts.join("\n")) };
+                let sys = if sys_parts.is_empty() {
+                    None
+                } else {
+                    Some(sys_parts.join("\n"))
+                };
                 (msgs, sys)
             };
             let user_system = req.system.or(extracted_system);
             let prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
-            let mut system_blocks = vec![json!({"type": "text", "text": prefix, "cache_control": {"type": "ephemeral"}})];
+            let mut system_blocks = vec![
+                json!({"type": "text", "text": prefix, "cache_control": {"type": "ephemeral"}}),
+            ];
             if let Some(s) = user_system {
                 system_blocks.push(json!({"type": "text", "text": s}));
             }
@@ -465,7 +474,9 @@ impl ProviderImpl for AnthropicProvider {
             }
             if let Some(po) = req.provider_options {
                 if let Some(map) = po.as_object() {
-                    for (k, v) in map { body[k] = v.clone(); }
+                    for (k, v) in map {
+                        body[k] = v.clone();
+                    }
                 }
             }
             body

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -14,6 +14,8 @@ pub enum Role {
 pub struct Message {
     pub role: Role,
     pub content: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content_blocks: Vec<ContentBlock>,
     pub tool_call_id: Option<String>,
     pub tool_calls: Vec<ToolCall>,
 }
@@ -23,6 +25,7 @@ impl Message {
         Self {
             role: Role::User,
             content: content.into(),
+            content_blocks: vec![],
             tool_call_id: None,
             tool_calls: Vec::new(),
         }
@@ -32,6 +35,7 @@ impl Message {
         Self {
             role: Role::Assistant,
             content: content.into(),
+            content_blocks: vec![],
             tool_call_id: None,
             tool_calls: Vec::new(),
         }
@@ -44,6 +48,7 @@ impl Message {
         Self {
             role: Role::Assistant,
             content: content.into(),
+            content_blocks: vec![],
             tool_call_id: None,
             tool_calls,
         }
@@ -53,6 +58,7 @@ impl Message {
         Self {
             role: Role::System,
             content: content.into(),
+            content_blocks: vec![],
             tool_call_id: None,
             tool_calls: Vec::new(),
         }
@@ -66,8 +72,50 @@ impl Message {
         Self {
             role: Role::Tool,
             content: content.into(),
+            content_blocks: vec![],
             tool_call_id: Some(tool_call_id.into()),
             tool_calls: Vec::new(),
+        }
+    }
+
+    /// Create a user message with an image (base64)
+    pub fn user_with_image(text: &str, base64_data: &str, media_type: &str) -> Self {
+        Self {
+            role: Role::User,
+            content: text.to_string(),
+            content_blocks: vec![
+                ContentBlock::Text {
+                    text: text.to_string(),
+                },
+                ContentBlock::Image {
+                    source: ImageSource::Base64 {
+                        media_type: media_type.to_string(),
+                        data: base64_data.to_string(),
+                    },
+                },
+            ],
+            tool_call_id: None,
+            tool_calls: vec![],
+        }
+    }
+
+    /// Create a user message with multiple content blocks
+    pub fn user_with_blocks(blocks: Vec<ContentBlock>) -> Self {
+        // Extract text from first text block for backward compat content field
+        let content = blocks
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.clone()),
+                _ => None,
+            })
+            .unwrap_or_default();
+
+        Self {
+            role: Role::User,
+            content,
+            content_blocks: blocks,
+            tool_call_id: None,
+            tool_calls: vec![],
         }
     }
 }
@@ -203,14 +251,14 @@ pub enum StreamEventType {
     ToolCallEnd,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentBlock {
     Text { text: String },
     Image { source: ImageSource },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ImageSource {
     Base64 { media_type: String, data: String },

--- a/sdks/rust/tests/anthropic_chat.rs
+++ b/sdks/rust/tests/anthropic_chat.rs
@@ -120,7 +120,10 @@ async fn anthropic_setup_token_uses_bearer_and_oauth_beta_header() {
     let mock = server
         .mock("POST", "/v1/messages")
         .match_header("authorization", "Bearer sk-ant-oat01-test-token")
-        .match_header("anthropic-beta", Matcher::Regex("oauth-2025-04-20".to_string()))
+        .match_header(
+            "anthropic-beta",
+            Matcher::Regex("oauth-2025-04-20".to_string()),
+        )
         .match_header("anthropic-version", "2023-06-01")
         .with_status(200)
         .with_header("content-type", "text/event-stream")

--- a/sdks/rust/tests/anthropic_live.rs
+++ b/sdks/rust/tests/anthropic_live.rs
@@ -113,9 +113,7 @@ async fn live_system_prompt() {
     };
 
     let request = ChatRequest::builder()
-        .message(Message::user(
-            "What is your name? Reply in one sentence.",
-        ))
+        .message(Message::user("What is your name? Reply in one sentence."))
         .system("Your name is TestBot. Always introduce yourself as TestBot.")
         .build();
 
@@ -165,9 +163,7 @@ async fn live_tool_use_single_turn() {
     };
 
     let request = ChatRequest::builder()
-        .message(Message::user(
-            "What's the weather in Tokyo? Use the tool.",
-        ))
+        .message(Message::user("What's the weather in Tokyo? Use the tool."))
         .tools(vec![Tool {
             name: "get_weather".to_string(),
             description: Some("Get current weather for a city".to_string()),
@@ -237,10 +233,7 @@ async fn live_tool_use_multi_turn() {
         .messages(vec![
             Message::user("What's the weather in Taipei? Use get_weather tool."),
             Message::assistant_with_tool_calls(&resp1.content, resp1.tool_calls.clone()),
-            Message::tool_result(
-                &tc.id,
-                r#"{"temperature": 28, "condition": "Sunny"}"#,
-            ),
+            Message::tool_result(&tc.id, r#"{"temperature": 28, "condition": "Sunny"}"#),
         ])
         .tools(tools)
         .build();
@@ -268,9 +261,7 @@ async fn live_stream_tool_use() {
     };
 
     let request = ChatRequest::builder()
-        .message(Message::user(
-            "Use the calculate tool to compute 2+2.",
-        ))
+        .message(Message::user("Use the calculate tool to compute 2+2."))
         .tools(vec![Tool {
             name: "calculate".to_string(),
             description: Some("Calculate a math expression".to_string()),
@@ -282,10 +273,7 @@ async fn live_stream_tool_use() {
         }])
         .build();
 
-    let mut stream = client
-        .stream_with(request)
-        .await
-        .expect("stream failed");
+    let mut stream = client.stream_with(request).await.expect("stream failed");
 
     let mut events = Vec::new();
     while let Some(event) = stream.next().await {
@@ -316,10 +304,7 @@ async fn live_stream_tool_use() {
         .iter()
         .filter(|e| e.event_type == StreamEventType::ToolCallStart)
         .collect();
-    assert_eq!(
-        starts[0].tool_call_name.as_deref(),
-        Some("calculate")
-    );
+    assert_eq!(starts[0].tool_call_name.as_deref(), Some("calculate"));
     assert!(starts[0].tool_call_id.is_some());
 
     let args: String = events
@@ -327,8 +312,7 @@ async fn live_stream_tool_use() {
         .filter(|e| e.event_type.clone() == StreamEventType::ToolCallArgs)
         .filter_map(|e| e.tool_call_args_delta.as_deref())
         .collect();
-    let parsed: serde_json::Value =
-        serde_json::from_str(&args).expect("failed to parse tool args");
+    let parsed: serde_json::Value = serde_json::from_str(&args).expect("failed to parse tool args");
     assert!(
         parsed.get("expression").is_some(),
         "Expected expression in args, got: {:?}",

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -108,7 +108,10 @@ async fn anthropic_stream_setup_token_uses_bearer_and_oauth_beta_header() {
     let mock = server
         .mock("POST", "/v1/messages")
         .match_header("authorization", "Bearer sk-ant-oat01-stream-token")
-        .match_header("anthropic-beta", Matcher::Regex("oauth-2025-04-20".to_string()))
+        .match_header(
+            "anthropic-beta",
+            Matcher::Regex("oauth-2025-04-20".to_string()),
+        )
         .match_header("anthropic-version", "2023-06-01")
         .with_status(200)
         .with_header("content-type", "text/event-stream")

--- a/sdks/rust/tests/vision_message.rs
+++ b/sdks/rust/tests/vision_message.rs
@@ -1,0 +1,70 @@
+use motosan_ai::{ContentBlock, ImageSource, Message, Role};
+
+#[test]
+fn user_with_image_creates_correct_blocks() {
+    let msg = Message::user_with_image("describe this", "base64data", "image/png");
+    assert_eq!(msg.role, Role::User);
+    assert_eq!(msg.content, "describe this");
+    assert_eq!(msg.content_blocks.len(), 2);
+    assert!(
+        matches!(&msg.content_blocks[0], ContentBlock::Text { text } if text == "describe this")
+    );
+    assert!(matches!(&msg.content_blocks[1], ContentBlock::Image { .. }));
+}
+
+#[test]
+fn user_with_blocks_extracts_text() {
+    let msg = Message::user_with_blocks(vec![
+        ContentBlock::Text {
+            text: "hello".to_string(),
+        },
+        ContentBlock::Image {
+            source: ImageSource::Url {
+                url: "https://example.com/img.png".to_string(),
+            },
+        },
+    ]);
+    assert_eq!(msg.content, "hello");
+    assert_eq!(msg.content_blocks.len(), 2);
+}
+
+#[test]
+fn existing_user_constructor_has_empty_blocks() {
+    let msg = Message::user("hello");
+    assert!(msg.content_blocks.is_empty());
+    assert_eq!(msg.content, "hello");
+}
+
+#[test]
+fn message_with_blocks_serialization_skips_empty() {
+    let msg = Message::user("hello");
+    let json = serde_json::to_value(&msg).unwrap();
+    // content_blocks should not be in JSON when empty
+    assert!(json.get("content_blocks").is_none());
+}
+
+#[test]
+fn message_with_blocks_serialization_includes_when_present() {
+    let msg = Message::user_with_image("describe", "data", "image/png");
+    let json = serde_json::to_value(&msg).unwrap();
+    assert!(json.get("content_blocks").is_some());
+    assert_eq!(json["content_blocks"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn message_roundtrip_with_blocks() {
+    let msg = Message::user_with_image("test", "abc", "image/jpeg");
+    let json = serde_json::to_string(&msg).unwrap();
+    let parsed: Message = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.content_blocks.len(), 2);
+    assert_eq!(parsed.content, "test");
+}
+
+#[test]
+fn message_roundtrip_without_blocks() {
+    let msg = Message::user("plain text");
+    let json = serde_json::to_string(&msg).unwrap();
+    let parsed: Message = serde_json::from_str(&json).unwrap();
+    assert!(parsed.content_blocks.is_empty());
+    assert_eq!(parsed.content, "plain text");
+}


### PR DESCRIPTION
## Summary
- Add `content_blocks: Vec<ContentBlock>` to Message struct with `#[serde(default, skip_serializing_if = "Vec::is_empty")]`
- Add `user_with_image()` and `user_with_blocks()` constructors
- Add `Eq` derive to ContentBlock and ImageSource
- Update all existing constructors with `content_blocks: vec![]`
- 7 new tests, all existing tests still pass

Closes #117

## Test plan
- [x] `cargo test --test vision_message` (7/7 pass)
- [x] `cargo test --lib` (8/8 pass)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)