### PR TITLE
fix: usage tokens = 0 in OAuth / streaming collect path (#128)

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -270,6 +270,8 @@ impl ProviderImpl for AnthropicProvider {
             let mut current_tc_id = String::new();
             let mut current_tc_name = String::new();
             let mut current_tc_args = String::new();
+            let mut input_tokens: u32 = 0;
+            let mut output_tokens: u32 = 0;
 
             while let Some(event) = stream.next().await {
                 if event.done {
@@ -278,6 +280,16 @@ impl ProviderImpl for AnthropicProvider {
                 match event.event_type {
                     crate::types::StreamEventType::Text => {
                         content.push_str(&event.content);
+                    }
+                    crate::types::StreamEventType::Usage => {
+                        if let Some(ref usage) = event.usage {
+                            // message_start carries input_tokens;
+                            // message_delta carries output_tokens.
+                            // Accumulate both so we capture whichever event
+                            // reports non-zero values.
+                            input_tokens += usage.input_tokens;
+                            output_tokens += usage.output_tokens;
+                        }
                     }
                     crate::types::StreamEventType::ToolCallStart => {
                         current_tc_id = event.tool_call_id.unwrap_or_default();
@@ -312,8 +324,8 @@ impl ProviderImpl for AnthropicProvider {
                 content,
                 model: self.model.clone(),
                 usage: crate::types::Usage {
-                    input_tokens: 0,
-                    output_tokens: 0,
+                    input_tokens,
+                    output_tokens,
                 },
                 stop_reason,
                 tool_calls,
@@ -658,6 +670,49 @@ impl Stream for AnthropicStreamAdapter {
                     };
 
                     match event_type {
+                        "message_start" => {
+                            if let Some(usage) = payload.get("message").and_then(|m| m.get("usage"))
+                            {
+                                let input_tokens = usage
+                                    .get("input_tokens")
+                                    .and_then(Value::as_u64)
+                                    .unwrap_or(0)
+                                    as u32;
+                                let output_tokens = usage
+                                    .get("output_tokens")
+                                    .and_then(Value::as_u64)
+                                    .unwrap_or(0)
+                                    as u32;
+                                return Poll::Ready(Some(StreamEvent::usage(
+                                    crate::types::Usage {
+                                        input_tokens,
+                                        output_tokens,
+                                    },
+                                )));
+                            }
+                            continue;
+                        }
+                        "message_delta" => {
+                            if let Some(usage) = payload.get("usage") {
+                                let input_tokens = usage
+                                    .get("input_tokens")
+                                    .and_then(Value::as_u64)
+                                    .unwrap_or(0)
+                                    as u32;
+                                let output_tokens = usage
+                                    .get("output_tokens")
+                                    .and_then(Value::as_u64)
+                                    .unwrap_or(0)
+                                    as u32;
+                                return Poll::Ready(Some(StreamEvent::usage(
+                                    crate::types::Usage {
+                                        input_tokens,
+                                        output_tokens,
+                                    },
+                                )));
+                            }
+                            continue;
+                        }
                         "content_block_start" => {
                             let block = payload.get("content_block");
                             if let Some(block) = block {

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -293,6 +293,7 @@ pub enum StreamEventType {
     ToolCallStart,
     ToolCallArgs,
     ToolCallEnd,
+    Usage,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -321,6 +322,9 @@ pub struct StreamEvent {
     pub tool_call_args_delta: Option<String>,
     #[serde(default)]
     pub event_type: StreamEventType,
+    /// Token usage reported via `message_start` or `message_delta` SSE events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
 }
 
 impl StreamEvent {
@@ -332,6 +336,7 @@ impl StreamEvent {
             tool_call_name: None,
             tool_call_args_delta: None,
             event_type: StreamEventType::Text,
+            usage: None,
         }
     }
 
@@ -343,6 +348,19 @@ impl StreamEvent {
             tool_call_name: None,
             tool_call_args_delta: None,
             event_type: StreamEventType::Text,
+            usage: None,
+        }
+    }
+
+    pub fn usage(usage: Usage) -> Self {
+        Self {
+            content: String::new(),
+            done: false,
+            tool_call_id: None,
+            tool_call_name: None,
+            tool_call_args_delta: None,
+            event_type: StreamEventType::Usage,
+            usage: Some(usage),
         }
     }
 
@@ -354,6 +372,7 @@ impl StreamEvent {
             tool_call_name: Some(name.into()),
             tool_call_args_delta: None,
             event_type: StreamEventType::ToolCallStart,
+            usage: None,
         }
     }
 
@@ -365,6 +384,7 @@ impl StreamEvent {
             tool_call_name: None,
             tool_call_args_delta: Some(delta.into()),
             event_type: StreamEventType::ToolCallArgs,
+            usage: None,
         }
     }
 
@@ -376,6 +396,7 @@ impl StreamEvent {
             tool_call_name: None,
             tool_call_args_delta: Some(delta.into()),
             event_type: StreamEventType::ToolCallArgs,
+            usage: None,
         }
     }
 
@@ -387,6 +408,7 @@ impl StreamEvent {
             tool_call_name: None,
             tool_call_args_delta: None,
             event_type: StreamEventType::ToolCallEnd,
+            usage: None,
         }
     }
 
@@ -398,6 +420,7 @@ impl StreamEvent {
             tool_call_name: None,
             tool_call_args_delta: None,
             event_type: StreamEventType::ToolCallEnd,
+            usage: None,
         }
     }
 }

--- a/sdks/rust/tests/anthropic_oauth_usage.rs
+++ b/sdks/rust/tests/anthropic_oauth_usage.rs
@@ -1,0 +1,170 @@
+#![cfg(feature = "anthropic")]
+
+use mockito::Matcher;
+use motosan_ai::providers::anthropic::AnthropicProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, Message, StreamEventType};
+use serde_json::json;
+use tokio_stream::StreamExt;
+
+/// OAuth chat() collects usage tokens from message_start and message_delta
+/// stream events instead of hardcoding them to 0.
+#[tokio::test]
+async fn oauth_chat_captures_usage_from_stream_events() {
+    let mut server = mockito::Server::new_async().await;
+
+    // Simulate a realistic Anthropic SSE stream with usage in
+    // message_start (input_tokens) and message_delta (output_tokens).
+    let sse_body = [
+        "event: message_start",
+        &format!(
+            "data: {}",
+            json!({
+                "type": "message_start",
+                "message": {
+                    "id": "msg_test",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "claude-sonnet-4-5-20250514",
+                    "usage": {"input_tokens": 100, "output_tokens": 0}
+                }
+            })
+        ),
+        "",
+        "event: content_block_delta",
+        &format!(
+            "data: {}",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello!"}})
+        ),
+        "",
+        "event: message_delta",
+        &format!(
+            "data: {}",
+            json!({
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 42}
+            })
+        ),
+        "",
+        "event: message_stop",
+        &format!("data: {}", json!({"type": "message_stop"})),
+        "",
+    ]
+    .join("\n");
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("authorization", "Bearer sk-ant-oat01-usage-test")
+        .match_header(
+            "anthropic-beta",
+            Matcher::Regex("oauth-2025-04-20".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("sk-ant-oat01-usage-test", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+
+    assert_eq!(response.content, "Hello!");
+    assert_eq!(
+        response.usage.input_tokens, 100,
+        "input_tokens should come from message_start"
+    );
+    assert_eq!(
+        response.usage.output_tokens, 42,
+        "output_tokens should come from message_delta"
+    );
+
+    mock.assert_async().await;
+}
+
+/// Stream path emits Usage events that carry token counts.
+#[tokio::test]
+async fn stream_emits_usage_events_from_message_start_and_delta() {
+    let mut server = mockito::Server::new_async().await;
+
+    let sse_body = [
+        "event: message_start",
+        &format!(
+            "data: {}",
+            json!({
+                "type": "message_start",
+                "message": {
+                    "id": "msg_test",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "claude-sonnet-4-5-20250514",
+                    "usage": {"input_tokens": 55, "output_tokens": 0}
+                }
+            })
+        ),
+        "",
+        "event: content_block_delta",
+        &format!(
+            "data: {}",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hi"}})
+        ),
+        "",
+        "event: message_delta",
+        &format!(
+            "data: {}",
+            json!({
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 10}
+            })
+        ),
+        "",
+        "event: message_stop",
+        &format!("data: {}", json!({"type": "message_stop"})),
+        "",
+    ]
+    .join("\n");
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut usage_events = Vec::new();
+
+    while let Some(event) = stream.next().await {
+        if event.event_type == StreamEventType::Usage {
+            usage_events.push(event);
+        }
+    }
+
+    assert_eq!(usage_events.len(), 2, "should emit 2 usage events");
+
+    // message_start usage
+    let start_usage = usage_events[0].usage.as_ref().expect("usage field");
+    assert_eq!(start_usage.input_tokens, 55);
+    assert_eq!(start_usage.output_tokens, 0);
+
+    // message_delta usage
+    let delta_usage = usage_events[1].usage.as_ref().expect("usage field");
+    assert_eq!(delta_usage.input_tokens, 0);
+    assert_eq!(delta_usage.output_tokens, 10);
+
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- Add `StreamEventType::Usage` variant to capture usage from stream events
- Emit usage events from `message_start` (input_tokens) and `message_delta` (output_tokens)
- OAuth `chat()` collect path accumulates usage from stream events instead of hardcoding 0
- 2 new integration tests with mockito

Closes #128

## Test plan
- [x] Tests pass (`cargo test --all-features`)
- [x] Format check pass (`cargo fmt`)
- [x] Live integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)