### PR TITLE
fix: merge anthropic-beta headers when OAuth + MCP are both active (#149)

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -60,10 +60,6 @@ impl AnthropicProvider {
         if Self::is_setup_token(&self.api_key) {
             request
                 .header("authorization", format!("Bearer {}", self.api_key))
-                .header(
-                    "anthropic-beta",
-                    "claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14",
-                )
                 .header("user-agent", "claude-code/1.0.33")
                 .header("x-app", "cli")
         } else {
@@ -71,14 +67,32 @@ impl AnthropicProvider {
         }
     }
 
+    fn build_beta_header(has_mcp: bool, is_oauth: bool) -> Option<String> {
+        let mut betas = vec![];
+        if is_oauth {
+            betas.push("claude-code-20250219");
+            betas.push("oauth-2025-04-20");
+            betas.push("fine-grained-tool-streaming-2025-05-14");
+            betas.push("interleaved-thinking-2025-05-14");
+        }
+        if has_mcp {
+            betas.push("mcp-client-2025-11-20");
+        }
+        if betas.is_empty() {
+            None
+        } else {
+            Some(betas.join(","))
+        }
+    }
+
     fn apply_beta_header(
         request: reqwest::RequestBuilder,
         has_mcp: bool,
+        is_oauth: bool,
     ) -> reqwest::RequestBuilder {
-        if has_mcp {
-            request.header("anthropic-beta", "mcp-client-2025-11-20")
-        } else {
-            request
+        match Self::build_beta_header(has_mcp, is_oauth) {
+            Some(header) => request.header("anthropic-beta", header),
+            None => request,
         }
     }
 
@@ -412,7 +426,7 @@ impl ProviderImpl for AnthropicProvider {
                 .post(self.endpoint())
                 .header("anthropic-version", "2023-06-01")
                 .json(&body);
-            let request = Self::apply_beta_header(request, has_mcp);
+            let request = Self::apply_beta_header(request, has_mcp, is_oauth);
             let response = match self.apply_auth(request).send().await {
                 Ok(response) => response,
                 Err(error) => {
@@ -740,7 +754,7 @@ impl ProviderImpl for AnthropicProvider {
                 .post(self.endpoint())
                 .header("anthropic-version", "2023-06-01")
                 .json(&body);
-            let request = Self::apply_beta_header(request, has_mcp);
+            let request = Self::apply_beta_header(request, has_mcp, is_oauth);
             let response = match self.apply_auth(request).send().await {
                 Ok(response) => response,
                 Err(error) => {

--- a/sdks/rust/tests/mcp_servers.rs
+++ b/sdks/rust/tests/mcp_servers.rs
@@ -7,6 +7,7 @@ use motosan_ai::{
     ChatRequest, McpServerConfig, McpServerType, McpToolConfig, Message, DEFAULT_ANTHROPIC_MODEL,
 };
 use serde_json::json;
+use tokio_stream::StreamExt;
 
 #[tokio::test]
 async fn anthropic_request_includes_mcp_servers_and_toolset() {
@@ -280,4 +281,126 @@ async fn mcp_tool_configs_replaces_auto_generated() {
             denied_tools: vec!["dangerous_tool".to_string()],
         }
     );
+}
+
+/// When both OAuth (setup token) and MCP servers are active, a single merged
+/// `anthropic-beta` header must be sent containing both `oauth-2025-04-20`
+/// and `mcp-client-2025-11-20`.
+#[tokio::test]
+async fn oauth_plus_mcp_sends_single_merged_beta_header() {
+    let mut server = mockito::Server::new_async().await;
+
+    // OAuth chat() delegates to stream(), so mock must return SSE format.
+    let sse_body = [
+        "event: message_start",
+        &format!(
+            "data: {}",
+            json!({
+                "type": "message_start",
+                "message": {
+                    "id": "msg_test",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": DEFAULT_ANTHROPIC_MODEL,
+                    "usage": {"input_tokens": 5, "output_tokens": 0}
+                }
+            })
+        ),
+        "",
+        "event: content_block_delta",
+        &format!(
+            "data: {}",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "merged"}})
+        ),
+        "",
+        "event: message_delta",
+        &format!(
+            "data: {}",
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 1}})
+        ),
+        "",
+        "event: message_stop",
+        &format!("data: {}", json!({"type": "message_stop"})),
+        "",
+    ]
+    .join("\n");
+
+    // Expect exactly ONE anthropic-beta header that contains BOTH betas.
+    let expected_beta =
+        "claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,mcp-client-2025-11-20";
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("authorization", "Bearer sk-ant-oat01-mcp-oauth-test")
+        .match_header("anthropic-beta", expected_beta)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("sk-ant-oat01-mcp-oauth-test", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .mcp_server(McpServerConfig {
+            kind: McpServerType::Url,
+            url: "https://mcp.example.com/sse".to_string(),
+            name: "linear".to_string(),
+            authorization_token: None,
+        })
+        .build();
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "merged");
+    mock.assert_async().await;
+}
+
+/// Stream path with OAuth + MCP also sends a single merged beta header.
+#[tokio::test]
+async fn oauth_plus_mcp_stream_sends_single_merged_beta_header() {
+    let mut server = mockito::Server::new_async().await;
+
+    let sse_body = [
+        "event: content_block_delta",
+        &format!(
+            "data: {}",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "streamed"}})
+        ),
+        "",
+        "event: message_stop",
+        &format!("data: {}", json!({"type": "message_stop"})),
+        "",
+    ]
+    .join("\n");
+
+    let expected_beta =
+        "claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,mcp-client-2025-11-20";
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("authorization", "Bearer sk-ant-oat01-stream-mcp-test")
+        .match_header("anthropic-beta", expected_beta)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("sk-ant-oat01-stream-mcp-test", None, Some(server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .mcp_server(McpServerConfig {
+            kind: McpServerType::Url,
+            url: "https://mcp.example.com/sse".to_string(),
+            name: "linear".to_string(),
+            authorization_token: None,
+        })
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream");
+    let mut text = String::new();
+    while let Some(event) = stream.next().await {
+        text.push_str(&event.content);
+    }
+    assert_eq!(text, "streamed");
+    mock.assert_async().await;
 }


### PR DESCRIPTION
## Summary
- Unified beta header handling: created `build_beta_header(has_mcp, is_oauth)` that merges all betas into a single comma-separated `anthropic-beta` header
- Removed duplicate `anthropic-beta` from `apply_auth()` — now only set in `apply_beta_header()`
- Added 2 tests: OAuth+MCP via chat (which internally delegates to stream) and direct stream path

Closes #149

## Test plan
- [x] Tests pass (`cargo test --all-features`)
- [x] Format check pass (`cargo fmt`)
- [x] Clippy clean (`cargo clippy --all-features -- -D warnings`)
- [x] Pre-push gate passed (Python unit + Rust unit + Python live + Rust live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)