### PR TITLE
feat: BoxStream::collect() helper → ChatResponse (#131)

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -39,4 +39,5 @@ tokio = { version = "1", optional = true, features = ["time"] }
 [dev-dependencies]
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
+tokio-stream = "0.1"
 mockito = "1"

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -82,6 +82,57 @@ impl Client {
         Ok(Self::wrap_with_think_stripper(raw))
     }
 
+    /// Stream a chat request and collect the full response into a [`ChatResponse`].
+    ///
+    /// This is a convenience wrapper around [`stream`](Self::stream) +
+    /// [`collect_stream`](crate::stream::collect_stream) that removes the
+    /// boilerplate of manually consuming stream events.
+    #[cfg(any(
+        feature = "anthropic",
+        feature = "openai",
+        feature = "minimax",
+        feature = "ollama_native"
+    ))]
+    pub async fn stream_collect(
+        &self,
+        messages: Vec<Message>,
+    ) -> Result<ChatResponse, MotosanError> {
+        let stream = self.stream(messages).await?;
+        let mut response = crate::stream::collect_stream(stream).await;
+        if let Some(model) = &self.model {
+            response.model = model.clone();
+        }
+        Ok(response)
+    }
+
+    /// Stream a fully-configured [`ChatRequest`] and collect the response.
+    ///
+    /// Like [`stream_collect`](Self::stream_collect) but accepts an already-
+    /// built request for full control over system prompt, tools, temperature,
+    /// etc.
+    #[cfg(any(
+        feature = "anthropic",
+        feature = "openai",
+        feature = "minimax",
+        feature = "ollama_native"
+    ))]
+    pub async fn stream_collect_with(
+        &self,
+        request: ChatRequest,
+    ) -> Result<ChatResponse, MotosanError> {
+        let model_hint = request
+            .model
+            .clone()
+            .or_else(|| self.model.clone())
+            .unwrap_or_default();
+        let stream = self.stream_with(request).await?;
+        let mut response = crate::stream::collect_stream(stream).await;
+        if response.model.is_empty() {
+            response.model = model_hint;
+        }
+        Ok(response)
+    }
+
     fn wrap_with_think_stripper(raw: BoxStream) -> BoxStream {
         Box::pin(ThinkStripperStream {
             inner: raw,

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -18,6 +18,13 @@ pub use models::{
 };
 pub use providers::Provider;
 pub use retry::RetryPolicy;
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native"
+))]
+pub use stream::collect_stream;
 pub use stream::{BoxStream, StreamEvent};
 pub use types::{
     ChatRequest, ChatRequestBuilder, ChatResponse, ContentBlock, ImageSource, McpServerConfig,

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -290,74 +290,10 @@ impl ProviderImpl for AnthropicProvider {
         // OAuth tokens require streaming + Claude Code identity.
         // Redirect to stream path and collect the full response.
         if is_oauth {
-            use tokio_stream::StreamExt;
-            let mut stream = self.stream(req).await?;
-            let mut content = String::new();
-            let mut tool_calls: Vec<ToolCall> = Vec::new();
-            let mut current_tc_id = String::new();
-            let mut current_tc_name = String::new();
-            let mut current_tc_args = String::new();
-            let mut input_tokens: u32 = 0;
-            let mut output_tokens: u32 = 0;
-
-            while let Some(event) = stream.next().await {
-                if event.done {
-                    break;
-                }
-                match event.event_type {
-                    crate::types::StreamEventType::Text => {
-                        content.push_str(&event.content);
-                    }
-                    crate::types::StreamEventType::Usage => {
-                        if let Some(ref usage) = event.usage {
-                            // message_start carries input_tokens;
-                            // message_delta carries output_tokens.
-                            // Accumulate both so we capture whichever event
-                            // reports non-zero values.
-                            input_tokens += usage.input_tokens;
-                            output_tokens += usage.output_tokens;
-                        }
-                    }
-                    crate::types::StreamEventType::ToolCallStart => {
-                        current_tc_id = event.tool_call_id.unwrap_or_default();
-                        current_tc_name = event.tool_call_name.unwrap_or_default();
-                        current_tc_args.clear();
-                    }
-                    crate::types::StreamEventType::ToolCallArgs => {
-                        if let Some(delta) = &event.tool_call_args_delta {
-                            current_tc_args.push_str(delta);
-                        }
-                    }
-                    crate::types::StreamEventType::ToolCallEnd => {
-                        let input: serde_json::Value =
-                            serde_json::from_str(&current_tc_args).unwrap_or_else(|_| json!({}));
-                        tool_calls.push(ToolCall {
-                            id: std::mem::take(&mut current_tc_id),
-                            name: std::mem::take(&mut current_tc_name),
-                            input,
-                        });
-                        current_tc_args.clear();
-                    }
-                }
-            }
-
-            let stop_reason = if tool_calls.is_empty() {
-                crate::types::StopReason::EndTurn
-            } else {
-                crate::types::StopReason::ToolUse
-            };
-
-            return Ok(ChatResponse {
-                content,
-                thinking: None,
-                model: self.model.clone(),
-                usage: crate::types::Usage {
-                    input_tokens,
-                    output_tokens,
-                },
-                stop_reason,
-                tool_calls,
-            });
+            let stream = self.stream(req).await?;
+            let mut response = crate::stream::collect_stream(stream).await;
+            response.model = self.model.clone();
+            return Ok(response);
         }
 
         let body = AnthropicRequestBuilder::new(req, self.model.clone(), is_oauth).build();

--- a/sdks/rust/src/stream.rs
+++ b/sdks/rust/src/stream.rs
@@ -3,3 +3,92 @@ use futures_core::Stream;
 use std::pin::Pin;
 
 pub type BoxStream = Pin<Box<dyn Stream<Item = StreamEvent> + Send>>;
+
+/// Collect a streaming response into a single [`ChatResponse`].
+///
+/// This eliminates the boilerplate of manually matching each
+/// [`StreamEventType`] variant and accumulating text, tool calls, and usage
+/// tokens.  The returned `ChatResponse` has `model` set to an empty string
+/// because the stream events do not carry model information; callers that
+/// need the model name should fill it in after the call.
+///
+/// # Example
+///
+/// ```ignore
+/// let stream = client.stream(messages).await?;
+/// let response = motosan_ai::collect_stream(stream).await;
+/// println!("{}", response.content);
+/// ```
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native"
+))]
+pub async fn collect_stream(mut stream: BoxStream) -> crate::types::ChatResponse {
+    use crate::types::{ChatResponse, StopReason, StreamEventType, ToolCall, Usage};
+    use tokio_stream::StreamExt;
+
+    let mut content = String::new();
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+    let mut current_tc_id = String::new();
+    let mut current_tc_name = String::new();
+    let mut current_tc_args = String::new();
+    let mut input_tokens: u32 = 0;
+    let mut output_tokens: u32 = 0;
+
+    while let Some(event) = stream.next().await {
+        if event.done {
+            break;
+        }
+        match event.event_type {
+            StreamEventType::Text => {
+                content.push_str(&event.content);
+            }
+            StreamEventType::Usage => {
+                if let Some(ref usage) = event.usage {
+                    input_tokens += usage.input_tokens;
+                    output_tokens += usage.output_tokens;
+                }
+            }
+            StreamEventType::ToolCallStart => {
+                current_tc_id = event.tool_call_id.unwrap_or_default();
+                current_tc_name = event.tool_call_name.unwrap_or_default();
+                current_tc_args.clear();
+            }
+            StreamEventType::ToolCallArgs => {
+                if let Some(delta) = &event.tool_call_args_delta {
+                    current_tc_args.push_str(delta);
+                }
+            }
+            StreamEventType::ToolCallEnd => {
+                let input: serde_json::Value = serde_json::from_str(&current_tc_args)
+                    .unwrap_or_else(|_| serde_json::json!({}));
+                tool_calls.push(ToolCall {
+                    id: std::mem::take(&mut current_tc_id),
+                    name: std::mem::take(&mut current_tc_name),
+                    input,
+                });
+                current_tc_args.clear();
+            }
+        }
+    }
+
+    let stop_reason = if tool_calls.is_empty() {
+        StopReason::EndTurn
+    } else {
+        StopReason::ToolUse
+    };
+
+    ChatResponse {
+        content,
+        thinking: None,
+        model: String::new(),
+        usage: Usage {
+            input_tokens,
+            output_tokens,
+        },
+        stop_reason,
+        tool_calls,
+    }
+}

