### PR TITLE
feat: server-side MCP support — mcp_servers in ChatRequest (#127)

### DIFF
--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -20,6 +20,6 @@ pub use providers::Provider;
 pub use retry::RetryPolicy;
 pub use stream::{BoxStream, StreamEvent};
 pub use types::{
-    ChatRequest, ChatRequestBuilder, ChatResponse, ContentBlock, ImageSource, Message, Role,
-    StopReason, StreamEventType, Tool, ToolCall, Usage,
+    ChatRequest, ChatRequestBuilder, ChatResponse, ContentBlock, ImageSource, McpServerConfig,
+    McpServerType, Message, Role, StopReason, StreamEventType, Tool, ToolCall, Usage,
 };

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -224,6 +224,25 @@ impl AnthropicRequestBuilder {
                 body["tools"] = json!(mapped_tools);
             }
         }
+        if let Some(mcp_servers) = &self.req.mcp_servers {
+            let servers: Vec<Value> = mcp_servers
+                .iter()
+                .map(|s| {
+                    let mut obj = json!({
+                        "type": s.kind,
+                        "url": s.url,
+                        "name": s.name,
+                    });
+                    if let Some(token) = &s.authorization_token {
+                        obj["authorization_token"] = json!(token);
+                    }
+                    obj
+                })
+                .collect();
+            if !servers.is_empty() {
+                body["mcp_servers"] = json!(servers);
+            }
+        }
         if let Some(provider_options) = self.req.provider_options {
             if let Some(map) = provider_options.as_object() {
                 for (key, value) in map {
@@ -509,6 +528,25 @@ impl ProviderImpl for AnthropicProvider {
                 })).collect();
                 if !mapped.is_empty() {
                     body["tools"] = json!(mapped);
+                }
+            }
+            if let Some(mcp_servers) = &req.mcp_servers {
+                let servers: Vec<Value> = mcp_servers
+                    .iter()
+                    .map(|s| {
+                        let mut obj = json!({
+                            "type": s.kind,
+                            "url": s.url,
+                            "name": s.name,
+                        });
+                        if let Some(token) = &s.authorization_token {
+                            obj["authorization_token"] = json!(token);
+                        }
+                        obj
+                    })
+                    .collect();
+                if !servers.is_empty() {
+                    body["mcp_servers"] = json!(servers);
                 }
             }
             if let Some(po) = req.provider_options {

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -127,6 +127,28 @@ pub struct Tool {
     pub input_schema: Option<Value>,
 }
 
+/// Server-side MCP server transport type.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum McpServerType {
+    Url,
+}
+
+/// Configuration for a server-side MCP server.
+///
+/// When included in a `ChatRequest`, the provider connects to the MCP server
+/// on the server side — the client never manages the MCP connection directly.
+/// Currently supported by the Anthropic provider only.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpServerConfig {
+    #[serde(rename = "type")]
+    pub kind: McpServerType,
+    pub url: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_token: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatRequest {
     pub messages: Vec<Message>,
@@ -136,6 +158,8 @@ pub struct ChatRequest {
     pub max_tokens: Option<u32>,
     pub tools: Option<Vec<Tool>>,
     pub provider_options: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcp_servers: Option<Vec<McpServerConfig>>,
 }
 
 impl ChatRequest {
@@ -153,6 +177,7 @@ pub struct ChatRequestBuilder {
     max_tokens: Option<u32>,
     tools: Option<Vec<Tool>>,
     provider_options: Option<Value>,
+    mcp_servers: Option<Vec<McpServerConfig>>,
 }
 
 impl ChatRequestBuilder {
@@ -202,6 +227,18 @@ impl ChatRequestBuilder {
         self
     }
 
+    /// Add a single server-side MCP server configuration.
+    pub fn mcp_server(mut self, server: McpServerConfig) -> Self {
+        self.mcp_servers.get_or_insert_with(Vec::new).push(server);
+        self
+    }
+
+    /// Set the full list of server-side MCP server configurations.
+    pub fn mcp_servers(mut self, servers: Vec<McpServerConfig>) -> Self {
+        self.mcp_servers = Some(servers);
+        self
+    }
+
     pub fn build(self) -> ChatRequest {
         ChatRequest {
             messages: self.messages,
@@ -211,6 +248,7 @@ impl ChatRequestBuilder {
             max_tokens: self.max_tokens,
             tools: self.tools,
             provider_options: self.provider_options,
+            mcp_servers: self.mcp_servers,
         }
     }
 }

--- a/sdks/rust/tests/mcp_servers.rs
+++ b/sdks/rust/tests/mcp_servers.rs
@@ -1,0 +1,138 @@
+#![cfg(feature = "anthropic")]
+
+use mockito::Matcher;
+use motosan_ai::providers::anthropic::AnthropicProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, McpServerConfig, McpServerType, Message, DEFAULT_ANTHROPIC_MODEL};
+use serde_json::json;
+
+#[tokio::test]
+async fn anthropic_request_includes_mcp_servers() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_body(Matcher::Regex(
+            r#""mcp_servers".*"type"\s*:\s*"url""#.to_string(),
+        ))
+        .match_body(Matcher::Regex(
+            r#""url"\s*:\s*"https://mcp\.example\.com/sse""#.to_string(),
+        ))
+        .match_body(Matcher::Regex(r#""name"\s*:\s*"linear""#.to_string()))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": DEFAULT_ANTHROPIC_MODEL,
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .mcp_server(McpServerConfig {
+            kind: McpServerType::Url,
+            url: "https://mcp.example.com/sse".to_string(),
+            name: "linear".to_string(),
+            authorization_token: None,
+        })
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "ok");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn mcp_server_config_serializes_correctly() {
+    let config = McpServerConfig {
+        kind: McpServerType::Url,
+        url: "https://mcp.example.com/sse".to_string(),
+        name: "linear".to_string(),
+        authorization_token: None,
+    };
+
+    let serialized = serde_json::to_value(&config).unwrap();
+    assert_eq!(serialized["type"], "url");
+    assert_eq!(serialized["url"], "https://mcp.example.com/sse");
+    assert_eq!(serialized["name"], "linear");
+    assert!(serialized.get("authorization_token").is_none());
+}
+
+#[tokio::test]
+async fn mcp_server_config_with_auth_token_serializes_correctly() {
+    let config = McpServerConfig {
+        kind: McpServerType::Url,
+        url: "https://mcp.example.com/sse".to_string(),
+        name: "linear".to_string(),
+        authorization_token: Some("secret-token".to_string()),
+    };
+
+    let serialized = serde_json::to_value(&config).unwrap();
+    assert_eq!(serialized["type"], "url");
+    assert_eq!(serialized["url"], "https://mcp.example.com/sse");
+    assert_eq!(serialized["name"], "linear");
+    assert_eq!(serialized["authorization_token"], "secret-token");
+}
+
+#[tokio::test]
+async fn chat_request_without_mcp_servers_omits_field() {
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let serialized = serde_json::to_value(&request).unwrap();
+    assert!(serialized.get("mcp_servers").is_none());
+}
+
+#[tokio::test]
+async fn chat_request_builder_mcp_server_accumulates() {
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .mcp_server(McpServerConfig {
+            kind: McpServerType::Url,
+            url: "https://mcp1.example.com/sse".to_string(),
+            name: "server1".to_string(),
+            authorization_token: None,
+        })
+        .mcp_server(McpServerConfig {
+            kind: McpServerType::Url,
+            url: "https://mcp2.example.com/sse".to_string(),
+            name: "server2".to_string(),
+            authorization_token: None,
+        })
+        .build();
+
+    let servers = request.mcp_servers.as_ref().unwrap();
+    assert_eq!(servers.len(), 2);
+    assert_eq!(servers[0].name, "server1");
+    assert_eq!(servers[1].name, "server2");
+}
+
+#[tokio::test]
+async fn chat_request_builder_mcp_servers_replaces() {
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .mcp_server(McpServerConfig {
+            kind: McpServerType::Url,
+            url: "https://should-be-replaced.com/sse".to_string(),
+            name: "old".to_string(),
+            authorization_token: None,
+        })
+        .mcp_servers(vec![McpServerConfig {
+            kind: McpServerType::Url,
+            url: "https://mcp.example.com/sse".to_string(),
+            name: "new".to_string(),
+            authorization_token: None,
+        }])
+        .build();
+
+    let servers = request.mcp_servers.as_ref().unwrap();
+    assert_eq!(servers.len(), 1);
+    assert_eq!(servers[0].name, "new");
+}


### PR DESCRIPTION
## Summary
- Add `McpServerConfig` and `McpServerType` types for server-side MCP configuration
- Add `mcp_servers` field to `ChatRequest` with `mcp_server()`/`mcp_servers()` builder methods
- Anthropic provider serializes `mcp_servers` in request body (both standard and OAuth paths)
- Other providers ignore `mcp_servers` gracefully
- 6 new unit tests covering serialization, builder ergonomics, and integration

Closes #127

## Test plan
- [x] Tests pass (`cargo test --all-features` — 138 tests)
- [x] Format check pass (`cargo fmt`)
- [x] Live integration tests pass (Anthropic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)