### PR TITLE
feat: serialize content_blocks in Anthropic and OpenAI providers

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -8,7 +8,9 @@ use crate::providers::{
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Role, StopReason, StreamEvent, ToolCall};
+use crate::types::{
+    ChatRequest, ChatResponse, ContentBlock, ImageSource, Role, StopReason, StreamEvent, ToolCall,
+};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures_core::Stream;
@@ -121,7 +123,25 @@ impl AnthropicRequestBuilder {
             match message.role {
                 Role::System => extracted_systems.push(message.content.clone()),
                 Role::User => {
-                    if self.oauth {
+                    if !message.content_blocks.is_empty() {
+                        // Use structured content blocks (vision/multimodal)
+                        let blocks: Vec<Value> = message.content_blocks.iter().map(|block| {
+                            match block {
+                                ContentBlock::Text { text } => json!({"type": "text", "text": text}),
+                                ContentBlock::Image { source } => match source {
+                                    ImageSource::Base64 { media_type, data } => json!({
+                                        "type": "image",
+                                        "source": {"type": "base64", "media_type": media_type, "data": data}
+                                    }),
+                                    ImageSource::Url { url } => json!({
+                                        "type": "image",
+                                        "source": {"type": "url", "url": url}
+                                    }),
+                                },
+                            }
+                        }).collect();
+                        messages.push(json!({"role": "user", "content": blocks}));
+                    } else if self.oauth {
                         messages.push(json!({"role": "user", "content": [{"type": "text", "text": message.content}]}));
                     } else {
                         messages.push(json!({"role": "user", "content": message.content}));

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -6,7 +6,9 @@ use crate::providers::{
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-use crate::types::{ChatRequest, ChatResponse, Role, StopReason, StreamEvent, ToolCall};
+use crate::types::{
+    ChatRequest, ChatResponse, ContentBlock, ImageSource, Role, StopReason, StreamEvent, ToolCall,
+};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures_core::Stream;
@@ -299,7 +301,29 @@ impl OpenAIRequestBuilder {
 
         for message in &self.req.messages {
             match message.role {
-                Role::User => messages.push(json!({"role": "user", "content": message.content})),
+                Role::User => {
+                    if !message.content_blocks.is_empty() {
+                        // Use structured content blocks (vision/multimodal)
+                        let blocks: Vec<Value> = message.content_blocks.iter().map(|block| {
+                            match block {
+                                ContentBlock::Text { text } => json!({"type": "text", "text": text}),
+                                ContentBlock::Image { source } => match source {
+                                    ImageSource::Base64 { media_type, data } => json!({
+                                        "type": "image_url",
+                                        "image_url": {"url": format!("data:{media_type};base64,{data}")}
+                                    }),
+                                    ImageSource::Url { url } => json!({
+                                        "type": "image_url",
+                                        "image_url": {"url": url}
+                                    }),
+                                },
+                            }
+                        }).collect();
+                        messages.push(json!({"role": "user", "content": blocks}));
+                    } else {
+                        messages.push(json!({"role": "user", "content": message.content}));
+                    }
+                }
                 Role::Assistant => {
                     if message.tool_calls.is_empty() {
                         messages.push(json!({"role": "assistant", "content": message.content}));

--- a/sdks/rust/tests/vision_anthropic.rs
+++ b/sdks/rust/tests/vision_anthropic.rs
@@ -1,0 +1,106 @@
+#![cfg(feature = "anthropic")]
+
+use motosan_ai::providers::anthropic::AnthropicProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, ContentBlock, ImageSource, Message};
+use serde_json::json;
+
+#[tokio::test]
+async fn anthropic_vision_request_serializes_content_blocks() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_body(mockito::Matcher::Regex(
+            r#""type"\s*:\s*"image""#.to_string(),
+        ))
+        .with_body(
+            json!({
+                "content": [{"type": "text", "text": "I see a cat"}],
+                "model": "claude-sonnet-4-20250514",
+                "role": "assistant",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 100, "output_tokens": 10}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+
+    let msg = Message::user_with_image("What is in this image?", "iVBOR...", "image/png");
+    let request = ChatRequest::builder().messages(vec![msg]).build();
+
+    let response = provider.chat(request).await.unwrap();
+    assert_eq!(response.content, "I see a cat");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn anthropic_plain_text_still_works() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_body(mockito::Matcher::Regex(
+            r#""content"\s*:\s*"hello""#.to_string(),
+        ))
+        .with_body(
+            json!({
+                "content": [{"type": "text", "text": "hi"}],
+                "model": "claude-sonnet-4-20250514",
+                "role": "assistant",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 2}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+
+    let msg = Message::user("hello");
+    let request = ChatRequest::builder().messages(vec![msg]).build();
+
+    let response = provider.chat(request).await.unwrap();
+    assert_eq!(response.content, "hi");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn anthropic_url_image_serializes_correctly() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_body(mockito::Matcher::Regex(r#""type"\s*:\s*"url""#.to_string()))
+        .with_body(
+            json!({
+                "content": [{"type": "text", "text": "A landscape photo"}],
+                "model": "claude-sonnet-4-20250514",
+                "role": "assistant",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 50, "output_tokens": 5}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+
+    let msg = Message::user_with_blocks(vec![
+        ContentBlock::Text {
+            text: "Describe this image".to_string(),
+        },
+        ContentBlock::Image {
+            source: ImageSource::Url {
+                url: "https://example.com/photo.jpg".to_string(),
+            },
+        },
+    ]);
+    let request = ChatRequest::builder().messages(vec![msg]).build();
+
+    let response = provider.chat(request).await.unwrap();
+    assert_eq!(response.content, "A landscape photo");
+    mock.assert_async().await;
+}

--- a/sdks/rust/tests/vision_openai.rs
+++ b/sdks/rust/tests/vision_openai.rs
@@ -1,0 +1,131 @@
+#![cfg(feature = "openai")]
+
+use motosan_ai::providers::openai::OpenAIProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, ContentBlock, ImageSource, Message};
+use serde_json::json;
+
+#[tokio::test]
+async fn openai_vision_request_serializes_content_blocks() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r#""type"\s*:\s*"image_url""#.to_string(),
+        ))
+        .with_body(
+            json!({
+                "choices": [{"message": {"role": "assistant", "content": "I see a cat"}, "finish_reason": "stop"}],
+                "model": "gpt-4o",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 10}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+
+    let msg = Message::user_with_image("What is in this image?", "iVBOR...", "image/png");
+    let request = ChatRequest::builder().messages(vec![msg]).build();
+
+    let response = provider.chat(request).await.unwrap();
+    assert_eq!(response.content, "I see a cat");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_vision_base64_uses_data_url_format() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r#"data:image/png;base64,"#.to_string(),
+        ))
+        .with_body(
+            json!({
+                "choices": [{"message": {"role": "assistant", "content": "A PNG image"}, "finish_reason": "stop"}],
+                "model": "gpt-4o",
+                "usage": {"prompt_tokens": 50, "completion_tokens": 5}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+
+    let msg = Message::user_with_image("Describe this", "abc123==", "image/png");
+    let request = ChatRequest::builder().messages(vec![msg]).build();
+
+    let response = provider.chat(request).await.unwrap();
+    assert_eq!(response.content, "A PNG image");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_plain_text_still_works() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r#""content"\s*:\s*"hello""#.to_string(),
+        ))
+        .with_body(
+            json!({
+                "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+                "model": "gpt-4o",
+                "usage": {"prompt_tokens": 5, "completion_tokens": 2}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+
+    let msg = Message::user("hello");
+    let request = ChatRequest::builder().messages(vec![msg]).build();
+
+    let response = provider.chat(request).await.unwrap();
+    assert_eq!(response.content, "hi");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_url_image_serializes_correctly() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r#""url"\s*:\s*"https://"#.to_string(),
+        ))
+        .with_body(
+            json!({
+                "choices": [{"message": {"role": "assistant", "content": "A landscape"}, "finish_reason": "stop"}],
+                "model": "gpt-4o",
+                "usage": {"prompt_tokens": 50, "completion_tokens": 5}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None, Some(server.url()));
+
+    let msg = Message::user_with_blocks(vec![
+        ContentBlock::Text {
+            text: "Describe this image".to_string(),
+        },
+        ContentBlock::Image {
+            source: ImageSource::Url {
+                url: "https://example.com/photo.jpg".to_string(),
+            },
+        },
+    ]);
+    let request = ChatRequest::builder().messages(vec![msg]).build();
+
+    let response = provider.chat(request).await.unwrap();
+    assert_eq!(response.content, "A landscape");
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- Anthropic provider: serialize `content_blocks` as `{"type": "image", "source": {"type": "base64", ...}}` format
- OpenAI provider: serialize `content_blocks` as `{"type": "image_url", "image_url": {"url": "data:...;base64,..."}}` format
- Falls back to plain `content` string when `content_blocks` is empty (backward compatible)
- 7 new mock tests across both providers

Closes #118
Closes #119

## Test plan
- [x] `cargo test --test vision_anthropic` (3 pass)
- [x] `cargo test --test vision_openai` (4 pass)
- [x] All existing tests pass (29 total, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)