--- a/sdks/rust/tests/collect_stream.rs
+++ b/sdks/rust/tests/collect_stream.rs
@@ -1,0 +1,322 @@
+#![cfg(feature = "anthropic")]
+
+use mockito::Matcher;
+use motosan_ai::providers::anthropic::AnthropicProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{
+    collect_stream, ChatRequest, Message, StopReason, StreamEvent, Tool,
+};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// collect_stream() unit tests (synthetic BoxStream, no HTTP)
+// ---------------------------------------------------------------------------
+
+fn boxed_stream(events: Vec<StreamEvent>) -> motosan_ai::BoxStream {
+    Box::pin(tokio_stream::iter(events))
+}
+
+#[tokio::test]
+async fn collect_stream_text_only() {
+    let events = vec![
+        StreamEvent::text("Hello"),
+        StreamEvent::text(", world!"),
+        StreamEvent::done(),
+    ];
+    let response = collect_stream(boxed_stream(events)).await;
+
+    assert_eq!(response.content, "Hello, world!");
+    assert!(response.tool_calls.is_empty());
+    assert_eq!(response.stop_reason, StopReason::EndTurn);
+    assert!(response.thinking.is_none());
+}
+
+#[tokio::test]
+async fn collect_stream_with_tool_calls() {
+    let events = vec![
+        StreamEvent::text("Let me check"),
+        StreamEvent::tool_call_start("toolu_1", "get_weather"),
+        StreamEvent::tool_call_args_with_id("toolu_1", r#"{"city":"#),
+        StreamEvent::tool_call_args_with_id("toolu_1", r#""Taipei"}"#),
+        StreamEvent::tool_call_end_with_id("toolu_1"),
+        StreamEvent::done(),
+    ];
+    let response = collect_stream(boxed_stream(events)).await;
+
+    assert_eq!(response.content, "Let me check");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].id, "toolu_1");
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+    assert_eq!(response.tool_calls[0].input, json!({"city": "Taipei"}));
+    assert_eq!(response.stop_reason, StopReason::ToolUse);
+}
+
+#[tokio::test]
+async fn collect_stream_multiple_tool_calls() {
+    let events = vec![
+        StreamEvent::tool_call_start("tc_1", "tool_a"),
+        StreamEvent::tool_call_args(r#"{"x":1}"#),
+        StreamEvent::tool_call_end(),
+        StreamEvent::tool_call_start("tc_2", "tool_b"),
+        StreamEvent::tool_call_args(r#"{"y":2}"#),
+        StreamEvent::tool_call_end(),
+        StreamEvent::done(),
+    ];
+    let response = collect_stream(boxed_stream(events)).await;
+
+    assert_eq!(response.tool_calls.len(), 2);
+    assert_eq!(response.tool_calls[0].name, "tool_a");
+    assert_eq!(response.tool_calls[1].name, "tool_b");
+    assert_eq!(response.stop_reason, StopReason::ToolUse);
+}
+
+#[tokio::test]
+async fn collect_stream_with_usage_events() {
+    let events = vec![
+        StreamEvent::usage(motosan_ai::Usage {
+            input_tokens: 100,
+            output_tokens: 0,
+        }),
+        StreamEvent::text("hi"),
+        StreamEvent::usage(motosan_ai::Usage {
+            input_tokens: 0,
+            output_tokens: 42,
+        }),
+        StreamEvent::done(),
+    ];
+    let response = collect_stream(boxed_stream(events)).await;
+
+    assert_eq!(response.usage.input_tokens, 100);
+    assert_eq!(response.usage.output_tokens, 42);
+    assert_eq!(response.content, "hi");
+}
+
+#[tokio::test]
+async fn collect_stream_empty_stream() {
+    let events = vec![StreamEvent::done()];
+    let response = collect_stream(boxed_stream(events)).await;
+
+    assert_eq!(response.content, "");
+    assert!(response.tool_calls.is_empty());
+    assert_eq!(response.stop_reason, StopReason::EndTurn);
+}
+
+#[tokio::test]
+async fn collect_stream_model_is_empty_by_default() {
+    let events = vec![StreamEvent::text("x"), StreamEvent::done()];
+    let response = collect_stream(boxed_stream(events)).await;
+    assert_eq!(response.model, "");
+}
+
+// ---------------------------------------------------------------------------
+// OAuth path now uses collect_stream internally (via AnthropicProvider)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn oauth_chat_uses_collect_stream_internally() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"hello\"}}\n\n",
+        "event: message_delta\n",
+        "data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":0,\"output_tokens\":5}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n"
+    );
+
+    let _mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("authorization", "Bearer sk-ant-oat01-test-token")
+        .match_header(
+            "anthropic-beta",
+            Matcher::Regex("oauth-2025-04-20".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("sk-ant-oat01-test-token", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+
+    let response = provider.chat(request).await.expect("chat response");
+
+    assert_eq!(response.content, "hello");
+    assert_eq!(response.usage.input_tokens, 10);
+    assert_eq!(response.usage.output_tokens, 5);
+    assert_eq!(response.stop_reason, StopReason::EndTurn);
+    assert!(response.thinking.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// stream → collect_stream via AnthropicProvider (simulates stream_collect_with)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn stream_then_collect_returns_chat_response() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":15,\"output_tokens\":0}}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"collected\"}}\n\n",
+        "event: message_delta\n",
+        "data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":0,\"output_tokens\":7}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n"
+    );
+
+    let _mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let stream = provider.stream(request).await.expect("stream response");
+    let response = collect_stream(stream).await;
+
+    assert_eq!(response.content, "collected");
+    assert_eq!(response.usage.input_tokens, 15);
+    assert_eq!(response.usage.output_tokens, 7);
+    assert_eq!(response.stop_reason, StopReason::EndTurn);
+}
+
+// ---------------------------------------------------------------------------
+// Tool calls through stream + collect_stream
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn stream_collect_with_tool_calls() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"checking\"}}\n\n",
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"t1\",\"name\":\"search\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"q\\\":\\\"rust\\\"}\"}}\n\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n"
+    );
+
+    let _mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("search for rust"))
+        .tools(vec![Tool {
+            name: "search".to_string(),
+            description: Some("Search".to_string()),
+            input_schema: Some(json!({"type": "object", "properties": {"q": {"type": "string"}}})),
+        }])
+        .build();
+
+    let stream = provider.stream(request).await.expect("stream response");
+    let response = collect_stream(stream).await;
+
+    assert_eq!(response.content, "checking");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].name, "search");
+    assert_eq!(response.tool_calls[0].input, json!({"q": "rust"}));
+    assert_eq!(response.stop_reason, StopReason::ToolUse);
+}
+
+// ---------------------------------------------------------------------------
+// Compare chat() vs stream+collect for same mock response (consistency)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn chat_vs_stream_collect_consistency() {
+    // Set up two mocks — one for non-stream chat, one for stream
+    let mut server = mockito::Server::new_async().await;
+
+    let chat_response_body = json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello there"}],
+        "model": "claude-sonnet-4-20250514",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 12, "output_tokens": 3}
+    });
+
+    let sse_body = concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":12,\"output_tokens\":0}}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"Hello there\"}}\n\n",
+        "event: message_delta\n",
+        "data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":0,\"output_tokens\":3}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n"
+    );
+
+    // First call: non-streaming chat
+    let _chat_mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(chat_response_body.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let chat_req = ChatRequest::builder().message(Message::user("hi")).build();
+    let chat_response = provider.chat(chat_req).await.expect("chat response");
+
+    // Remove first mock and create stream mock
+    drop(_chat_mock);
+
+    let _stream_mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let stream_req = ChatRequest::builder().message(Message::user("hi")).build();
+    let stream = provider.stream(stream_req).await.expect("stream response");
+    let mut stream_response = collect_stream(stream).await;
+    // collect_stream sets model to empty; match it for comparison
+    stream_response.model = chat_response.model.clone();
+
+    assert_eq!(chat_response.content, stream_response.content);
+    assert_eq!(chat_response.stop_reason, stream_response.stop_reason);
+    assert_eq!(
+        chat_response.usage.input_tokens,
+        stream_response.usage.input_tokens
+    );
+    assert_eq!(
+        chat_response.usage.output_tokens,
+        stream_response.usage.output_tokens
+    );
+    assert_eq!(
+        chat_response.tool_calls.len(),
+        stream_response.tool_calls.len()
+    );
+}

--- a/sdks/rust/tests/collect_stream.rs
+++ b/sdks/rust/tests/collect_stream.rs
@@ -3,9 +3,7 @@
 use mockito::Matcher;
 use motosan_ai::providers::anthropic::AnthropicProvider;
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{
-    collect_stream, ChatRequest, Message, StopReason, StreamEvent, Tool,
-};
+use motosan_ai::{collect_stream, ChatRequest, Message, StopReason, StreamEvent, Tool};
 use serde_json::json;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add public `collect_stream(BoxStream) -> ChatResponse` function in new `stream.rs`
- Add `Client::stream_collect()` and `Client::stream_collect_with()` convenience methods
- Refactor Anthropic OAuth collect path to use `collect_stream()` (DRY — removed ~60 lines of duplication)
- 10 new tests including chat-vs-stream consistency comparison

Closes #131

## Test plan
- [x] Tests pass (`cargo test --all-features`)
- [x] Format check pass (`cargo fmt`)
- [x] Live integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)