### PR TITLE
feat: From<ToolDef> for Tool + align optional fields (#125)

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -19,6 +19,7 @@ openai = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream", "dep:toki
 minimax = ["dep:reqwest", "dep:eventsource-stream", "dep:tokio-stream", "dep:tokio"]
 ollama = ["openai"]
 ollama_native = ["ollama", "dep:reqwest", "dep:tokio", "dep:tokio-stream", "dep:bytes"]
+agent-tool = ["dep:motosan-agent-tool"]
 full = ["anthropic", "openai", "minimax", "ollama", "ollama_native"]
 
 [dependencies]
@@ -28,6 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 
+motosan-agent-tool = { version = "0.2", optional = true }
 bytes = { version = "1", optional = true }
 reqwest = { version = "0.12", optional = true, features = ["json", "stream", "rustls-tls"] }
 eventsource-stream = { version = "0.2", optional = true }

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -7,6 +7,9 @@ pub mod stream;
 pub mod think_stripper;
 pub mod types;
 
+#[cfg(feature = "agent-tool")]
+pub mod tool_compat;
+
 pub use client::{Client, ClientBuilder};
 pub use error::MotosanError;
 pub use models::{

--- a/sdks/rust/src/tool_compat.rs
+++ b/sdks/rust/src/tool_compat.rs
@@ -1,0 +1,87 @@
+#[cfg(feature = "agent-tool")]
+use motosan_agent_tool::ToolDef;
+
+use crate::types::Tool;
+
+#[cfg(feature = "agent-tool")]
+impl From<ToolDef> for Tool {
+    fn from(def: ToolDef) -> Self {
+        Self {
+            name: def.name,
+            description: Some(def.description),
+            input_schema: Some(def.input_schema),
+        }
+    }
+}
+
+#[cfg(feature = "agent-tool")]
+impl From<Tool> for ToolDef {
+    fn from(t: Tool) -> Self {
+        Self {
+            name: t.name,
+            description: t.description.unwrap_or_default(),
+            input_schema: t
+                .input_schema
+                .unwrap_or_else(|| serde_json::json!({"type":"object"})),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "agent-tool"))]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_tool_from_tooldef() {
+        let def = ToolDef {
+            name: "get_weather".into(),
+            description: "Fetch current weather".into(),
+            input_schema: json!({"type": "object", "properties": {"city": {"type": "string"}}}),
+        };
+
+        let tool: Tool = def.into();
+
+        assert_eq!(tool.name, "get_weather");
+        assert_eq!(tool.description.as_deref(), Some("Fetch current weather"));
+        assert_eq!(
+            tool.input_schema.unwrap(),
+            json!({"type": "object", "properties": {"city": {"type": "string"}}})
+        );
+    }
+
+    #[test]
+    fn test_tooldef_from_tool_with_none_fields() {
+        let tool = Tool {
+            name: "search".into(),
+            description: None,
+            input_schema: None,
+        };
+
+        let def: ToolDef = tool.into();
+
+        assert_eq!(def.name, "search");
+        assert_eq!(def.description, "");
+        assert_eq!(def.input_schema, json!({"type": "object"}));
+    }
+
+    #[test]
+    fn test_tooldef_from_tool_with_some_fields() {
+        let tool = Tool {
+            name: "calc".into(),
+            description: Some("Calculator".into()),
+            input_schema: Some(
+                json!({"type": "object", "properties": {"expr": {"type": "string"}}}),
+            ),
+        };
+
+        let def: ToolDef = tool.into();
+
+        assert_eq!(def.name, "calc");
+        assert_eq!(def.description, "Calculator");
+        assert_eq!(
+            def.input_schema,
+            json!({"type": "object", "properties": {"expr": {"type": "string"}}})
+        );
+    }
+}

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -191,6 +191,12 @@ impl ChatRequestBuilder {
         self
     }
 
+    #[cfg(feature = "agent-tool")]
+    pub fn tool_defs(mut self, defs: &[motosan_agent_tool::ToolDef]) -> Self {
+        self.tools = Some(defs.iter().cloned().map(Tool::from).collect());
+        self
+    }
+
     pub fn provider_options(mut self, provider_options: Value) -> Self {
         self.provider_options = Some(provider_options);
         self


### PR DESCRIPTION
## Summary
- Add `agent-tool` feature flag with `motosan-agent-tool = "0.2"` optional dependency
- Implement bidirectional `From` conversions between `Tool` and `ToolDef`
- Add `ChatRequestBuilder::tool_defs(&[ToolDef])` convenience method
- 3 unit tests covering all conversion paths

Closes #125

## Test plan
- [x] `cargo check --features agent-tool` — compiles
- [x] `cargo check` (no features) — no breakage
- [x] `cargo test --features agent-tool` — passes (unit tests)
- [x] `cargo clippy --features agent-tool` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)