### PR TITLE
feat: first-class extended thinking support (#130)

### DIFF
--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -21,5 +21,6 @@ pub use retry::RetryPolicy;
 pub use stream::{BoxStream, StreamEvent};
 pub use types::{
     ChatRequest, ChatRequestBuilder, ChatResponse, ContentBlock, ImageSource, McpServerConfig,
-    McpServerType, Message, Role, StopReason, StreamEventType, Tool, ToolCall, Usage,
+    McpServerType, Message, Role, StopReason, StreamEventType, ThinkingConfig, Tool, ToolCall,
+    Usage,
 };

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -204,11 +204,20 @@ impl AnthropicRequestBuilder {
                 body["system"] = json!(system_prompt);
             }
         }
-        if let Some(temperature) = self.req.temperature {
+        // When thinking is enabled, Anthropic requires temperature=1.0.
+        if self.req.thinking.is_some() {
+            body["temperature"] = json!(1.0);
+        } else if let Some(temperature) = self.req.temperature {
             body["temperature"] = json!(temperature);
         }
         let max_tokens = self.req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
         body["max_tokens"] = json!(max_tokens);
+        if let Some(ref thinking) = self.req.thinking {
+            body["thinking"] = json!({
+                "type": "enabled",
+                "budget_tokens": thinking.budget_tokens,
+            });
+        }
         if let Some(tools) = self.req.tools {
             let mapped_tools: Vec<Value> = tools
                 .into_iter()
@@ -310,6 +319,7 @@ impl ProviderImpl for AnthropicProvider {
 
             return Ok(ChatResponse {
                 content,
+                thinking: None,
                 model: self.model.clone(),
                 usage: crate::types::Usage {
                     input_tokens: 0,
@@ -369,17 +379,31 @@ impl ProviderImpl for AnthropicProvider {
             return Err(map_http_error(status.as_u16(), message));
         }
 
-        let content = payload
-            .get("content")
-            .and_then(Value::as_array)
+        let content_blocks = payload.get("content").and_then(Value::as_array);
+
+        let content = content_blocks
             .map(|items| {
                 items
                     .iter()
+                    .filter(|item| item.get("type").and_then(Value::as_str) != Some("thinking"))
                     .filter_map(|item| item.get("text").and_then(Value::as_str))
                     .collect::<Vec<_>>()
                     .join("")
             })
             .unwrap_or_default();
+
+        let thinking = content_blocks.and_then(|items| {
+            let parts: Vec<&str> = items
+                .iter()
+                .filter(|item| item.get("type").and_then(Value::as_str) == Some("thinking"))
+                .filter_map(|item| item.get("thinking").and_then(Value::as_str))
+                .collect();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join(""))
+            }
+        });
 
         let tool_calls = payload
             .get("content")
@@ -433,6 +457,7 @@ impl ProviderImpl for AnthropicProvider {
 
         Ok(ChatResponseBuilder::new(DEFAULT_ANTHROPIC_MODEL)
             .content(content)
+            .thinking(thinking)
             .tool_calls(tool_calls)
             .model(model)
             .usage(input_tokens, output_tokens)
@@ -517,8 +542,16 @@ impl ProviderImpl for AnthropicProvider {
                 "stream": true,
                 "system": system_blocks,
             });
-            if let Some(temperature) = req.temperature {
+            if req.thinking.is_some() {
+                body["temperature"] = json!(1.0);
+            } else if let Some(temperature) = req.temperature {
                 body["temperature"] = json!(temperature);
+            }
+            if let Some(ref thinking) = req.thinking {
+                body["thinking"] = json!({
+                    "type": "enabled",
+                    "budget_tokens": thinking.budget_tokens,
+                });
             }
             if let Some(tools) = req.tools {
                 let mapped: Vec<Value> = tools.into_iter().map(|t| json!({

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -60,6 +60,7 @@ pub trait ProviderImpl: Send + Sync {
 ))]
 pub(crate) struct ChatResponseBuilder {
     content: String,
+    thinking: Option<String>,
     tool_calls: Vec<ToolCall>,
     model: String,
     usage: Usage,
@@ -76,6 +77,7 @@ impl ChatResponseBuilder {
     pub(crate) fn new(default_model: impl Into<String>) -> Self {
         Self {
             content: String::new(),
+            thinking: None,
             tool_calls: Vec::new(),
             model: default_model.into(),
             usage: Usage {
@@ -88,6 +90,11 @@ impl ChatResponseBuilder {
 
     pub(crate) fn content(mut self, content: impl Into<String>) -> Self {
         self.content = content.into();
+        self
+    }
+
+    pub(crate) fn thinking(mut self, thinking: Option<String>) -> Self {
+        self.thinking = thinking;
         self
     }
 
@@ -117,6 +124,7 @@ impl ChatResponseBuilder {
     pub(crate) fn build(self) -> ChatResponse {
         ChatResponse {
             content: self.content,
+            thinking: self.thinking,
             tool_calls: self.tool_calls,
             model: self.model,
             usage: self.usage,

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -1,6 +1,16 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Configuration for extended thinking (Anthropic).
+///
+/// When enabled the provider will include a `thinking` block in the request
+/// and surface any thinking content in [`ChatResponse::thinking`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThinkingConfig {
+    /// Token budget for extended thinking (Anthropic typical range: 1024-32000).
+    pub budget_tokens: u32,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
@@ -160,6 +170,8 @@ pub struct ChatRequest {
     pub provider_options: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mcp_servers: Option<Vec<McpServerConfig>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingConfig>,
 }
 
 impl ChatRequest {
@@ -178,6 +190,7 @@ pub struct ChatRequestBuilder {
     tools: Option<Vec<Tool>>,
     provider_options: Option<Value>,
     mcp_servers: Option<Vec<McpServerConfig>>,
+    thinking: Option<ThinkingConfig>,
 }
 
 impl ChatRequestBuilder {
@@ -239,6 +252,15 @@ impl ChatRequestBuilder {
         self
     }
 
+    /// Enable extended thinking with a token budget.
+    ///
+    /// When thinking is enabled on the Anthropic provider, temperature is
+    /// automatically forced to 1.0 (an Anthropic API constraint).
+    pub fn thinking(mut self, budget_tokens: u32) -> Self {
+        self.thinking = Some(ThinkingConfig { budget_tokens });
+        self
+    }
+
     pub fn build(self) -> ChatRequest {
         ChatRequest {
             messages: self.messages,
@@ -249,6 +271,7 @@ impl ChatRequestBuilder {
             tools: self.tools,
             provider_options: self.provider_options,
             mcp_servers: self.mcp_servers,
+            thinking: self.thinking,
         }
     }
 }
@@ -256,6 +279,9 @@ impl ChatRequestBuilder {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatResponse {
     pub content: String,
+    /// Raw thinking content when extended thinking is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
     pub tool_calls: Vec<ToolCall>,
     pub model: String,
     pub usage: Usage,

--- a/sdks/rust/tests/thinking_support.rs
+++ b/sdks/rust/tests/thinking_support.rs
@@ -1,0 +1,164 @@
+#![cfg(feature = "anthropic")]
+
+use mockito::Matcher;
+use motosan_ai::providers::anthropic::AnthropicProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, Message, ThinkingConfig};
+use serde_json::json;
+
+#[tokio::test]
+async fn thinking_config_serializes_as_enabled() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_body(Matcher::Regex(
+            r#""thinking"\s*:\s*\{\s*"budget_tokens"\s*:\s*8000\s*,\s*"type"\s*:\s*"enabled"\s*\}"#
+                .to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "claude-sonnet-4-5",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+                "content": [
+                    {"type": "thinking", "thinking": "Let me reason about this..."},
+                    {"type": "text", "text": "The answer is 42."}
+                ]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("What is the meaning of life?"))
+        .thinking(8000)
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+
+    // Text content should exclude thinking blocks
+    assert_eq!(response.content, "The answer is 42.");
+    // Thinking field should contain the thinking content
+    assert_eq!(
+        response.thinking.as_deref(),
+        Some("Let me reason about this...")
+    );
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn thinking_auto_sets_temperature_to_one() {
+    let mut server = mockito::Server::new_async().await;
+    // Verify temperature is 1.0 even though the user did not set it
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_body(Matcher::Regex(r#""temperature"\s*:\s*1\.0"#.to_string()))
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "claude-sonnet-4-5",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .thinking(4000)
+        .temperature(0.5) // should be overridden to 1.0
+        .build();
+
+    let _ = provider.chat(request).await.expect("chat response");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn response_without_thinking_has_none() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "claude-sonnet-4-5",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 10},
+                "content": [{"type": "text", "text": "hello"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "hello");
+    assert!(response.thinking.is_none());
+
+    mock.assert_async().await;
+}
+
+#[test]
+fn thinking_config_builder_sets_budget_tokens() {
+    let request = ChatRequest::builder()
+        .message(Message::user("test"))
+        .thinking(16000)
+        .build();
+
+    assert!(request.thinking.is_some());
+    assert_eq!(request.thinking.unwrap().budget_tokens, 16000);
+}
+
+#[test]
+fn thinking_config_serde_roundtrip() {
+    let config = ThinkingConfig {
+        budget_tokens: 8000,
+    };
+    let json = serde_json::to_string(&config).unwrap();
+    let deserialized: ThinkingConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.budget_tokens, 8000);
+}
+
+#[test]
+fn chat_response_thinking_field_serde() {
+    let json = json!({
+        "content": "answer",
+        "thinking": "my reasoning",
+        "tool_calls": [],
+        "model": "claude-sonnet-4-5",
+        "usage": {"input_tokens": 5, "output_tokens": 10},
+        "stop_reason": "end_turn"
+    });
+    let resp: motosan_ai::ChatResponse = serde_json::from_value(json).unwrap();
+    assert_eq!(resp.thinking.as_deref(), Some("my reasoning"));
+    assert_eq!(resp.content, "answer");
+}
+
+#[test]
+fn chat_response_without_thinking_deserializes() {
+    let json = json!({
+        "content": "answer",
+        "tool_calls": [],
+        "model": "claude-sonnet-4-5",
+        "usage": {"input_tokens": 5, "output_tokens": 10},
+        "stop_reason": "end_turn"
+    });
+    let resp: motosan_ai::ChatResponse = serde_json::from_value(json).unwrap();
+    assert!(resp.thinking.is_none());
+}


### PR DESCRIPTION
## Summary
- Add `ThinkingConfig` type and `ChatRequest::thinking(budget_tokens)` builder method
- Anthropic provider serializes `{"type":"enabled","budget_tokens":N}` and auto-sets temperature=1.0
- Add `ChatResponse::thinking: Option<String>` to capture thinking blocks from responses
- Response parsing separates thinking blocks from text content
- ThinkStripper streaming unaffected (no regression)
- 7 new tests

Closes #130

## Test plan
- [x] Tests pass (`cargo test --all-features`)
- [x] Format check pass (`cargo fmt`)
- [x] Live integration tests pass
- [x] ThinkStripper tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)