### PR TITLE
feat(rust): add bare flag to ClaudeCodeProvider

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -37,6 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.82.0
+      - name: Pin indexmap for MSRV
+        # indexmap >=2.14 requires hashbrown >=0.17, which itself requires
+        # the unstable `edition2024` Cargo feature — unavailable on 1.82.
+        # Cargo.lock is gitignored (library crate), so without this pin
+        # CI resolves transitively to the latest indexmap on every run.
+        run: |
+          cargo generate-lockfile
+          cargo update -p indexmap --precise 2.13.1
       - name: Cargo build (no features)
         run: cargo build
       - name: Cargo test (no features)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.12.0 (crates.io) · Python v0.5.0 (PyPI)
+Rust v0.12.1 (crates.io) · Python v0.5.0 (PyPI)
 
 ## Where To Find Things
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [rust-0.12.1] — 2026-04-19
+
+### Added (Rust only)
+
+- **`ClaudeCodeProvider.bare(bool)`** — forwards `--bare` to the spawned `claude` subprocess (skips hooks, plugins, auto-memory, keychain reads, and user/project settings discovery). Intended for daemon / server embeddings that must not inherit the operator's interactive Claude Code state. Leave `false` (default) for workflows that should pick up `~/.claude/` configuration.
+
 ## [0.11.1] — 2026-04-15
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.12.0 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.12.1 |
 | Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.5.0 |
 
 ## Install
@@ -34,7 +34,7 @@ response = await client.chat([Message.user("Hello")])
 ```toml
 # Rust (Cargo.toml)
 [dependencies]
-motosan-ai = { version = "0.12.0", features = ["anthropic"] }
+motosan-ai = { version = "0.12.1", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full | claude-code | codex-cli | gemini-cli
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ let client = Client::builder()
     .provider(Provider::ClaudeCode)
     .claude_code(
         ClaudeCodeProvider::new()
+            .bare(true)                               // --bare (daemon-safe; skip hooks/plugins/auto-memory)
             .model("sonnet")
             .system_prompt("Be terse.")              // --system-prompt
             .permission_mode(PermissionMode::Plan)    // --permission-mode plan

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, and MiniMax — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.5.0 · Rust 0.12.0
+- Python 0.5.0 · Rust 0.12.1
 - GitHub: https://github.com/motosan-dev/motosan-ai
 - PyPI: https://pypi.org/project/motosan-ai/
 - crates.io: https://crates.io/crates/motosan-ai
@@ -18,7 +18,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.12.0", features = ["anthropic"] }
+motosan-ai = { version = "0.12.1", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 # CLI backends (Rust only, shell out to a local binary):
 #   claude-code  → ClaudeCodeProvider → `claude --print --output-format stream-json`
@@ -530,6 +530,7 @@ let client = Client::builder()
     .provider(Provider::ClaudeCode)
     .claude_code(
         ClaudeCodeProvider::new()
+            .bare(true)                                 // --bare (daemon-safe; skip hooks/plugins/auto-memory)
             .model("sonnet")                            // --model
             .system_prompt("Be terse.")                 // --system-prompt (full replacement)
             .permission_mode(PermissionMode::Plan)      // --permission-mode plan
@@ -599,6 +600,7 @@ Key notes:
 - `ApprovalMode` variants (Gemini): `Default` / `AutoEdit` / `Yolo` / `Plan`. `yolo(true)` is shorthand for `--yolo` (same effect as `ApprovalMode::Yolo`).
 - `PermissionMode` variants (Claude Code): `AcceptEdits` / `Auto` / `BypassPermissions` / `Default` / `DontAsk` / `Plan`. Distinct from `.agent_mode(true)`, which forwards `--dangerously-skip-permissions` and switches the blocking path to `--output-format json` so usage tokens can be parsed.
 - `EffortLevel` variants (Claude Code): `Low` / `Medium` / `High` / `Max`. Maps to `--effort`.
+- Claude Code isolation: `.bare(true)` forwards `--bare`, so the spawned `claude` skips hooks, plugins, auto-memory, keychain reads, and user/project settings discovery. Recommended for daemons / servers that must not inherit the operator's interactive state; leave `false` for workflows that should pick up `~/.claude/`. Emitted before `--dangerously-skip-permissions`.
 - Claude Code system prompts: `.system_prompt(...)` forwards `--system-prompt` (full replacement); message-extracted system prompts flow through `--append-system-prompt`. Both can coexist — Claude applies append on top of replace.
 - Claude Code budget: `.max_budget_usd(amount)` drops non-finite and negative values at argv-build time so the CLI never receives an invalid number. Only meaningful under `--print`.
 - Claude Code session flags (`--session-id` / `--resume` / `--continue` / `--fork-session` / `--no-session-persistence`) all live on the same `ClaudeCodeProvider` builder; blank string inputs are skipped so `.resume("")` is a no-op.

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
+## [0.12.1] - 2026-04-19
+
+### Added
+- **`ClaudeCodeProvider.bare` field + `.bare(bool)` builder** — forwards `--bare` to the spawned `claude` subprocess, which skips hooks, plugins, auto-memory, keychain reads, and user/project settings discovery. Intended for daemon / server embeddings that must not inherit the operator's interactive Claude Code state. Leave `false` (default) for workflows that should pick up `~/.claude/` configuration. Emitted in argv before `--dangerously-skip-permissions` so the two flags compose deterministically; order locked by `common_args_bare_precedes_agent_mode` and the full-loadout order test.
+
 ## [0.12.0] - 2026-04-15
 
 ### Breaking

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -310,7 +310,7 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
 ```toml
