### PR TITLE
docs: document three LlmClient backends (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.6.0] — 2026-04-05
+
+### Added
+
+- **ClaudeCodeClient** — new backend that shells out to the `claude` CLI binary, enabling chat and streaming without an API key. Requires `--features claude-code`.
+  - `ClaudeCodeClient::chat()` — blocking subprocess invocation returning `ChatResponse`
+  - `ClaudeCodeClient::stream()` — NDJSON streaming via `--output-format stream-json`
+  - Configurable binary path (`CLAUDE_CODE_PATH` env or builder), agent mode, model override
+- **README** — documented all three LlmClient backends (API key, OAuth token, Claude Code CLI)
+- **Feature flag** — `claude-code` feature in Cargo.toml gating the new backend
+
+### Limitations
+
+- `ClaudeCodeClient` does not support tool calling — `tool_calls` is always an empty vec
+- Requires `claude` CLI installed and authenticated locally

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ response = await client.chat([Message.user("Hello")])
 # Rust (Cargo.toml)
 [dependencies]
 motosan-ai = { version = "0.5.4", features = ["anthropic"] }
-# features: anthropic | openai | minimax | ollama | ollama_native | full
+# features: anthropic | openai | minimax | ollama | ollama_native | full | claude-code
 ```
 
 ```bash
@@ -53,6 +53,40 @@ pip install "motosan-ai[full]"   # all providers
 | MiniMax | `MiniMax-M2.5-highspeed` | `minimax` | `[minimax]` |
 | Ollama | `llama3.2` | `ollama` / `ollama_native` | `[ollama]` |
 
+## Backends (Rust)
+
+`motosan-ai` supports three ways to talk to Claude, all returning the same `ChatResponse` / `StreamEvent` types:
+
+```rust
+use motosan_ai::{Client, Message, Provider};
+
+// 1. API key — direct HTTP to Anthropic
+let client = Client::builder()
+    .provider(Provider::Anthropic)
+    .api_key("sk-ant-api03-...")
+    .build()?;
+let response = client.chat(vec![Message::user("Hello")]).await?;
+
+// 2. OAuth token — same Client, auto-detected from token prefix
+let client = Client::builder()
+    .provider(Provider::Anthropic)
+    .api_key("sk-ant-oat01-...")   // OAuth format
+    .build()?;
+let response = client.chat(vec![Message::user("Hello")]).await?;
+```
+
+```rust
+// 3. Claude Code CLI — no API key needed (uses your local claude session)
+// Requires: cargo add motosan-ai --features claude-code
+use motosan_ai::ClaudeCodeClient;
+
+let client = ClaudeCodeClient::new();
+let response = client.chat(request).await?;
+let stream = client.stream(request).await?;   // NDJSON streaming
+```
+
+> **ClaudeCodeClient limitations:** No tool calling support — `tool_calls` is always empty. Requires the `claude` CLI installed and authenticated. Enable with `--features claude-code`.
+
 ## Features
 
 - **Chat & Streaming** — `chat()`, `stream()`, `chat_with()`, `stream_with()`, `stream_collect()`
@@ -63,6 +97,7 @@ pip install "motosan-ai[full]"   # all providers
 - **Stream Read Timeout** — configurable per-chunk timeout to prevent SSE hanging
 - **Extended Thinking** — first-class support for Anthropic thinking mode
 - **MCP** — server-side MCP support in `ChatRequest`
+- **Claude Code Backend** — shell out to `claude` CLI via `ClaudeCodeClient` (`--features claude-code`)
 
 ## Quick Example
 

--- a/WORKER_REPORT.md
+++ b/WORKER_REPORT.md
@@ -1,29 +1,24 @@
-# Worker Report: Issue #158
+# Worker Report: Issue #159
 
 ## Summary
-Implemented `ClaudeCodeClient::stream()` method with NDJSON parsing for `--output-format stream-json`.
+Documented the three LlmClient backends (API key, OAuth, Claude Code CLI) in README and created CHANGELOG for v0.6.0.
 
 ## Changes
 
-### `sdks/rust/Cargo.toml`
-- Added `async-stream = { version = "0.3", optional = true }` dependency
-- Added `"dep:async-stream"` to `claude-code` feature list
+### `README.md`
+- Added "Backends (Rust)" section with examples for all three backends
+- Added `claude-code` to the feature list comment in Install section
+- Added "Claude Code Backend" bullet to Features list
+- Documented ClaudeCodeClient limitations (no tool calling, requires CLI)
 
-### `sdks/rust/src/claude_code/stream_json.rs` (new)
-- `ClaudeStreamEvent` — tagged enum deserializing `text` and `result` NDJSON events
-- `ClaudeStreamUsage` — usage fields from result events
-- `NdjsonAction` — parsed action enum (Text or Result)
-- `parse_ndjson_line()` — parses a single NDJSON line into `NdjsonAction`
-- 6 unit tests: text event, result with/without usage, unknown events, malformed JSON, empty text
+### `CHANGELOG.md` (new)
+- Created with `[0.6.0]` entry documenting ClaudeCodeClient and its limitations
 
-### `sdks/rust/src/claude_code/mod.rs`
-- Added `stream()` method to `ClaudeCodeClient`
-- Spawns `claude --print --output-format stream-json` with optional flags
-- Reads stdout line-by-line via `BufReader`, parses each line with `parse_ndjson_line`
-- Yields `StreamEvent::text`, `StreamEvent::usage`, and `StreamEvent::done` events
-- Returns `Result<BoxStream, MotosanError>`
+## Acceptance Criteria
+- [x] README updated with three-backend example
+- [x] Feature flag instructions documented (`--features claude-code`)
+- [x] Limitations of ClaudeCodeClient noted (no tool calling)
+- [x] CHANGELOG updated
 
-## Verification
-- `cargo fmt` — clean
-- `cargo check --features claude-code` — compiles (only pre-existing warning)
-- `cargo test --features claude-code` — 31 passed, 0 failed, 1 ignored (integration)
+## Concerns
+- None. This is a docs-only change.


### PR DESCRIPTION
Closes #159

## Summary
- Added "Backends (Rust)" section to README documenting all three backends: API key, OAuth token, and Claude Code CLI
- Documented `--features claude-code` feature flag in install section
- Noted ClaudeCodeClient limitations (no tool calling, requires CLI)
- Created CHANGELOG.md with `[0.6.0]` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)