### PR TITLE
feat: ClaudeCodeClient::chat_stream() NDJSON streaming (#158)

### DIFF
--- a/WORKER_REPORT.md
+++ b/WORKER_REPORT.md
@@ -1,28 +1,29 @@
-# Worker Report: Issue #157
+# Worker Report: Issue #158
 
 ## Summary
-Implemented `ClaudeCodeClient::chat()` — the blocking subprocess path that invokes the `claude` CLI via `tokio::process::Command`.
+Implemented `ClaudeCodeClient::stream()` method with NDJSON parsing for `--output-format stream-json`.
 
 ## Changes
 
 ### `sdks/rust/Cargo.toml`
-- Added `process` and `io-util` features to the tokio dependency (needed for subprocess spawning and stdin writing).
+- Added `async-stream = { version = "0.3", optional = true }` dependency
+- Added `"dep:async-stream"` to `claude-code` feature list
 
-### `sdks/rust/src/claude_code/spawn.rs`
-- `SpawnConfig` struct: holds binary path, agent mode flag, model, and system prompt.
-- `invoke_cli()` async function: spawns `claude --print`, passes prompt via stdin, handles 300s timeout, parses agent-mode JSON output for result/usage.
-
-### `sdks/rust/src/claude_code/prompt.rs` (NEW)
-- `messages_to_prompt()`: flattens multi-turn `Message` slice into `(Option<system_prompt>, user_prompt)` for the CLI.
-- 4 unit tests covering single message, multi-turn, system extraction, and empty input.
+### `sdks/rust/src/claude_code/stream_json.rs` (new)
+- `ClaudeStreamEvent` — tagged enum deserializing `text` and `result` NDJSON events
+- `ClaudeStreamUsage` — usage fields from result events
+- `NdjsonAction` — parsed action enum (Text or Result)
+- `parse_ndjson_line()` — parses a single NDJSON line into `NdjsonAction`
+- 6 unit tests: text event, result with/without usage, unknown events, malformed JSON, empty text
 
 ### `sdks/rust/src/claude_code/mod.rs`
-- Added `pub mod prompt;` declaration.
-- Implemented `chat()` method on `ClaudeCodeClient`: extracts system prompt, flattens messages, builds `SpawnConfig`, calls `invoke_cli`, returns `ChatResponse`.
-- Added `#[ignore]` integration test for manual CLI verification.
+- Added `stream()` method to `ClaudeCodeClient`
+- Spawns `claude --print --output-format stream-json` with optional flags
+- Reads stdout line-by-line via `BufReader`, parses each line with `parse_ndjson_line`
+- Yields `StreamEvent::text`, `StreamEvent::usage`, and `StreamEvent::done` events
+- Returns `Result<BoxStream, MotosanError>`
 
 ## Verification
 - `cargo fmt` — clean
-- `cargo check --features claude-code` — compiles (no new warnings)
-- `cargo clippy --features claude-code` — no new warnings (pre-existing `client.rs` warnings unchanged)
-- `cargo test --features claude-code` — 25 passed, 0 failed, 1 ignored
+- `cargo check --features claude-code` — compiles (only pre-existing warning)
+- `cargo test --features claude-code` — 31 passed, 0 failed, 1 ignored (integration)

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -40,7 +40,7 @@ ollama_native = [
   "dep:tokio-stream",
   "dep:bytes",
 ]
-claude-code = ["dep:tokio", "dep:tokio-stream"]
+claude-code = ["dep:tokio", "dep:tokio-stream", "dep:async-stream"]
 agent-tool = ["dep:motosan-agent-tool"]
 full = ["anthropic", "openai", "minimax", "ollama", "ollama_native"]
 
@@ -62,6 +62,7 @@ reqwest = { version = "0.12", optional = true, features = [
 eventsource-stream = { version = "0.2", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tokio = { version = "1", optional = true, features = ["time", "process", "io-util"] }
+async-stream = { version = "0.3", optional = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/sdks/rust/src/claude_code/mod.rs
+++ b/sdks/rust/src/claude_code/mod.rs
@@ -6,6 +6,7 @@ use std::env;
 use std::path::PathBuf;
 
 use crate::error::MotosanError;
+use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, StopReason};
 
 /// Client that shells out to the `claude` CLI binary.
@@ -74,6 +75,94 @@ impl ClaudeCodeClient {
             usage,
             stop_reason: StopReason::EndTurn,
         })
+    }
+
+    /// Stream a chat request via `claude --print --output-format stream-json`.
+    ///
+    /// Returns a `BoxStream` that yields `StreamEvent` items parsed from
+    /// newline-delimited JSON events emitted by the CLI.
+    pub async fn stream(&self, request: ChatRequest) -> Result<BoxStream, MotosanError> {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        use tokio::process::Command;
+
+        let (msg_system, user_prompt) = prompt::messages_to_prompt(&request.messages);
+        let system_prompt = request.system.or(msg_system);
+        let model = request.model.or_else(|| self.model.clone());
+
+        let mut cmd = Command::new(&self.binary_path);
+        cmd.arg("--print").arg("--output-format").arg("stream-json");
+
+        if self.agent_mode {
+            cmd.arg("--dangerously-skip-permissions");
+        }
+
+        if let Some(ref m) = model {
+            cmd.arg("--model").arg(m);
+        }
+
+        if let Some(ref sp) = system_prompt {
+            if !sp.is_empty() {
+                cmd.arg("--append-system-prompt").arg(sp);
+            }
+        }
+
+        cmd.arg("-");
+        cmd.kill_on_drop(true);
+        cmd.stdin(std::process::Stdio::piped());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| MotosanError::ProviderError(format!("failed to spawn claude CLI: {e}")))?;
+
+        // Write prompt to stdin then close it
+        {
+            let mut stdin = child.stdin.take().ok_or_else(|| {
+                MotosanError::ProviderError("failed to open claude CLI stdin".to_string())
+            })?;
+            stdin.write_all(user_prompt.as_bytes()).await.map_err(|e| {
+                MotosanError::ProviderError(format!("failed to write to claude stdin: {e}"))
+            })?;
+            // stdin dropped here, sending EOF
+        }
+
+        let stdout = child.stdout.take().ok_or_else(|| {
+            MotosanError::ProviderError("failed to open claude CLI stdout".to_string())
+        })?;
+
+        let reader = BufReader::new(stdout);
+
+        let stream = async_stream::stream! {
+            let mut lines = reader.lines();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                let line = line.trim().to_string();
+                if line.is_empty() {
+                    continue;
+                }
+
+                if let Some(action) = stream_json::parse_ndjson_line(&line) {
+                    match action {
+                        stream_json::NdjsonAction::Text(event) => {
+                            yield event;
+                        }
+                        stream_json::NdjsonAction::Result { usage, done } => {
+                            if let Some(usage_event) = usage {
+                                yield usage_event;
+                            }
+                            yield done;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Wait for child to exit
+            let _ = child.wait().await;
+        };
+
+        Ok(Box::pin(stream) as BoxStream)
     }
 }
 

--- a/sdks/rust/src/claude_code/stream_json.rs
+++ b/sdks/rust/src/claude_code/stream_json.rs
@@ -1,1 +1,129 @@
+use serde::Deserialize;
 
+use crate::types::{StreamEvent, Usage};
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+pub enum ClaudeStreamEvent {
+    #[serde(rename = "text")]
+    Text { text: String },
+
+    #[serde(rename = "result")]
+    Result {
+        #[allow(dead_code)]
+        result: String,
+        #[serde(default)]
+        usage: Option<ClaudeStreamUsage>,
+    },
+
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize)]
+pub struct ClaudeStreamUsage {
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+}
+
+/// Action produced by parsing a single NDJSON line.
+pub enum NdjsonAction {
+    Text(StreamEvent),
+    Result {
+        usage: Option<StreamEvent>,
+        done: StreamEvent,
+    },
+}
+
+/// Parse a single NDJSON line into an action.
+/// Returns `None` for unrecognized or malformed events.
+pub fn parse_ndjson_line(line: &str) -> Option<NdjsonAction> {
+    let event: ClaudeStreamEvent = serde_json::from_str(line).ok()?;
+    match event {
+        ClaudeStreamEvent::Text { text } if !text.is_empty() => {
+            Some(NdjsonAction::Text(StreamEvent::text(text)))
+        }
+        ClaudeStreamEvent::Result { usage, .. } => {
+            let usage_event = usage.map(|u| {
+                StreamEvent::usage(Usage {
+                    input_tokens: u.input_tokens.unwrap_or(0) as u32,
+                    output_tokens: u.output_tokens.unwrap_or(0) as u32,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                })
+            });
+            Some(NdjsonAction::Result {
+                usage: usage_event,
+                done: StreamEvent::done(),
+            })
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_text_event() {
+        let line = r#"{"type":"text","text":"Hello"}"#;
+        let action = parse_ndjson_line(line).expect("should parse");
+        match action {
+            NdjsonAction::Text(event) => {
+                assert_eq!(event.content, "Hello");
+                assert!(!event.done);
+            }
+            _ => panic!("expected Text action"),
+        }
+    }
+
+    #[test]
+    fn parse_result_with_usage() {
+        let line =
+            r#"{"type":"result","result":"done","usage":{"input_tokens":12,"output_tokens":8}}"#;
+        let action = parse_ndjson_line(line).expect("should parse");
+        match action {
+            NdjsonAction::Result { usage, done } => {
+                let usage = usage.expect("usage should be present");
+                let u = usage.usage.expect("usage field should exist");
+                assert_eq!(u.input_tokens, 12);
+                assert_eq!(u.output_tokens, 8);
+                assert!(done.done);
+            }
+            _ => panic!("expected Result action"),
+        }
+    }
+
+    #[test]
+    fn parse_result_without_usage() {
+        let line = r#"{"type":"result","result":"done"}"#;
+        let action = parse_ndjson_line(line).expect("should parse");
+        match action {
+            NdjsonAction::Result { usage, done } => {
+                assert!(usage.is_none());
+                assert!(done.done);
+            }
+            _ => panic!("expected Result action"),
+        }
+    }
+
+    #[test]
+    fn ignore_unknown_event() {
+        let line = r#"{"type":"progress","percent":50}"#;
+        assert!(parse_ndjson_line(line).is_none());
+    }
+
+    #[test]
+    fn handle_malformed_json() {
+        assert!(parse_ndjson_line("not json at all").is_none());
+        assert!(parse_ndjson_line("{").is_none());
+        assert!(parse_ndjson_line("").is_none());
+    }
+
+    #[test]
+    fn ignore_empty_text() {
+        let line = r#"{"type":"text","text":""}"#;
+        assert!(parse_ndjson_line(line).is_none());
+    }
+}


### PR DESCRIPTION
Closes #158

## Summary
- Implement `ClaudeCodeClient::stream()` — spawns `claude --print --output-format stream-json`
- NDJSON parser in `stream_json.rs` — `ClaudeStreamEvent` tagged enum with text/result/other variants
- Returns `BoxStream` yielding `StreamEvent::text`, `StreamEvent::usage`, `StreamEvent::done`
- 6 unit tests for NDJSON parsing

## Test plan
- [x] `cargo test --features claude-code` — 31 passed, 1 ignored
- [x] `cargo check --features claude-code` passes
- [x] Text delta events emitted for each text chunk
- [x] Usage event emitted when available in result
- [x] Done event emitted at stream end
- [x] `kill_on_drop(true)` set on child process