### PR TITLE
fix: mcp_toolset serialization uses mcp_server_name instead of server_label (#153)

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -160,14 +160,14 @@ fn serialize_mcp_tool_config(config: &McpToolConfig) -> Value {
     match config {
         McpToolConfig::All { mcp_server_name } => json!({
             "type": "mcp_toolset",
-            "server_label": mcp_server_name,
+            "mcp_server_name": mcp_server_name,
         }),
         McpToolConfig::Allowed {
             mcp_server_name,
             allowed_tools,
         } => json!({
             "type": "mcp_toolset",
-            "server_label": mcp_server_name,
+            "mcp_server_name": mcp_server_name,
             "allowed_tools": allowed_tools,
         }),
         McpToolConfig::Denied {
@@ -175,7 +175,7 @@ fn serialize_mcp_tool_config(config: &McpToolConfig) -> Value {
             denied_tools,
         } => json!({
             "type": "mcp_toolset",
-            "server_label": mcp_server_name,
+            "mcp_server_name": mcp_server_name,
             "denied_tools": denied_tools,
         }),
     }

--- a/sdks/rust/tests/mcp_servers.rs
+++ b/sdks/rust/tests/mcp_servers.rs
@@ -25,7 +25,7 @@ async fn anthropic_request_includes_mcp_servers_and_toolset() {
         .match_body(Matcher::Regex(r#""name"\s*:\s*"linear""#.to_string()))
         .match_body(Matcher::Regex(r#""type"\s*:\s*"mcp_toolset""#.to_string()))
         .match_body(Matcher::Regex(
-            r#""server_label"\s*:\s*"linear""#.to_string(),
+            r#""mcp_server_name"\s*:\s*"linear""#.to_string(),
         ))
         .with_status(200)
         .with_body(


### PR DESCRIPTION
## Summary
- Changed `serialize_mcp_tool_config` to use `"mcp_server_name"` instead of `"server_label"` in all three `McpToolConfig` arms
- Updated mock test regex to match the corrected field name
- Verified with live OAuth + MCP request: API no longer returns `mcp_server_name: Field required`

Closes #153

## Test plan
- [x] All tests pass (`cargo test --all-features`)
- [x] Pre-push gate passed (Python + Rust unit + live tests)
- [x] Live OAuth + MCP test: serialization error gone, API accepts request

🤖 Generated with [Claude Code](https://claude.com/claude-code)