### PR TITLE
fix: has_mcp should also check mcp_tool_configs (not only mcp_servers) (#150)

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -402,7 +402,8 @@ impl ProviderImpl for AnthropicProvider {
             return Ok(response);
         }
 
-        let has_mcp = req.mcp_servers.as_ref().is_some_and(|s| !s.is_empty());
+        let has_mcp = req.mcp_servers.as_ref().is_some_and(|s| !s.is_empty())
+            || req.mcp_tool_configs.as_ref().is_some_and(|c| !c.is_empty());
         let body = AnthropicRequestBuilder::new(req, self.model.clone(), is_oauth).build();
         let mut attempt = 0;
         let payload: Value;
@@ -550,7 +551,8 @@ impl ProviderImpl for AnthropicProvider {
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
         let is_oauth = Self::is_setup_token(&self.api_key);
-        let has_mcp = req.mcp_servers.as_ref().is_some_and(|s| !s.is_empty());
+        let has_mcp = req.mcp_servers.as_ref().is_some_and(|s| !s.is_empty())
+            || req.mcp_tool_configs.as_ref().is_some_and(|c| !c.is_empty());
         let body = if is_oauth {
             // OAuth: build body manually with system as array of blocks
             let (messages, extracted_system) = {

--- a/sdks/rust/tests/mcp_servers.rs
+++ b/sdks/rust/tests/mcp_servers.rs
@@ -281,3 +281,52 @@ async fn mcp_tool_configs_replaces_auto_generated() {
         }
     );
 }
+
+/// Direct `ChatRequest` construction with only `mcp_tool_configs` (no `mcp_servers`)
+/// must still trigger the beta header.
+#[tokio::test]
+async fn beta_header_sent_when_only_mcp_tool_configs_present() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_header("anthropic-beta", "mcp-client-2025-11-20")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": DEFAULT_ANTHROPIC_MODEL,
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+
+    // Construct ChatRequest directly (bypassing builder) with only mcp_tool_configs
+    let request = ChatRequest {
+        messages: vec![Message::user("hello")],
+        model: None,
+        system: None,
+        system_blocks: None,
+        system_cache: false,
+        temperature: None,
+        max_tokens: None,
+        tools: None,
+        tool_choice: None,
+        provider_options: None,
+        mcp_servers: None,
+        mcp_tool_configs: Some(vec![McpToolConfig::All {
+            mcp_server_name: "linear".to_string(),
+        }]),
+        thinking: None,
+        stop_sequences: None,
+    };
+
+    let response = provider.chat(request).await.expect("chat response");
+    assert_eq!(response.content, "ok");
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- Fixed `has_mcp` computation in both `chat()` and `stream()` to also check `mcp_tool_configs`, not just `mcp_servers`
- Prevents API errors when `ChatRequest` is constructed directly (bypassing builder) with only `mcp_tool_configs` populated
- Added test for direct `ChatRequest` construction with only `mcp_tool_configs`

Closes #150

## Test plan
- [x] Tests pass (`cargo test --all-features`)
- [x] Format check pass (`cargo fmt`)
- [x] Pre-push gate passed (Python unit + Rust unit + Python live + Rust live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)