### PR TITLE
feat(capabilities): provider capability declaration + unified pre-flight validation

### DIFF
--- a/docs/superpowers/plans/2026-04-20-provider-capabilities.md
+++ b/docs/superpowers/plans/2026-04-20-provider-capabilities.md
@@ -1,0 +1,693 @@
+# Provider Capabilities Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `capabilities()` method to `ProviderImpl` so providers declare what content types they support, with automatic pre-flight validation in `LlmClient` that returns `Err(UnsupportedFeature)` before sending unsupported content to an API.
+
+**Architecture:** `ProviderCapabilities` struct holds `supports_image` and `supports_document` booleans. `ProviderImpl` gains two provided methods: `capabilities()` (defaults to text-only) and `validate_request()` (iterates `content_blocks`, returns `Err` on unsupported types). `LlmClient::dispatch_chat` and `dispatch_stream_inner` call `validate_request` before dispatching to each provider. The existing `reject_document_blocks()` helper is deleted — superseded by the framework layer.
+
+**Tech Stack:** Rust, `async_trait`, `thiserror`. No new dependencies.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `sdks/rust/src/types.rs` | Add `ProviderCapabilities` struct |
+| `sdks/rust/src/providers/mod.rs` | Add `capabilities()` + `validate_request()` to trait; remove `reject_document_blocks()`; fix `ContentBlock` import cfg gate |
+| `sdks/rust/src/client.rs` | Call `validate_request` in `dispatch_chat` and `dispatch_stream_inner` |
+| `sdks/rust/src/providers/anthropic.rs` | Override `capabilities()` → `full()` |
+| `sdks/rust/src/providers/openai.rs` | Override `capabilities()` → `with_image()`; remove `reject_document_blocks` calls |
+| `sdks/rust/src/providers/gemini.rs` | Override `capabilities()` → `with_image()` |
+| `sdks/rust/src/providers/gemini_code_assist.rs` | Override `capabilities()` → `with_image()` |
+| `sdks/rust/src/providers/minimax.rs` | Remove `reject_document_blocks` calls and import |
+
+---
+
+## Task 1: Add `ProviderCapabilities` to `types.rs`
+
+**Files:**
+- Modify: `sdks/rust/src/types.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+At the bottom of `sdks/rust/src/types.rs`, add:
+
+```rust
+#[cfg(test)]
+mod capabilities_tests {
+    use super::*;
+
+    #[test]
+    fn text_only_has_no_capabilities() {
+        let caps = ProviderCapabilities::text_only();
+        assert!(!caps.supports_image);
+        assert!(!caps.supports_document);
+    }
+
+    #[test]
+    fn with_image_supports_image_only() {
+        let caps = ProviderCapabilities::with_image();
+        assert!(caps.supports_image);
+        assert!(!caps.supports_document);
+    }
+
+    #[test]
+    fn full_supports_everything() {
+        let caps = ProviderCapabilities::full();
+        assert!(caps.supports_image);
+        assert!(caps.supports_document);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd sdks/rust && cargo test capabilities_tests 2>&1 | grep -E "error|FAILED|cannot find"
+```
+
+Expected: compile error — `ProviderCapabilities` not found.
+
+- [ ] **Step 3: Add `ProviderCapabilities` to `types.rs`**
+
+Find the end of the public type definitions in `sdks/rust/src/types.rs` (before the first `#[cfg(test)]` block) and add:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderCapabilities {
+    pub supports_image: bool,
+    pub supports_document: bool,
+}
+
+impl ProviderCapabilities {
+    pub fn text_only() -> Self {
+        Self { supports_image: false, supports_document: false }
+    }
+
+    pub fn with_image() -> Self {
+        Self { supports_image: true, supports_document: false }
+    }
+
+    pub fn full() -> Self {
+        Self { supports_image: true, supports_document: true }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd sdks/rust && cargo test capabilities_tests 2>&1 | grep -E "test.*ok|FAILED|error"
+```
+
+Expected:
+```
+test types::capabilities_tests::text_only_has_no_capabilities ... ok
+test types::capabilities_tests::with_image_supports_image_only ... ok
+test types::capabilities_tests::full_supports_everything ... ok
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdks/rust/src/types.rs
+git commit -m "feat(capabilities): add ProviderCapabilities type"
+```
+
+---
+
+## Task 2: Add `capabilities()` and `validate_request()` to `ProviderImpl`
+
+**Files:**
+- Modify: `sdks/rust/src/providers/mod.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+At the bottom of `sdks/rust/src/providers/mod.rs`, add:
+
+```rust
+#[cfg(test)]
+mod validate_tests {
+    use super::*;
+    use crate::types::{ContentBlock, ImageSource, Message, ProviderCapabilities};
+
+    struct TextOnlyProvider;
+
+    #[async_trait]
+    impl ProviderImpl for TextOnlyProvider {
+        async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+            unimplemented!()
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError> {
+            unimplemented!()
+        }
+    }
+
+    struct FullProvider;
+
+    #[async_trait]
+    impl ProviderImpl for FullProvider {
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities::full()
+        }
+        async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+            unimplemented!()
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError> {
+            unimplemented!()
+        }
+    }
+
+    fn req_with_image() -> ChatRequest {
+        let msg = Message::user_with_image("look", "abc123", "image/png");
+        ChatRequest::builder().messages(vec![msg]).build()
+    }
+
+    fn req_with_document() -> ChatRequest {
+        let msg = Message::user_with_pdf_base64("read this", "abc123");
+        ChatRequest::builder().messages(vec![msg]).build()
+    }
+
+    fn req_text_only() -> ChatRequest {
+        ChatRequest::builder().messages(vec![Message::user("hello")]).build()
+    }
+
+    #[test]
+    fn text_only_provider_rejects_image() {
+        let p = TextOnlyProvider;
+        let result = p.validate_request(&req_with_image());
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
+
+    #[test]
+    fn text_only_provider_rejects_document() {
+        let p = TextOnlyProvider;
+        let result = p.validate_request(&req_with_document());
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
+
+    #[test]
+    fn full_provider_accepts_image() {
+        let p = FullProvider;
+        assert!(p.validate_request(&req_with_image()).is_ok());
+    }
+
+    #[test]
+    fn full_provider_accepts_document() {
+        let p = FullProvider;
+        assert!(p.validate_request(&req_with_document()).is_ok());
+    }
+
+    #[test]
+    fn any_provider_accepts_plain_text() {
+        let p = TextOnlyProvider;
+        assert!(p.validate_request(&req_text_only()).is_ok());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd sdks/rust && cargo test validate_tests 2>&1 | grep -E "error|FAILED|cannot find"
+```
+
+Expected: compile errors — `capabilities`, `validate_request` not found on trait.
+
+- [ ] **Step 3: Update the `ContentBlock` import and the `ProviderImpl` trait**
+
+In `sdks/rust/src/providers/mod.rs`:
+
+**3a.** Find this import block (around line 12–13):
+```rust
+#[cfg(any(feature = "openai", feature = "minimax", feature = "ollama_native"))]
+use crate::types::ContentBlock;
+```
+
+Replace with (add `ProviderCapabilities` and remove the cfg gate on `ContentBlock`):
+```rust
+use crate::types::{ContentBlock, ProviderCapabilities};
+```
+
+**3b.** Replace the `ProviderImpl` trait (lines 72–76) with:
+```rust
+#[async_trait]
+pub trait ProviderImpl: Send + Sync {
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities::text_only()
+    }
+
+    fn validate_request(&self, req: &ChatRequest) -> Result<(), MotosanError> {
+        let caps = self.capabilities();
+        for msg in &req.messages {
+            for block in &msg.content_blocks {
+                match block {
+                    ContentBlock::Image { .. } if !caps.supports_image => {
+                        return Err(MotosanError::UnsupportedFeature(
+                            "provider does not support image input".into(),
+                        ));
+                    }
+                    ContentBlock::Document { .. } if !caps.supports_document => {
+                        return Err(MotosanError::UnsupportedFeature(
+                            "provider does not support document input".into(),
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError>;
+    async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError>;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd sdks/rust && cargo test validate_tests 2>&1 | grep -E "test.*ok|FAILED|error\["
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Run full test suite to catch regressions**
+
+```bash
+cd sdks/rust && cargo test --all-features 2>&1 | tail -20
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sdks/rust/src/providers/mod.rs
+git commit -m "feat(capabilities): add capabilities() and validate_request() to ProviderImpl"
+```
+
+---
+
+## Task 3: Override `capabilities()` in Anthropic, OpenAI, Gemini, GeminiCodeAssist
+
+**Files:**
+- Modify: `sdks/rust/src/providers/anthropic.rs`
+- Modify: `sdks/rust/src/providers/openai.rs`
+- Modify: `sdks/rust/src/providers/gemini.rs`
+- Modify: `sdks/rust/src/providers/gemini_code_assist.rs`
+
+- [ ] **Step 1: Write failing tests for each provider's capabilities**
+
+At the bottom of each provider file, in its existing `#[cfg(test)]` block, add:
+
+**`anthropic.rs`** — inside `mod tests`:
+```rust
+#[test]
+fn capabilities_are_full() {
+    let p = AnthropicProvider::new("key", None, None);
+    let caps = p.capabilities();
+    assert!(caps.supports_image);
+    assert!(caps.supports_document);
+}
+```
+
+**`openai.rs`** — inside `mod tests`:
+```rust
+#[test]
+fn capabilities_support_image_only() {
+    let p = OpenAIProvider::new("key", None, None, None);
+    let caps = p.capabilities();
+    assert!(caps.supports_image);
+    assert!(!caps.supports_document);
+}
+```
+
+**`gemini.rs`** — inside `mod tests`:
+```rust
+#[test]
+fn capabilities_support_image_only() {
+    let p = GeminiProvider::new("key", None, None);
+    let caps = p.capabilities();
+    assert!(caps.supports_image);
+    assert!(!caps.supports_document);
+}
+```
+
+**`gemini_code_assist.rs`** — inside the test module:
+```rust
+#[test]
+fn capabilities_support_image_only() {
+    let p = GeminiCodeAssistProvider::new("token".into(), None, None);
+    let caps = p.capabilities();
+    assert!(caps.supports_image);
+    assert!(!caps.supports_document);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd sdks/rust && cargo test --all-features "capabilities_are_full\|capabilities_support_image_only" 2>&1 | grep -E "FAILED|ok"
+```
+
+Expected: all 4 tests FAILED (default is text-only, assertions fail).
+
+- [ ] **Step 3: Add `capabilities()` overrides**
+
+In each `impl ProviderImpl for XProvider` block, add the `capabilities()` method before `async fn chat`:
+
+**`anthropic.rs`** — in `impl ProviderImpl for AnthropicProvider`:
+```rust
+fn capabilities(&self) -> crate::types::ProviderCapabilities {
+    crate::types::ProviderCapabilities::full()
+}
+```
+
+**`openai.rs`** — in `impl ProviderImpl for OpenAIProvider`:
+```rust
+fn capabilities(&self) -> crate::types::ProviderCapabilities {
+    crate::types::ProviderCapabilities::with_image()
+}
+```
+
+**`gemini.rs`** — in `impl ProviderImpl for GeminiProvider`:
+```rust
+fn capabilities(&self) -> crate::types::ProviderCapabilities {
+    crate::types::ProviderCapabilities::with_image()
+}
+```
+
+**`gemini_code_assist.rs`** — in `impl ProviderImpl for GeminiCodeAssistProvider`:
+```rust
+fn capabilities(&self) -> crate::types::ProviderCapabilities {
+    crate::types::ProviderCapabilities::with_image()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd sdks/rust && cargo test --all-features "capabilities_are_full\|capabilities_support_image_only" 2>&1 | grep -E "FAILED|ok"
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdks/rust/src/providers/anthropic.rs sdks/rust/src/providers/openai.rs sdks/rust/src/providers/gemini.rs sdks/rust/src/providers/gemini_code_assist.rs
+git commit -m "feat(capabilities): declare capabilities in Anthropic, OpenAI, Gemini providers"
+```
+
+---
+
+## Task 4: Wire validation into `LlmClient` dispatch
+
+**Files:**
+- Modify: `sdks/rust/src/client.rs`
+
+The pattern in both `dispatch_chat` and `dispatch_stream_inner` is:
+
+```rust
+// Before:
+use crate::providers::ProviderImpl;
+return self.build_X_provider().chat(request).await;
+
+// After:
+use crate::providers::ProviderImpl;
+let p = self.build_X_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+Apply the same pattern to `stream`:
+```rust
+// Before:
+use crate::providers::ProviderImpl;
+return self.build_X_provider().stream(request).await;
+
+// After:
+use crate::providers::ProviderImpl;
+let p = self.build_X_provider();
+p.validate_request(&request)?;
+return p.stream(request).await;
+```
+
+- [ ] **Step 1: Write a failing integration test**
+
+At the bottom of `sdks/rust/src/client.rs`, add inside an existing `#[cfg(test)]` block (or create one):
+
+```rust
+#[cfg(test)]
+mod dispatch_validation_tests {
+    use super::*;
+    use crate::types::{ContentBlock, ImageSource, Message};
+
+    #[cfg(feature = "ollama_native")]
+    #[tokio::test]
+    async fn dispatch_chat_rejects_image_for_ollama() {
+        let client = LlmClient::ollama_native("http://localhost:11434", None);
+        let msg = Message::user_with_image("look", "abc123", "image/png");
+        let req = ChatRequest::builder().messages(vec![msg]).build();
+        let result = client.chat_with(req).await;
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
+
+    #[cfg(feature = "ollama_native")]
+    #[tokio::test]
+    async fn dispatch_stream_rejects_image_for_ollama() {
+        let client = LlmClient::ollama_native("http://localhost:11434", None);
+        let msg = Message::user_with_image("look", "abc123", "image/png");
+        let req = ChatRequest::builder().messages(vec![msg]).build();
+        let result = client.stream_with(req).await;
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cd sdks/rust && cargo test --features ollama_native dispatch_validation_tests 2>&1 | grep -E "FAILED|ok|error"
+```
+
+Expected: tests FAILED — network error or wrong error type (validation not wired yet).
+
+- [ ] **Step 3: Update `dispatch_chat` in `client.rs`**
+
+Apply the provider/validate/call pattern to every provider arm in `dispatch_chat`. The arms to update (all inside `#[cfg(feature = "...")]` blocks):
+
+For **Anthropic** (feature = "anthropic"):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_anthropic_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+For **OpenAI** (feature = "openai"):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_openai_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+For **Minimax** (feature = "minimax"):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_minimax_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+For **Ollama** native (feature = "ollama_native", `if self.ollama_native`):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_ollama_native_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+For **Ollama** non-native (feature = "ollama"):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_ollama_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+For **ClaudeCode** (feature = "claude-code"):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_claude_code_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+For **CodexCli** (feature = "codex-cli"):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_codex_cli_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+For **GeminiCli** (feature = "gemini-cli"):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_gemini_cli_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+For **Gemini** (feature = "gemini"):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_gemini_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+For **GeminiCodeAssist** (feature = "gemini-code-assist"):
+```rust
+use crate::providers::ProviderImpl;
+let p = self.build_gemini_code_assist_provider();
+p.validate_request(&request)?;
+return p.chat(request).await;
+```
+
+- [ ] **Step 4: Apply the same pattern to `dispatch_stream_inner`**
+
+Same providers, same pattern, replace `.chat(request)` with `.stream(request)`.
+
+- [ ] **Step 5: Run to verify tests pass**
+
+```bash
+cd sdks/rust && cargo test --features ollama_native dispatch_validation_tests 2>&1 | grep -E "FAILED|ok"
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+cd sdks/rust && cargo test --all-features 2>&1 | tail -20
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sdks/rust/src/client.rs
+git commit -m "feat(capabilities): wire validate_request into LlmClient dispatch"
+```
+
+---
+
+## Task 5: Remove `reject_document_blocks()`
+
+**Files:**
+- Modify: `sdks/rust/src/providers/mod.rs`
+- Modify: `sdks/rust/src/providers/openai.rs`
+- Modify: `sdks/rust/src/providers/minimax.rs`
+
+- [ ] **Step 1: Remove all call sites in `openai.rs`**
+
+In `sdks/rust/src/providers/openai.rs`:
+
+Remove from the import line (around line 5):
+```rust
+parse_retry_after, reject_document_blocks, sleep_before_retry,
+```
+→ Replace with:
+```rust
+parse_retry_after, sleep_before_retry,
+```
+
+Remove the two `reject_document_blocks(&req, "OpenAI")?;` lines (around lines 475 and 592). These are the only call sites in openai.rs — the `unreachable!()` comment on the Document arm of `build_request` can also be removed and replaced with `ContentBlock::Document { .. } => {}`.
+
+- [ ] **Step 2: Remove all call sites in `minimax.rs`**
+
+In `sdks/rust/src/providers/minimax.rs`:
+
+Remove from the import line (around line 5):
+```rust
+parse_retry_after, reject_document_blocks, sleep_before_retry,
+```
+→ Replace with:
+```rust
+parse_retry_after, sleep_before_retry,
+```
+
+Remove the two `reject_document_blocks(&req, "MiniMax")?;` lines (around lines 343 and 463).
+
+- [ ] **Step 3: Remove `reject_document_blocks` from `providers/mod.rs`**
+
+In `sdks/rust/src/providers/mod.rs`, delete the entire function:
+```rust
+/// Return an `UnsupportedFeature` error if any message contains a `Document` block.
+#[cfg(any(feature = "openai", feature = "minimax", feature = "ollama_native"))]
+pub(crate) fn reject_document_blocks(
+    req: &ChatRequest,
+    provider_name: &str,
+) -> Result<(), MotosanError> {
+    for message in &req.messages {
+        for block in &message.content_blocks {
+            if matches!(block, ContentBlock::Document { .. }) {
+                return Err(MotosanError::UnsupportedFeature(format!(
+                    "Document content blocks (PDF) are not supported by the {} provider",
+                    provider_name
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Compile and test**
+
+```bash
+cd sdks/rust && cargo test --all-features 2>&1 | tail -20
+```
+
+Expected: all tests pass, no unused import warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdks/rust/src/providers/mod.rs sdks/rust/src/providers/openai.rs sdks/rust/src/providers/minimax.rs
+git commit -m "refactor(capabilities): remove reject_document_blocks — superseded by validate_request"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Run the full CI gate**
+
+```bash
+cd /Users/daiwanwei/Projects/wade/motosan-ai && check-rust 2>&1 | tail -30
+```
+
+Expected: `fmt`, `clippy`, and `test --all-features` all pass with no warnings.
+
+- [ ] **Step 2: Verify capabilities coverage across all providers**
+
+```bash
+cd sdks/rust && cargo test --all-features "capabilities" 2>&1 | grep -E "test.*ok|FAILED"
+```
+
+Expected: 7 capability tests pass (1 per provider that declares non-default capabilities, plus the `ProviderCapabilities` named-constructor tests).
+
+- [ ] **Step 3: Commit if any final fixes were needed**
+
+```bash
+git add -p
+git commit -m "fix(capabilities): final cleanup from CI gate"
+```

--- a/docs/superpowers/specs/2026-04-20-provider-capabilities-design.md
+++ b/docs/superpowers/specs/2026-04-20-provider-capabilities-design.md
@@ -1,0 +1,151 @@
+# Provider Capabilities — Design Spec
+
+**Date:** 2026-04-20  
+**Scope:** Rust SDK only (`sdks/rust/`)
+
+## Problem
+
+Message input handling across providers is inconsistent:
+
+| Provider     | content_blocks | Image | Document        |
+|--------------|---------------|-------|-----------------|
+| Anthropic    | ✓ full        | ✓     | ✓               |
+| OpenAI       | ✓ partial     | ✓     | explicit error  |
+| Gemini HTTP  | ✓ partial     | ✓     | silently dropped |
+| MiniMax      | ✗             | ✗     | explicit error  |
+| Ollama       | ✗             | ✗     | explicit error  |
+| Gemini CLI   | ✗             | ✗     | ✗               |
+| Claude Code  | ✗             | ✗     | ✗               |
+
+Issues:
+- Gemini silently drops documents (data loss)
+- Validation logic (`reject_document_blocks`) duplicated across providers
+- No single source of truth for what a provider supports
+
+## Design
+
+### 1. `ProviderCapabilities` type
+
+Added to `types.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderCapabilities {
+    pub supports_image: bool,
+    pub supports_document: bool,
+}
+
+impl ProviderCapabilities {
+    pub fn text_only() -> Self { Self { supports_image: false, supports_document: false } }
+    pub fn with_image() -> Self { Self { supports_image: true, supports_document: false } }
+    pub fn full() -> Self { Self { supports_image: true, supports_document: true } }
+}
+```
+
+### 2. `ProviderImpl` trait changes
+
+Two methods added to the trait in `providers/mod.rs`:
+
+```rust
+fn capabilities(&self) -> ProviderCapabilities {
+    ProviderCapabilities::text_only()  // safe default
+}
+
+fn validate_request(&self, req: &ChatRequest) -> Result<(), MotosanError> {
+    let caps = self.capabilities();
+    for msg in &req.messages {
+        for block in &msg.content_blocks {
+            match block {
+                ContentBlock::Image { .. } if !caps.supports_image =>
+                    return Err(MotosanError::UnsupportedFeature(
+                        "provider does not support image input".into()
+                    )),
+                ContentBlock::Document { .. } if !caps.supports_document =>
+                    return Err(MotosanError::UnsupportedFeature(
+                        "provider does not support document input".into()
+                    )),
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+- `capabilities()` has a safe default (text-only) — existing providers compile without changes
+- `validate_request()` is a provided method — validation logic lives in one place
+- New `MotosanError::UnsupportedFeature(String)` variant required
+
+### 3. `LlmClient` dispatch
+
+`chat()` and `stream()` each get one validation line before dispatch:
+
+```rust
+pub async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+    self.provider.validate_request(&req)?;
+    self.provider.chat(req).await
+}
+
+pub async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
+    self.provider.validate_request(&req)?;
+    self.provider.stream(req).await
+}
+```
+
+### 4. Per-provider `capabilities()` overrides
+
+Only three providers override the default:
+
+| Provider    | Override                       |
+|-------------|-------------------------------|
+| Anthropic   | `ProviderCapabilities::full()` |
+| OpenAI      | `ProviderCapabilities::with_image()` |
+| Gemini HTTP | `ProviderCapabilities::with_image()` |
+| Gemini Code Assist | `ProviderCapabilities::with_image()` |
+
+All others (MiniMax, Ollama, Gemini CLI, Claude Code) use the text-only default.
+
+`GeminiCodeAssistProvider` reuses `GeminiProvider::build_request` for message serialization, so it also gets `with_image()`.
+
+**Cleanup:** `reject_document_blocks()` helper removed from OpenAI and MiniMax — superseded by framework-level validation.
+
+## Error Handling
+
+```rust
+// New variant in MotosanError
+UnsupportedFeature(String)
+```
+
+Error is returned before any HTTP request is made. Callers receive a clear error message identifying which content type is unsupported.
+
+## Testing
+
+**Unit — `ProviderCapabilities`**
+- Named constructors produce correct field values
+
+**Unit — `validate_request()`**
+- text-only provider + Image block → `Err(UnsupportedFeature)`
+- text-only provider + Document block → `Err(UnsupportedFeature)`
+- full provider + Image + Document → `Ok(())`
+- empty `content_blocks` → always `Ok(())`
+
+**Unit — per-provider `capabilities()`**
+- Anthropic → `full()`
+- OpenAI, Gemini → `with_image()`
+- MiniMax, Ollama, Gemini CLI, Claude Code → `text_only()`
+
+No live API tests needed — capability declaration is pure logic.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/types.rs` | Add `ProviderCapabilities` |
+| `src/error.rs` | Add `UnsupportedFeature` variant |
+| `src/providers/mod.rs` | Add `capabilities()` + `validate_request()` to `ProviderImpl` |
+| `src/client.rs` | Add `validate_request()` call in `chat()` and `stream()` |
+| `src/providers/anthropic.rs` | Override `capabilities()` → `full()` |
+| `src/providers/openai.rs` | Override `capabilities()` → `with_image()`; remove `reject_document_blocks()` |
+| `src/providers/gemini.rs` | Override `capabilities()` → `with_image()` |
+| `src/providers/gemini_code_assist.rs` | Override `capabilities()` → `with_image()` |
+| `src/providers/minimax.rs` | Remove `reject_document_blocks()` |

--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 from collections.abc import AsyncIterator
@@ -266,8 +267,6 @@ class ClaudeCodeClient:
             # breaks out of the async-for loop early or an exception is raised.
             # Guard against ProcessLookupError when the process has already exited
             # (the normal completion path).
-            try:
+            with contextlib.suppress(ProcessLookupError):
                 proc.kill()
-            except ProcessLookupError:
-                pass
             await proc.wait()

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -942,44 +942,6 @@ impl futures_core::Stream for ReadTimeoutStream {
     }
 }
 
-#[cfg(test)]
-mod dispatch_validation_tests {
-    use super::*;
-    use crate::types::Message;
-
-    #[cfg(feature = "ollama_native")]
-    #[tokio::test]
-    async fn dispatch_chat_rejects_image_for_ollama() {
-        let client = Client::builder()
-            .provider(crate::providers::Provider::Ollama)
-            .api_key("")
-            .ollama_base_url("http://localhost:11434")
-            .ollama_native(true)
-            .build()
-            .expect("client build");
-        let msg = Message::user_with_image("look", "abc123", "image/png");
-        let req = ChatRequest::builder().messages(vec![msg]).build();
-        let result = client.chat_with(req).await;
-        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
-    }
-
-    #[cfg(feature = "ollama_native")]
-    #[tokio::test]
-    async fn dispatch_stream_rejects_image_for_ollama() {
-        let client = Client::builder()
-            .provider(crate::providers::Provider::Ollama)
-            .api_key("")
-            .ollama_base_url("http://localhost:11434")
-            .ollama_native(true)
-            .build()
-            .expect("client build");
-        let msg = Message::user_with_image("look", "abc123", "image/png");
-        let req = ChatRequest::builder().messages(vec![msg]).build();
-        let result = client.stream_with(req).await;
-        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
-    }
-}
-
 /// Stream wrapper that filters `<think>...</think>` tags from text events.
 struct ThinkStripperStream {
     inner: BoxStream,
@@ -1016,5 +978,43 @@ impl futures_core::Stream for ThinkStripperStream {
                 Poll::Pending => return Poll::Pending,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod dispatch_validation_tests {
+    use super::*;
+    use crate::types::Message;
+
+    #[cfg(feature = "ollama_native")]
+    #[tokio::test]
+    async fn dispatch_chat_rejects_image_for_ollama() {
+        let client = Client::builder()
+            .provider(crate::providers::Provider::Ollama)
+            .api_key("")
+            .ollama_base_url("http://localhost:11434")
+            .ollama_native(true)
+            .build()
+            .expect("client build");
+        let msg = Message::user_with_image("look", "abc123", "image/png");
+        let req = ChatRequest::builder().messages(vec![msg]).build();
+        let result = client.chat_with(req).await;
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
+
+    #[cfg(feature = "ollama_native")]
+    #[tokio::test]
+    async fn dispatch_stream_rejects_image_for_ollama() {
+        let client = Client::builder()
+            .provider(crate::providers::Provider::Ollama)
+            .api_key("")
+            .ollama_base_url("http://localhost:11434")
+            .ollama_native(true)
+            .build()
+            .expect("client build");
+        let msg = Message::user_with_image("look", "abc123", "image/png");
+        let req = ChatRequest::builder().messages(vec![msg]).build();
+        let result = client.stream_with(req).await;
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
     }
 }

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1019,4 +1019,35 @@ mod dispatch_validation_tests {
         let result = client.stream_with(req).await;
         assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
     }
+
+    // Validates that the framework-level guard fires before any HTTP call for
+    // a text-only HTTP provider. No server needed — UnsupportedFeature is returned
+    // from validate_request() before reqwest touches the network.
+    #[cfg(feature = "minimax")]
+    #[tokio::test]
+    async fn dispatch_chat_rejects_image_for_minimax() {
+        let client = Client::builder()
+            .provider(crate::providers::Provider::Minimax)
+            .api_key("fake-key")
+            .build()
+            .expect("client build");
+        let msg = Message::user_with_image("look", "abc123", "image/png");
+        let req = ChatRequest::builder().messages(vec![msg]).build();
+        let result = client.chat_with(req).await;
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
+
+    #[cfg(feature = "minimax")]
+    #[tokio::test]
+    async fn dispatch_chat_rejects_document_for_minimax() {
+        let client = Client::builder()
+            .provider(crate::providers::Provider::Minimax)
+            .api_key("fake-key")
+            .build()
+            .expect("client build");
+        let msg = Message::user_with_pdf_base64("summarize", "abc123");
+        let req = ChatRequest::builder().messages(vec![msg]).build();
+        let result = client.chat_with(req).await;
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
 }

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -532,6 +532,8 @@ impl Client {
     }
 
     #[cfg(feature = "ollama")]
+    // Uses OpenAIProvider under the hood, which declares with_image() capabilities.
+    // Multimodal accuracy here is model-dependent; use the ollama_native path for text-only safety.
     fn build_ollama_provider(&self) -> crate::providers::openai::OpenAIProvider {
         use crate::providers::openai::{OpenAIAuthStyle, OpenAIProvider};
 

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -180,7 +180,9 @@ impl Client {
                 #[cfg(feature = "anthropic")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_anthropic_provider().chat(request).await;
+                    let p = self.build_anthropic_provider();
+                    p.validate_request(&request)?;
+                    return p.chat(request).await;
                 }
                 #[cfg(not(feature = "anthropic"))]
                 {
@@ -192,7 +194,9 @@ impl Client {
                 #[cfg(feature = "openai")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_openai_provider().chat(request).await;
+                    let p = self.build_openai_provider();
+                    p.validate_request(&request)?;
+                    return p.chat(request).await;
                 }
                 #[cfg(not(feature = "openai"))]
                 {
@@ -204,7 +208,9 @@ impl Client {
                 #[cfg(feature = "minimax")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_minimax_provider().chat(request).await;
+                    let p = self.build_minimax_provider();
+                    p.validate_request(&request)?;
+                    return p.chat(request).await;
                 }
                 #[cfg(not(feature = "minimax"))]
                 {
@@ -217,13 +223,17 @@ impl Client {
                 {
                     if self.ollama_native {
                         use crate::providers::ProviderImpl;
-                        return self.build_ollama_native_provider().chat(request).await;
+                        let p = self.build_ollama_native_provider();
+                        p.validate_request(&request)?;
+                        return p.chat(request).await;
                     }
                 }
                 #[cfg(feature = "ollama")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_ollama_provider().chat(request).await;
+                    let p = self.build_ollama_provider();
+                    p.validate_request(&request)?;
+                    return p.chat(request).await;
                 }
                 #[cfg(not(feature = "ollama"))]
                 {
@@ -234,7 +244,10 @@ impl Client {
             Provider::ClaudeCode => {
                 #[cfg(feature = "claude-code")]
                 {
-                    return self.build_claude_code_provider().chat(request).await;
+                    use crate::providers::ProviderImpl;
+                    let p = self.build_claude_code_provider();
+                    p.validate_request(&request)?;
+                    return p.chat(request).await;
                 }
                 #[cfg(not(feature = "claude-code"))]
                 {
@@ -245,7 +258,10 @@ impl Client {
             Provider::CodexCli => {
                 #[cfg(feature = "codex-cli")]
                 {
-                    return self.build_codex_cli_provider().chat(request).await;
+                    use crate::providers::ProviderImpl;
+                    let p = self.build_codex_cli_provider();
+                    p.validate_request(&request)?;
+                    return p.chat(request).await;
                 }
                 #[cfg(not(feature = "codex-cli"))]
                 {
@@ -256,7 +272,10 @@ impl Client {
             Provider::GeminiCli => {
                 #[cfg(feature = "gemini-cli")]
                 {
-                    return self.build_gemini_cli_provider().chat(request).await;
+                    use crate::providers::ProviderImpl;
+                    let p = self.build_gemini_cli_provider();
+                    p.validate_request(&request)?;
+                    return p.chat(request).await;
                 }
                 #[cfg(not(feature = "gemini-cli"))]
                 {
@@ -268,7 +287,9 @@ impl Client {
                 #[cfg(feature = "gemini")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_gemini_provider().chat(request).await;
+                    let p = self.build_gemini_provider();
+                    p.validate_request(&request)?;
+                    return p.chat(request).await;
                 }
                 #[cfg(not(feature = "gemini"))]
                 {
@@ -280,7 +301,9 @@ impl Client {
                 #[cfg(feature = "gemini-code-assist")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_gemini_code_assist_provider().chat(request).await;
+                    let p = self.build_gemini_code_assist_provider();
+                    p.validate_request(&request)?;
+                    return p.chat(request).await;
                 }
                 #[cfg(not(feature = "gemini-code-assist"))]
                 {
@@ -312,7 +335,9 @@ impl Client {
                 #[cfg(feature = "anthropic")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_anthropic_provider().stream(request).await;
+                    let p = self.build_anthropic_provider();
+                    p.validate_request(&request)?;
+                    return p.stream(request).await;
                 }
                 #[cfg(not(feature = "anthropic"))]
                 {
@@ -324,7 +349,9 @@ impl Client {
                 #[cfg(feature = "openai")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_openai_provider().stream(request).await;
+                    let p = self.build_openai_provider();
+                    p.validate_request(&request)?;
+                    return p.stream(request).await;
                 }
                 #[cfg(not(feature = "openai"))]
                 {
@@ -336,7 +363,9 @@ impl Client {
                 #[cfg(feature = "minimax")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_minimax_provider().stream(request).await;
+                    let p = self.build_minimax_provider();
+                    p.validate_request(&request)?;
+                    return p.stream(request).await;
                 }
                 #[cfg(not(feature = "minimax"))]
                 {
@@ -349,13 +378,17 @@ impl Client {
                 {
                     if self.ollama_native {
                         use crate::providers::ProviderImpl;
-                        return self.build_ollama_native_provider().stream(request).await;
+                        let p = self.build_ollama_native_provider();
+                        p.validate_request(&request)?;
+                        return p.stream(request).await;
                     }
                 }
                 #[cfg(feature = "ollama")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_ollama_provider().stream(request).await;
+                    let p = self.build_ollama_provider();
+                    p.validate_request(&request)?;
+                    return p.stream(request).await;
                 }
                 #[cfg(not(feature = "ollama"))]
                 {
@@ -366,7 +399,10 @@ impl Client {
             Provider::ClaudeCode => {
                 #[cfg(feature = "claude-code")]
                 {
-                    return self.build_claude_code_provider().stream(request).await;
+                    use crate::providers::ProviderImpl;
+                    let p = self.build_claude_code_provider();
+                    p.validate_request(&request)?;
+                    return p.stream(request).await;
                 }
                 #[cfg(not(feature = "claude-code"))]
                 {
@@ -377,7 +413,10 @@ impl Client {
             Provider::CodexCli => {
                 #[cfg(feature = "codex-cli")]
                 {
-                    return self.build_codex_cli_provider().stream(request).await;
+                    use crate::providers::ProviderImpl;
+                    let p = self.build_codex_cli_provider();
+                    p.validate_request(&request)?;
+                    return p.stream(request).await;
                 }
                 #[cfg(not(feature = "codex-cli"))]
                 {
@@ -388,7 +427,10 @@ impl Client {
             Provider::GeminiCli => {
                 #[cfg(feature = "gemini-cli")]
                 {
-                    return self.build_gemini_cli_provider().stream(request).await;
+                    use crate::providers::ProviderImpl;
+                    let p = self.build_gemini_cli_provider();
+                    p.validate_request(&request)?;
+                    return p.stream(request).await;
                 }
                 #[cfg(not(feature = "gemini-cli"))]
                 {
@@ -400,7 +442,9 @@ impl Client {
                 #[cfg(feature = "gemini")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self.build_gemini_provider().stream(request).await;
+                    let p = self.build_gemini_provider();
+                    p.validate_request(&request)?;
+                    return p.stream(request).await;
                 }
                 #[cfg(not(feature = "gemini"))]
                 {
@@ -412,10 +456,9 @@ impl Client {
                 #[cfg(feature = "gemini-code-assist")]
                 {
                     use crate::providers::ProviderImpl;
-                    return self
-                        .build_gemini_code_assist_provider()
-                        .stream(request)
-                        .await;
+                    let p = self.build_gemini_code_assist_provider();
+                    p.validate_request(&request)?;
+                    return p.stream(request).await;
                 }
                 #[cfg(not(feature = "gemini-code-assist"))]
                 {
@@ -896,6 +939,44 @@ impl futures_core::Stream for ReadTimeoutStream {
                 Poll::Pending => Poll::Pending,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod dispatch_validation_tests {
+    use super::*;
+    use crate::types::Message;
+
+    #[cfg(feature = "ollama_native")]
+    #[tokio::test]
+    async fn dispatch_chat_rejects_image_for_ollama() {
+        let client = Client::builder()
+            .provider(crate::providers::Provider::Ollama)
+            .api_key("")
+            .ollama_base_url("http://localhost:11434")
+            .ollama_native(true)
+            .build()
+            .expect("client build");
+        let msg = Message::user_with_image("look", "abc123", "image/png");
+        let req = ChatRequest::builder().messages(vec![msg]).build();
+        let result = client.chat_with(req).await;
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
+
+    #[cfg(feature = "ollama_native")]
+    #[tokio::test]
+    async fn dispatch_stream_rejects_image_for_ollama() {
+        let client = Client::builder()
+            .provider(crate::providers::Provider::Ollama)
+            .api_key("")
+            .ollama_base_url("http://localhost:11434")
+            .ollama_native(true)
+            .build()
+            .expect("client build");
+        let msg = Message::user_with_image("look", "abc123", "image/png");
+        let req = ChatRequest::builder().messages(vec![msg]).build();
+        let result = client.stream_with(req).await;
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
     }
 }
 

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -43,6 +43,6 @@ pub use stream::collect_stream;
 pub use stream::{BoxStream, StreamEvent};
 pub use types::{
     ChatRequest, ChatRequestBuilder, ChatResponse, ContentBlock, DocumentSource, ImageSource,
-    McpServerConfig, McpServerType, McpToolConfig, Message, Role, StopReason, StreamEventType,
-    SystemBlock, ThinkingConfig, Tool, ToolCall, ToolChoice, Usage,
+    McpServerConfig, McpServerType, McpToolConfig, Message, ProviderCapabilities, Role, StopReason,
+    StreamEventType, SystemBlock, ThinkingConfig, Tool, ToolCall, ToolChoice, Usage,
 };

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -404,6 +404,10 @@ impl AnthropicRequestBuilder {
 
 #[async_trait]
 impl ProviderImpl for AnthropicProvider {
+    fn capabilities(&self) -> crate::types::ProviderCapabilities {
+        crate::types::ProviderCapabilities::full()
+    }
+
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let is_oauth = Self::is_setup_token(&self.api_key);
 
@@ -998,5 +1002,18 @@ impl Stream for AnthropicStreamAdapter {
                 Poll::Pending => return Poll::Pending,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capabilities_are_full() {
+        let p = AnthropicProvider::new("key", None, None);
+        let caps = p.capabilities();
+        assert!(caps.supports_image);
+        assert!(caps.supports_document);
     }
 }

--- a/sdks/rust/src/providers/gemini.rs
+++ b/sdks/rust/src/providers/gemini.rs
@@ -314,6 +314,10 @@ impl GeminiProvider {
 
 #[async_trait]
 impl ProviderImpl for GeminiProvider {
+    fn capabilities(&self) -> crate::types::ProviderCapabilities {
+        crate::types::ProviderCapabilities::with_image()
+    }
+
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let model = req.model.clone().unwrap_or_else(|| self.model.clone());
         let url = self.generate_url(&req);
@@ -549,6 +553,14 @@ mod tests {
     fn build(msgs: Vec<Message>) -> Value {
         let req = ChatRequest::builder().messages(msgs).build();
         GeminiProvider::build_request(&req)
+    }
+
+    #[test]
+    fn capabilities_support_image_only() {
+        let p = GeminiProvider::new("key", None, None);
+        let caps = p.capabilities();
+        assert!(caps.supports_image);
+        assert!(!caps.supports_document);
     }
 
     #[test]

--- a/sdks/rust/src/providers/gemini.rs
+++ b/sdks/rust/src/providers/gemini.rs
@@ -109,7 +109,7 @@ impl GeminiProvider {
                                     parts.push(json!({"fileData": {"fileUri": url}}));
                                 }
                             },
-                            ContentBlock::Document { .. } => {}
+                            ContentBlock::Document { .. } => unreachable!("document block reached Gemini serializer; caller skipped validate_request"),
                         }
                     }
                     if parts.is_empty() {

--- a/sdks/rust/src/providers/gemini_code_assist.rs
+++ b/sdks/rust/src/providers/gemini_code_assist.rs
@@ -104,6 +104,10 @@ impl GeminiCodeAssistProvider {
 
 #[async_trait]
 impl ProviderImpl for GeminiCodeAssistProvider {
+    fn capabilities(&self) -> crate::types::ProviderCapabilities {
+        crate::types::ProviderCapabilities::with_image()
+    }
+
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let model = req.model.clone().unwrap_or_else(|| self.model.clone());
         let stream = self.stream(req).await?;
@@ -323,6 +327,14 @@ mod tests {
 
     fn provider() -> GeminiCodeAssistProvider {
         GeminiCodeAssistProvider::new("ya29.fake", "test-project", None, None)
+    }
+
+    #[test]
+    fn capabilities_support_image_only() {
+        let p = GeminiCodeAssistProvider::new("ya29.fake", "test-project", None, None);
+        let caps = p.capabilities();
+        assert!(caps.supports_image);
+        assert!(!caps.supports_document);
     }
 
     #[test]

--- a/sdks/rust/src/providers/minimax.rs
+++ b/sdks/rust/src/providers/minimax.rs
@@ -2,8 +2,7 @@ use crate::error::MotosanError;
 use crate::models::DEFAULT_MINIMAX_MODEL;
 use crate::providers::{
     extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
-    parse_retry_after, reject_document_blocks, sleep_before_retry, ChatResponseBuilder,
-    ProviderImpl,
+    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -340,7 +339,6 @@ impl MinimaxRequestBuilder {
 #[async_trait]
 impl ProviderImpl for MinimaxProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        reject_document_blocks(&req, "MiniMax")?;
         let expose_reasoning = self.resolve_expose_reasoning(&req);
         let body = MinimaxRequestBuilder::new(req, self.model.clone()).build();
         let mut attempt = 0;
@@ -460,7 +458,6 @@ impl ProviderImpl for MinimaxProvider {
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
-        reject_document_blocks(&req, "MiniMax")?;
         let expose_reasoning = self.resolve_expose_reasoning(&req);
         let body = MinimaxRequestBuilder::new(req, self.model.clone())
             .stream(true)

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -292,25 +292,6 @@ pub(crate) async fn sleep_before_retry(
     tokio::time::sleep(delay).await;
 }
 
-/// Return an `UnsupportedFeature` error if any message contains a `Document` block.
-#[cfg(any(feature = "openai", feature = "minimax", feature = "ollama_native"))]
-pub(crate) fn reject_document_blocks(
-    req: &ChatRequest,
-    provider_name: &str,
-) -> Result<(), MotosanError> {
-    for message in &req.messages {
-        for block in &message.content_blocks {
-            if matches!(block, ContentBlock::Document { .. }) {
-                return Err(MotosanError::UnsupportedFeature(format!(
-                    "Document content blocks (PDF) are not supported by the {} provider",
-                    provider_name
-                )));
-            }
-        }
-    }
-    Ok(())
-}
-
 #[cfg(feature = "anthropic")]
 pub mod anthropic;
 
@@ -341,7 +322,7 @@ pub mod gemini_code_assist;
 #[cfg(test)]
 mod validate_tests {
     use super::*;
-    use crate::types::{ContentBlock, ImageSource, Message, ProviderCapabilities};
+    use crate::types::{Message, ProviderCapabilities};
 
     struct TextOnlyProvider;
 

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -9,9 +9,7 @@ use crate::error::MotosanError;
 ))]
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
-#[cfg(any(feature = "openai", feature = "minimax", feature = "ollama_native"))]
-use crate::types::ContentBlock;
-use crate::types::{ChatRequest, ChatResponse};
+use crate::types::{ChatRequest, ChatResponse, ContentBlock, ProviderCapabilities};
 #[cfg(any(
     feature = "anthropic",
     feature = "openai",
@@ -71,6 +69,32 @@ pub enum Provider {
 
 #[async_trait]
 pub trait ProviderImpl: Send + Sync {
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities::text_only()
+    }
+
+    fn validate_request(&self, req: &ChatRequest) -> Result<(), MotosanError> {
+        let caps = self.capabilities();
+        for msg in &req.messages {
+            for block in &msg.content_blocks {
+                match block {
+                    ContentBlock::Image { .. } if !caps.supports_image => {
+                        return Err(MotosanError::UnsupportedFeature(
+                            "provider does not support image input".into(),
+                        ));
+                    }
+                    ContentBlock::Document { .. } if !caps.supports_document => {
+                        return Err(MotosanError::UnsupportedFeature(
+                            "provider does not support document input".into(),
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError>;
     async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError>;
 }
@@ -313,3 +337,84 @@ pub mod gemini;
 
 #[cfg(feature = "gemini-code-assist")]
 pub mod gemini_code_assist;
+
+#[cfg(test)]
+mod validate_tests {
+    use super::*;
+    use crate::types::{ContentBlock, ImageSource, Message, ProviderCapabilities};
+
+    struct TextOnlyProvider;
+
+    #[async_trait]
+    impl ProviderImpl for TextOnlyProvider {
+        async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+            unimplemented!()
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError> {
+            unimplemented!()
+        }
+    }
+
+    struct FullProvider;
+
+    #[async_trait]
+    impl ProviderImpl for FullProvider {
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities::full()
+        }
+        async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, MotosanError> {
+            unimplemented!()
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream, MotosanError> {
+            unimplemented!()
+        }
+    }
+
+    fn req_with_image() -> ChatRequest {
+        let msg = Message::user_with_image("look", "abc123", "image/png");
+        ChatRequest::builder().messages(vec![msg]).build()
+    }
+
+    fn req_with_document() -> ChatRequest {
+        let msg = Message::user_with_pdf_base64("read this", "abc123");
+        ChatRequest::builder().messages(vec![msg]).build()
+    }
+
+    fn req_text_only() -> ChatRequest {
+        ChatRequest::builder()
+            .messages(vec![Message::user("hello")])
+            .build()
+    }
+
+    #[test]
+    fn text_only_provider_rejects_image() {
+        let p = TextOnlyProvider;
+        let result = p.validate_request(&req_with_image());
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
+
+    #[test]
+    fn text_only_provider_rejects_document() {
+        let p = TextOnlyProvider;
+        let result = p.validate_request(&req_with_document());
+        assert!(matches!(result, Err(MotosanError::UnsupportedFeature(_))));
+    }
+
+    #[test]
+    fn full_provider_accepts_image() {
+        let p = FullProvider;
+        assert!(p.validate_request(&req_with_image()).is_ok());
+    }
+
+    #[test]
+    fn full_provider_accepts_document() {
+        let p = FullProvider;
+        assert!(p.validate_request(&req_with_document()).is_ok());
+    }
+
+    #[test]
+    fn any_provider_accepts_plain_text() {
+        let p = TextOnlyProvider;
+        assert!(p.validate_request(&req_text_only()).is_ok());
+    }
+}

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -2,8 +2,7 @@ use crate::error::MotosanError;
 use crate::models::DEFAULT_OLLAMA_MODEL;
 use crate::providers::{
     extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
-    parse_retry_after, reject_document_blocks, sleep_before_retry, ChatResponseBuilder,
-    ProviderImpl,
+    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -229,7 +228,6 @@ impl OllamaProvider {
 #[async_trait]
 impl ProviderImpl for OllamaProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        reject_document_blocks(&req, "Ollama")?;
         let body = self.build_request_body(&req, false);
         let mut attempt = 0;
         let payload: Value;
@@ -334,7 +332,6 @@ impl ProviderImpl for OllamaProvider {
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
-        reject_document_blocks(&req, "Ollama")?;
         let body = self.build_request_body(&req, true);
         let mut attempt = 0;
 

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -2,8 +2,7 @@ use crate::error::MotosanError;
 use crate::models::DEFAULT_OPENAI_MODEL;
 use crate::providers::{
     extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
-    parse_retry_after, reject_document_blocks, sleep_before_retry, ChatResponseBuilder,
-    ProviderImpl,
+    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -355,8 +354,8 @@ impl OpenAIRequestBuilder {
                                         "image_url": {"url": url}
                                     }),
                                 },
-                                // Document blocks are rejected before reaching this point.
-                                ContentBlock::Document { .. } => unreachable!("Document blocks should be rejected before serialization"),
+                                // Document blocks are rejected via validate_request() before reaching serialization.
+                                ContentBlock::Document { .. } => unreachable!(),
                             }
                         }).collect();
                         messages.push(json!({"role": "user", "content": blocks}));
@@ -476,7 +475,6 @@ impl ProviderImpl for OpenAIProvider {
     }
 
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        reject_document_blocks(&req, "OpenAI")?;
         let fallback_request = req.clone();
         let body = OpenAIRequestBuilder::new(req, self.model.clone()).build();
         let mut attempt = 0;
@@ -593,7 +591,6 @@ impl ProviderImpl for OpenAIProvider {
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
-        reject_document_blocks(&req, "OpenAI")?;
         let body = OpenAIRequestBuilder::new(req, self.model.clone())
             .stream(true)
             .build();

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -471,6 +471,10 @@ impl OpenAIRequestBuilder {
 
 #[async_trait]
 impl ProviderImpl for OpenAIProvider {
+    fn capabilities(&self) -> crate::types::ProviderCapabilities {
+        crate::types::ProviderCapabilities::with_image()
+    }
+
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         reject_document_blocks(&req, "OpenAI")?;
         let fallback_request = req.clone();
@@ -814,5 +818,18 @@ impl Stream for OpenAIStreamAdapter {
                 Poll::Pending => return Poll::Pending,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capabilities_support_image_only() {
+        let p = OpenAIProvider::new("key", None);
+        let caps = p.capabilities();
+        assert!(caps.supports_image);
+        assert!(!caps.supports_document);
     }
 }

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -814,6 +814,35 @@ impl StreamEvent {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderCapabilities {
+    pub supports_image: bool,
+    pub supports_document: bool,
+}
+
+impl ProviderCapabilities {
+    pub fn text_only() -> Self {
+        Self {
+            supports_image: false,
+            supports_document: false,
+        }
+    }
+
+    pub fn with_image() -> Self {
+        Self {
+            supports_image: true,
+            supports_document: false,
+        }
+    }
+
+    pub fn full() -> Self {
+        Self {
+            supports_image: true,
+            supports_document: true,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1044,5 +1073,31 @@ mod tests {
 
         assert!(req.system_blocks.is_none());
         assert_eq!(req.system.as_deref(), Some("Plain system"));
+    }
+}
+
+#[cfg(test)]
+mod capabilities_tests {
+    use super::*;
+
+    #[test]
+    fn text_only_has_no_capabilities() {
+        let caps = ProviderCapabilities::text_only();
+        assert!(!caps.supports_image);
+        assert!(!caps.supports_document);
+    }
+
+    #[test]
+    fn with_image_supports_image_only() {
+        let caps = ProviderCapabilities::with_image();
+        assert!(caps.supports_image);
+        assert!(!caps.supports_document);
+    }
+
+    #[test]
+    fn full_supports_everything() {
+        let caps = ProviderCapabilities::full();
+        assert!(caps.supports_image);
+        assert!(caps.supports_document);
     }
 }

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -814,7 +814,7 @@ impl StreamEvent {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ProviderCapabilities {
     pub supports_image: bool,
     pub supports_document: bool,


### PR DESCRIPTION
## Summary

- Adds `ProviderCapabilities` type (`supports_image`, `supports_document`) to `types.rs`
- Extends `ProviderImpl` trait with two provided methods: `capabilities()` (default: text-only) and `validate_request()` (pre-flight check that returns `Err(UnsupportedFeature)` for unsupported content blocks)
- Wires `validate_request` into `LlmClient::dispatch_chat` and `dispatch_stream_inner` — runs before every API call, across all 10 providers
- Anthropic declares `full()`, OpenAI/Gemini/GeminiCodeAssist declare `with_image()`, all others default to text-only
- Removes `reject_document_blocks()` helper — superseded by framework-level validation
- Fixes pre-existing Python `ruff SIM105` lint error in `claude_code.py`

## Test Plan

- [ ] `check-rust` passes (fmt + clippy + test --all-features, 428 tests)
- [ ] `check-python` passes (ruff + pytest)
- [ ] `cargo test --all-features capabilities` shows capability tests for all providers
- [ ] Sending an image message to an Ollama/MiniMax/GeminiCli client returns `Err(UnsupportedFeature)` before any network call

🤖 Generated with [Claude Code](https://claude.com/claude-code)