-motosan-ai = { version = "0.12.0", features = ["claude-code"] }
+motosan-ai = { version = "0.12.1", features = ["claude-code"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -323,6 +323,7 @@ let client = Client::builder()
     .provider(Provider::ClaudeCode)
     .claude_code(
         ClaudeCodeProvider::new()                       // uses $CLAUDE_CODE_PATH or "claude" in PATH
+            .bare(true)                                 // --bare (daemon-safe: skip hooks/plugins/auto-memory)
             .model("sonnet")                            // --model
             .system_prompt("Be terse.")                 // --system-prompt (full replacement)
             .permission_mode(PermissionMode::Plan)      // --permission-mode plan
@@ -376,6 +377,9 @@ All setters return `Self` for chaining. Omitted setters leave the corresponding 
 - `.agent_mode(bool)` — `--dangerously-skip-permissions`, also switches the blocking path to `--output-format json` so usage tokens can be parsed.
 - `.permission_mode(PermissionMode::{AcceptEdits,Auto,BypassPermissions,Default,DontAsk,Plan})` — `--permission-mode`.
 
+**Isolation**
+- `.bare(bool)` — `--bare`. Spawned `claude` skips hooks, plugins, auto-memory, keychain reads, and user/project settings discovery, so the subprocess does not inherit the operator's interactive Claude Code state. Recommended `true` for daemon / server use; leave `false` for interactive workflows that should pick up `~/.claude/` configuration. Emitted before `--dangerously-skip-permissions` in argv.
+
 **Workspace & tools**
 - `.add_dir(path)` / `.add_dirs(vec)` — `--add-dir` (repeatable).
 - `.allow_tool(name)` / `.allowed_tools(vec)` — `--allowed-tools` (variadic).
@@ -415,7 +419,7 @@ Notes:
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
 ```toml
-motosan-ai = { version = "0.12.0", features = ["codex-cli"] }
+motosan-ai = { version = "0.12.1", features = ["codex-cli"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -478,7 +482,7 @@ Notes:
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
 ```toml
-motosan-ai = { version = "0.12.0", features = ["gemini-cli"] }
+motosan-ai = { version = "0.12.1", features = ["gemini-cli"] }
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/rust/src/providers/claude_code/mod.rs
+++ b/sdks/rust/src/providers/claude_code/mod.rs
@@ -49,7 +49,9 @@ pub struct ClaudeCodeProvider {
     ///   `~/.claude/` user settings, project `.claude/` settings,
     ///   auto-memory, plugin sync, and `CLAUDE.md` auto-discovery
     ///   all stop. [`setting_sources`](Self::setting_sources) becomes
-    ///   inert because the discovery step it controls is disabled.
+    ///   inert because the discovery step it controls is disabled —
+    ///   the CLI accepts the flag without error, the values simply
+    ///   have no effect.
     /// - **Explicit context still flows**: values you pass via
     ///   [`settings`](Self::settings), [`mcp_config`](Self::mcp_config),
     ///   [`add_dirs`](Self::add_dirs), [`plugin_dirs`](Self::plugin_dirs),
@@ -596,6 +598,26 @@ mod tests {
         assert!(
             content.chars().any(|c| c as u32 > 0x2000),
             "expected a non-ASCII character (emoji), got: {content:?}"
+        );
+    }
+
+    /// End-to-end verification that `.bare(true)` is accepted by the
+    /// installed `claude` CLI and a plain `--print` turn still completes.
+    /// Catches a future CLI rename of the flag. Requires `ANTHROPIC_API_KEY`
+    /// in the environment because `--bare` disables OAuth / keychain auth.
+    #[tokio::test]
+    #[ignore]
+    async fn integration_bare_flag_accepted_by_cli() {
+        let client = ClaudeCodeProvider::new().bare(true);
+
+        let resp = client
+            .chat(test_request("Reply with only the word 'pong'."))
+            .await
+            .expect("chat should succeed under --bare");
+        assert!(
+            resp.content.to_lowercase().contains("pong"),
+            "expected 'pong' in response, got: {}",
+            resp.content
         );
     }
 

--- a/sdks/rust/src/providers/claude_code/mod.rs
+++ b/sdks/rust/src/providers/claude_code/mod.rs
@@ -29,6 +29,36 @@ pub struct ClaudeCodeProvider {
     /// Whether to pass `--dangerously-skip-permissions` and switch the
     /// blocking path to `--output-format json` (so usage can be parsed).
     pub agent_mode: bool,
+    /// Whether to pass `--bare`. Skips hooks, plugins, auto-memory,
+    /// keychain reads, and user/project settings discovery, so the
+    /// subprocess does not inherit ambient Claude Code state from
+    /// the operator's shell. Recommended `true` for daemon / server
+    /// use; leave `false` for interactive workflows that should pick
+    /// up the operator's `~/.claude/` configuration.
+    ///
+    /// # Interactions with other fields
+    ///
+    /// - **Auth**: under `--bare`, Anthropic auth is restricted to
+    ///   `ANTHROPIC_API_KEY` or an `apiKeyHelper` declared inside
+    ///   the file passed to [`settings`](Self::settings). OAuth
+    ///   subscription and keychain reads are **never** consulted.
+    ///   Callers running headless must export `ANTHROPIC_API_KEY`
+    ///   or hand a `--settings` JSON before flipping this on, or
+    ///   every request will fail with an auth error.
+    /// - **Auto-discovered context is suppressed**: hooks,
+    ///   `~/.claude/` user settings, project `.claude/` settings,
+    ///   auto-memory, plugin sync, and `CLAUDE.md` auto-discovery
+    ///   all stop. [`setting_sources`](Self::setting_sources) becomes
+    ///   inert because the discovery step it controls is disabled.
+    /// - **Explicit context still flows**: values you pass via
+    ///   [`settings`](Self::settings), [`mcp_config`](Self::mcp_config),
+    ///   [`add_dirs`](Self::add_dirs), [`plugin_dirs`](Self::plugin_dirs),
+    ///   [`agent`](Self::agent), [`system_prompt`](Self::system_prompt),
+    ///   and the message-extracted `--append-system-prompt` are
+    ///   honoured normally — `--bare` only kills the *implicit*
+    ///   discovery path, not what you hand the CLI yourself.
+    /// - Skills still resolve via `/skill-name` invocation.
+    pub bare: bool,
     /// Default model forwarded as `--model <name>`.
     pub model: Option<String>,
     /// Full system-prompt replacement (`--system-prompt`). Coexists
@@ -83,6 +113,7 @@ impl ClaudeCodeProvider {
         Self {
             binary_path,
             agent_mode: false,
+            bare: false,
             model: None,
             system_prompt: None,
             permission_mode: None,
@@ -117,6 +148,22 @@ impl ClaudeCodeProvider {
     /// Enable or disable agent mode (`--dangerously-skip-permissions`).
     pub fn agent_mode(mut self, enabled: bool) -> Self {
         self.agent_mode = enabled;
+        self
+    }
+
+    /// Enable or disable `--bare`. When `true`, the spawned `claude`
+    /// subprocess skips hooks, plugins, auto-memory, keychain reads,
+    /// and user/project settings discovery — useful for daemons that
+    /// must not inherit the operator's interactive Claude Code state.
+    ///
+    /// **Read [`Self::bare`] before flipping this on** — `--bare`
+    /// restricts Anthropic auth to `ANTHROPIC_API_KEY` /
+    /// `apiKeyHelper` (no OAuth, no keychain) and silently makes
+    /// [`Self::setting_sources`] inert. Explicit `settings`,
+    /// `mcp_config`, `add_dirs`, `plugin_dirs`, `agent`, and
+    /// `system_prompt` still work as expected.
+    pub fn bare(mut self, enabled: bool) -> Self {
+        self.bare = enabled;
         self
     }
 
@@ -285,6 +332,7 @@ impl ClaudeCodeProvider {
         spawn::SpawnConfig {
             binary_path: self.binary_path.clone(),
             agent_mode: self.agent_mode,
+            bare: self.bare,
             model: request_model.or_else(|| self.model.clone()),
             append_system_prompt,
             system_prompt: self.system_prompt.clone(),
@@ -447,6 +495,7 @@ mod tests {
     fn builder_methods_populate_spawn_config() {
         let provider = ClaudeCodeProvider::new()
             .agent_mode(true)
+            .bare(true)
             .model("sonnet")
             .system_prompt("be terse")
             .permission_mode(PermissionMode::Plan)
@@ -471,6 +520,7 @@ mod tests {
 
         let cfg = provider.build_spawn_config(None, Some("append".to_string()));
         assert!(cfg.agent_mode);
+        assert!(cfg.bare);
         assert_eq!(cfg.model.as_deref(), Some("sonnet"));
         assert_eq!(cfg.system_prompt.as_deref(), Some("be terse"));
         assert_eq!(cfg.append_system_prompt.as_deref(), Some("append"));

--- a/sdks/rust/src/providers/claude_code/spawn.rs
+++ b/sdks/rust/src/providers/claude_code/spawn.rs
@@ -94,6 +94,17 @@ pub struct SpawnConfig {
     /// Whether to pass `--dangerously-skip-permissions`. Also flips the
     /// blocking path to `--output-format json` so usage can be parsed.
     pub agent_mode: bool,
+    /// Whether to pass `--bare`. Skips hooks, plugins, auto-memory,
+    /// keychain reads, and user/project settings discovery so the
+    /// subprocess does not inherit ambient Claude Code state.
+    /// Under `--bare`, Anthropic auth is restricted to
+    /// `ANTHROPIC_API_KEY` or an `apiKeyHelper` declared inside
+    /// `settings`; `setting_sources` is inert because the discovery
+    /// it controls is disabled. Explicit `settings`, `mcp_config`,
+    /// `add_dirs`, `plugin_dirs`, `agent`, and `system_prompt` are
+    /// still honoured. See [`super::ClaudeCodeProvider::bare`] for
+    /// the public-API documentation.
+    pub bare: bool,
     /// Model name for `--model`. `None` / `"default"` / blank are skipped.
     pub model: Option<String>,
     /// Text appended via `--append-system-prompt`. Usually populated
@@ -180,6 +191,10 @@ pub(crate) fn model_to_forward(model: &str) -> Option<&str> {
 /// command line for debugging.
 pub(crate) fn common_args(config: &SpawnConfig) -> Vec<OsString> {
     let mut args: Vec<OsString> = Vec::new();
+
+    if config.bare {
+        args.push("--bare".into());
+    }
 
     if config.agent_mode {
         args.push("--dangerously-skip-permissions".into());
@@ -455,6 +470,7 @@ mod tests {
         SpawnConfig {
             binary_path: PathBuf::from("claude"),
             agent_mode: false,
+            bare: false,
             model: None,
             append_system_prompt: None,
             system_prompt: None,
@@ -525,6 +541,28 @@ mod tests {
         assert_eq!(
             args_as_strings(&common_args(&cfg)),
             vec!["--dangerously-skip-permissions"]
+        );
+    }
+
+    #[test]
+    fn common_args_bare_emits_bare_flag() {
+        let cfg = SpawnConfig {
+            bare: true,
+            ..empty_config()
+        };
+        assert_eq!(args_as_strings(&common_args(&cfg)), vec!["--bare"]);
+    }
+
+    #[test]
+    fn common_args_bare_precedes_agent_mode() {
+        let cfg = SpawnConfig {
+            bare: true,
+            agent_mode: true,
+            ..empty_config()
+        };
+        assert_eq!(
+            args_as_strings(&common_args(&cfg)),
+            vec!["--bare", "--dangerously-skip-permissions"]
         );
     }
 
@@ -813,6 +851,7 @@ mod tests {
         let cfg = SpawnConfig {
             binary_path: PathBuf::from("claude"),
             agent_mode: true,
+            bare: true,
             model: Some("sonnet".to_string()),
             append_system_prompt: Some("append".to_string()),
             system_prompt: Some("base".to_string()),
@@ -838,6 +877,7 @@ mod tests {
         assert_eq!(
             args_as_strings(&common_args(&cfg)),
             vec![
+                "--bare",
                 "--dangerously-skip-permissions",
                 "--permission-mode",
                 "plan",

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) — LLM ch
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.5.0 / Rust 0.12.0
+Multi-provider LLM SDK — Python 0.5.0 / Rust 0.12.1
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama
 
@@ -19,7 +19,7 @@ pip install "motosan-ai[anthropic,openai]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.12.0", features = ["anthropic"] }
+motosan-ai = { version = "0.12.1", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli
 ```
@@ -98,6 +98,6 @@ let resp = client.chat(vec![Message::user("Hi")]).await?;
 - **ThinkStripper**: Applied automatically in all `stream()` / `stream_with()` calls — no manual setup needed
 - **Anthropic OAuth**: Auto-detected by token prefix (`sk-ant-oat01*`), `chat()` auto-redirects to `stream()` for OAuth tokens
 - **Retry**: Enabled by default (3 retries, exponential backoff, jitter) for 429/5xx/timeout
-- **CLI backends** (Rust only): `ClaudeCodeProvider` (feature `claude-code`, shells out to `claude`), `CodexCliProvider` (feature `codex-cli`, shells out to `codex exec --json`), and `GeminiCliProvider` (feature `gemini-cli`, shells out to `gemini -p "" -o stream-json`). Live in `providers/{claude_code,codex_cli,gemini_cli}/` alongside HTTP providers. All three implement `ProviderImpl`. All three report empty `tool_calls` — tools run inside the CLI. `CodexCliProvider.chat()` splits multi-message turns into `content` (last `agent_message`) + `thinking` (preamble). `GeminiCliProvider` merges the system prompt into the stdin payload because Gemini CLI has no `--system-prompt` flag. `ClaudeCodeProvider` (since v0.12.0) covers the full SDK-relevant flag surface: `.model` / `.system_prompt` / `.permission_mode(PermissionMode::*)` / `.effort(EffortLevel::*)` / `.fallback_model` / `.add_dir` / `.allow_tool` / `.disallow_tool` / `.mcp_config` / `.strict_mcp_config` / `.settings` / `.setting_source` / `.session_id` / `.resume` / `.continue_latest` / `.fork_session` / `.no_session_persistence` / `.plugin_dir` / `.agent` / `.max_budget_usd`.
+- **CLI backends** (Rust only): `ClaudeCodeProvider` (feature `claude-code`, shells out to `claude`), `CodexCliProvider` (feature `codex-cli`, shells out to `codex exec --json`), and `GeminiCliProvider` (feature `gemini-cli`, shells out to `gemini -p "" -o stream-json`). Live in `providers/{claude_code,codex_cli,gemini_cli}/` alongside HTTP providers. All three implement `ProviderImpl`. All three report empty `tool_calls` — tools run inside the CLI. `CodexCliProvider.chat()` splits multi-message turns into `content` (last `agent_message`) + `thinking` (preamble). `GeminiCliProvider` merges the system prompt into the stdin payload because Gemini CLI has no `--system-prompt` flag. `ClaudeCodeProvider` (since v0.12.0) covers the full SDK-relevant flag surface: `.bare` (daemon-safe `--bare`; skips hooks/plugins/auto-memory/keychain/user+project settings) / `.model` / `.system_prompt` / `.permission_mode(PermissionMode::*)` / `.effort(EffortLevel::*)` / `.fallback_model` / `.add_dir` / `.allow_tool` / `.disallow_tool` / `.mcp_config` / `.strict_mcp_config` / `.settings` / `.setting_source` / `.session_id` / `.resume` / `.continue_latest` / `.fork_session` / `.no_session_persistence` / `.plugin_dir` / `.agent` / `.max_budget_usd`.
 - **Unified `Client::builder()` dispatch** (Rust, since v0.11.0): `Provider::ClaudeCode`, `Provider::CodexCli`, and `Provider::GeminiCli` are first-class `Provider` variants. CLI backends are reachable through `Client::builder().provider(Provider::GeminiCli).gemini_cli(GeminiCliProvider::new().model("gemini-2.5-pro")).build()?` — no `api_key` required for CLI paths. Downstream consumers can hold a single `Client` and dispatch to any backend through `chat()` / `stream()` without provider-specific branching. The v0.10.0 `ClaudeCodeClient` / `CodexCliClient` type aliases were removed in v0.11.0.
 - **OpenAI-compatible endpoints** (Rust): `OpenAIProvider` takes **full URLs** via `.with_chat_url(url)` / `.with_responses_url(url)` (or `.openai_chat_url(url)` on `ClientBuilder`). No `/v1` auto-injection, no `base_url` heuristics — what you pass is what gets POSTed. Works for Groq (`https://api.groq.com/openai/v1/chat/completions`), DeepSeek, Together, self-hosted proxies, etc. Defaults to `https://api.openai.com/v1/chat/completions`.


### PR DESCRIPTION
## Summary

Adds `bare: bool` to `ClaudeCodeProvider` (default `false`) plus a `.bare(enabled)` builder method. When `true`, the spawned `claude` subprocess receives `--bare`, skipping hooks, plugins, auto-memory, keychain reads, and user/project settings discovery.

Released as **v0.12.1** (additive — see SemVer note below).

## Motivation

Daemon / server callers (e.g. [exodia-claw](https://github.com/motosan-dev/exodia-claw)) need the subprocess to be deterministic and isolated from the operator's interactive `~/.claude/` state. Without `--bare`, the daemon inherits whichever hooks, plugins, or auto-memory entries the operator happened to have when the binary started — making behavior depend on ambient state outside the program.

This unblocks consolidation of exodia-claw's standalone `ClaudeCodeEngine` (which already passes `--bare` via raw `tokio::process::Command`) onto motosan-ai's `ClaudeCodeProvider`, so exodia-claw can use one provider abstraction instead of two.

## SemVer note

This is treated as **additive** (patch bump 0.12.0 → 0.12.1):

- The default value `bare: false` keeps every existing call site behaviour-identical.
- The supported public API — `ClaudeCodeProvider::new()` plus the builder methods — is fully backward-compatible.
- Struct-literal construction (`ClaudeCodeProvider { binary_path, ... }`) does break, but that path has never been the recommended one and already broke in v0.12.0 when 19 fields were added.
- `spawn::SpawnConfig` is not re-exported (`pub use spawn::{EffortLevel, PermissionMode}` only), so its field-add is internal.

## Documented interactions (in `ClaudeCodeProvider::bare` rustdoc)

- **Auth**: under `--bare`, Anthropic auth is restricted to `ANTHROPIC_API_KEY` or an `apiKeyHelper` declared in the file passed to `settings`. OAuth subscription and keychain reads are never consulted — callers going headless must export the env var or hand over `settings` before flipping this on, or every request will fail with an auth error.
- **Auto-discovered context is suppressed**: `setting_sources` becomes inert because the discovery it controls is disabled (the CLI accepts the flag without error, the values simply have no effect).
- **Explicit context still flows**: `settings`, `mcp_config`, `add_dirs`, `plugin_dirs`, `agent`, `system_prompt`, and the message-extracted `--append-system-prompt` are honoured normally.
- Skills still resolve via `/skill-name` invocation.

## Argv layout

`--bare` is emitted first in `common_args`, preceding `--dangerously-skip-permissions`. The full-loadout order test is updated to lock the new position.

## Tests

- `common_args_bare_emits_bare_flag` — bare alone emits exactly `--bare`
- `common_args_bare_precedes_agent_mode` — locks `--bare` before `--dangerously-skip-permissions`
- `builder_methods_populate_spawn_config` extended to assert `bare(true)` round-trips through `build_spawn_config`
- `common_args_full_loadout_order_is_stable` updated to include `--bare` at the new locked position
- `integration_bare_flag_accepted_by_cli` (`#[ignore]`) — live test that spawns `claude --bare --print` to catch a future CLI rename

## CI fix included

The `rust-msrv-no-features` job was failing on **every** PR touching `sdks/rust/**` (not specific to this change): without a committed `Cargo.lock`, fresh resolution picked `indexmap 2.14.0`, which transitively requires `hashbrown 0.17`, which itself requires the unstable `edition2024` Cargo feature unavailable on the 1.82.0 toolchain. Pinned `indexmap` to `2.13.1` in the MSRV job only.

## Test plan
- [x] `cargo test --features claude-code -p motosan-ai claude_code::` — 39 passed, 5 ignored
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo doc --features claude-code -p motosan-ai --no-deps` — no new warnings on `claude_code` module
- [x] CI MSRV job pinned (see commit `3e13a13`)
- [x] README "Builder reference" + Option A example updated (commit `9fffece`)
- [x] `CHANGELOG.md` `[Unreleased]` → `[0.12.1]` entry under `### Added` (commit `9fffece`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)