### PR TITLE
feat(rust): ClientBuilder::anthropic_base_url (v0.14.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.14.0 (crates.io) · Python v0.10.0 (PyPI)
+Rust v0.14.2 (crates.io) · Python v0.10.0 (PyPI)
 
 ## Where To Find Things
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.14.0 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.14.2 |
 | Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.9.3 |
 
 ## Install
@@ -34,7 +34,7 @@ response = await client.chat([Message.user("Hello")])
 ```toml
 # Rust (Cargo.toml)
 [dependencies]
-motosan-ai = { version = "0.14.0", features = ["anthropic"] }
+motosan-ai = { version = "0.14.2", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.10.0 · Rust 0.14.0
+- Python 0.10.0 · Rust 0.14.2
 - GitHub: https://github.com/motosan-dev/motosan-ai
 - PyPI: https://pypi.org/project/motosan-ai/
 - crates.io: https://crates.io/crates/motosan-ai
@@ -19,7 +19,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.14.0", features = ["anthropic"] }
+motosan-ai = { version = "0.14.2", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient):
@@ -571,6 +571,16 @@ Billing: subscription-based ($19–$45/seat/month). 1,000–2,000 requests/day d
 
 - Regular API key (`sk-ant-api*`): uses `x-api-key` header
 - OAuth token (`sk-ant-oat01*`): auto-switches to OAuth mode with `Authorization: Bearer`, streaming required, `chat()` auto-redirects to `stream()`
+
+### Anthropic Base URL
+
+```rust
+// Point at a proxy, on-prem deployment, or Anthropic-compatible third-party endpoint.
+// Defaults to https://api.anthropic.com when unset. (Rust v0.14.2+)
+client_builder.anthropic_base_url("https://proxy.example.com/anthropic")
+```
+
+Getter: `client.anthropic_base_url() -> Option<&str>` returns the override, or `None` if the default is in use.
 
 ### OpenAI
 

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
+## [0.14.2] - 2026-05-16
+
+### Added
+- **`ClientBuilder::anthropic_base_url(...)`** — override the Anthropic base URL for staging, on-prem proxies, or Anthropic-compatible third-party endpoints. Defaults to `https://api.anthropic.com` when unset. Mirrors the existing `minimax_base_url` / `ollama_base_url` setters. The new value is forwarded to `AnthropicProvider::new(..., base_url)` in `build_anthropic_provider`.
+- **`Client::anthropic_base_url() -> Option<&str>`** — getter that returns the override if one was set, `None` otherwise. Used by downstream consumers and the new round-trip test.
+
+### Notes
+- Purely additive: existing `Client::builder().provider(Provider::Anthropic).api_key(...).build()` callers see no behaviour change.
+- Restores parity with M1-era capo and similar downstream wrappers that previously rolled their own `AnthropicProvider` constructor to support custom base URLs.
+
 ## [0.14.1] - 2026-04-25
 
 ### Fixed

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -317,7 +317,7 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
 ```toml
-motosan-ai = { version = "0.14.0", features = ["claude-code"] }
+motosan-ai = { version = "0.14.2", features = ["claude-code"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -426,7 +426,7 @@ Notes:
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
 ```toml
-motosan-ai = { version = "0.14.0", features = ["codex-cli"] }
+motosan-ai = { version = "0.14.2", features = ["codex-cli"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -489,7 +489,7 @@ Notes:
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
 ```toml
-motosan-ai = { version = "0.14.0", features = ["gemini-cli"] }
+motosan-ai = { version = "0.14.2", features = ["gemini-cli"] }
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -15,6 +15,7 @@ pub struct Client {
     openai_responses_fallback: bool,
     openai_chat_url: Option<String>,
     openai_responses_url: Option<String>,
+    anthropic_base_url: Option<String>,
     minimax_base_url: Option<String>,
     ollama_base_url: String,
     ollama_native: bool,
@@ -80,6 +81,13 @@ impl Client {
 
     pub fn openai_responses_fallback(&self) -> bool {
         self.openai_responses_fallback
+    }
+
+    /// The custom Anthropic base URL, if one was set via
+    /// [`ClientBuilder::anthropic_base_url`]. Returns `None` when the client
+    /// uses the default `https://api.anthropic.com`.
+    pub fn anthropic_base_url(&self) -> Option<&str> {
+        self.anthropic_base_url.as_deref()
     }
 
     pub async fn chat(&self, messages: Vec<Message>) -> Result<ChatResponse, MotosanError> {
@@ -486,7 +494,7 @@ impl Client {
         crate::providers::anthropic::AnthropicProvider::new(
             self.api_key.clone(),
             self.model.clone(),
-            None,
+            self.anthropic_base_url.clone(),
         )
         .with_retry_policy(self.retry_policy.clone())
     }
@@ -657,6 +665,7 @@ pub struct ClientBuilder {
     openai_responses_fallback: Option<bool>,
     openai_chat_url: Option<String>,
     openai_responses_url: Option<String>,
+    anthropic_base_url: Option<String>,
     minimax_base_url: Option<String>,
     ollama_base_url: Option<String>,
     ollama_native: Option<bool>,
@@ -730,6 +739,14 @@ impl ClientBuilder {
     /// enabled.
     pub fn openai_responses_url(mut self, url: impl Into<String>) -> Self {
         self.openai_responses_url = Some(url.into());
+        self
+    }
+
+    /// Override the Anthropic base URL. Useful for staging, on-prem
+    /// proxies, or Anthropic-compatible third-party endpoints. Defaults to
+    /// `https://api.anthropic.com` when unset.
+    pub fn anthropic_base_url(mut self, anthropic_base_url: impl Into<String>) -> Self {
+        self.anthropic_base_url = Some(anthropic_base_url.into());
         self
     }
 
@@ -860,6 +877,7 @@ impl ClientBuilder {
             openai_responses_fallback: self.openai_responses_fallback.unwrap_or(false),
             openai_chat_url: self.openai_chat_url,
             openai_responses_url: self.openai_responses_url,
+            anthropic_base_url: self.anthropic_base_url,
             minimax_base_url: self.minimax_base_url,
             ollama_base_url: self
                 .ollama_base_url

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -51,6 +51,31 @@ fn builder_uses_default_retry_policy_and_allows_override() {
     );
 }
 
+#[cfg(feature = "anthropic")]
+#[test]
+fn builder_anthropic_base_url_defaults_to_none_and_round_trips_override() {
+    // Default: no override set → getter returns None (provider falls back to
+    // https://api.anthropic.com).
+    let default_client = Client::builder()
+        .provider(Provider::Anthropic)
+        .api_key("k")
+        .build()
+        .expect("build client");
+    assert_eq!(default_client.anthropic_base_url(), None);
+
+    // Override: set a custom URL → getter returns it verbatim.
+    let custom_client = Client::builder()
+        .provider(Provider::Anthropic)
+        .api_key("k")
+        .anthropic_base_url("https://proxy.example.com/anthropic")
+        .build()
+        .expect("build client");
+    assert_eq!(
+        custom_client.anthropic_base_url(),
+        Some("https://proxy.example.com/anthropic")
+    );
+}
+
 #[cfg(feature = "minimax")]
 #[tokio::test]
 async fn builder_accepts_minimax_base_url_override() {

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -76,6 +76,45 @@ fn builder_anthropic_base_url_defaults_to_none_and_round_trips_override() {
     );
 }
 
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn builder_anthropic_base_url_is_forwarded_to_http_request() {
+    // Regression guard: the getter test above can pass even if
+    // build_anthropic_provider stops threading self.anthropic_base_url into
+    // AnthropicProvider::new. This test asserts the override actually reaches
+    // the wire by pointing the client at a mockito server and verifying the
+    // POST lands on that host.
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_body(
+            serde_json::json!({
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .provider(Provider::Anthropic)
+        .api_key("test-key")
+        .anthropic_base_url(server.url())
+        .build()
+        .expect("build client");
+
+    let _ = client
+        .chat(vec![Message::user("hi")])
+        .await
+        .expect("chat against mock server");
+    mock.assert_async().await;
+}
+
 #[cfg(feature = "minimax")]
 #[tokio::test]
 async fn builder_accepts_minimax_base_url_override() {

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.10.0 / Rust 0.14.0
+Multi-provider LLM SDK — Python 0.10.0 / Rust 0.14.2
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI
 
@@ -20,7 +20,7 @@ pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.14.0", features = ["anthropic"] }
+motosan-ai = { version = "0.14.2", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-motosan-ai = { version = "0.14.0", features = ["anthropic"] }
+motosan-ai = { version = "0.14.2", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```


### PR DESCRIPTION
## Summary

- Adds `ClientBuilder::anthropic_base_url(...)` setter + `Client::anthropic_base_url() -> Option<&str>` getter, threading a custom Anthropic endpoint through `build_anthropic_provider`. Restores M1-era parity for proxy / on-prem / staging Anthropic-compatible deployments — downstream consumers (e.g. capo's `BaseUrlAnthropicClient`) no longer need to roll their own provider wrapper.
- Purely additive; bumps `motosan-ai` 0.14.1 → 0.14.2 (semver patch).
- Updates all release-checklist docs (CLAUDE.md §Release): `AGENTS.md`, `llms.txt`, `skills/motosan-ai/SKILL.md`, plus user-facing READMEs and the Rust API reference doc. `llms.txt` gets a new **Anthropic Base URL** section next to the existing **Anthropic Auth** block.
- Tests: getter round-trip + mockito-backed wire-through assertion (`builder_anthropic_base_url_is_forwarded_to_http_request`) that posts against a mock server to lock in actual forwarding behaviour — guards against future refactors of `build_anthropic_provider` silently dropping the field.

## Commits

- `7847136` feat(rust): add ClientBuilder::anthropic_base_url (v0.14.2)
- `ac03b16` docs(rust): bump to v0.14.2 + cover anthropic_base_url forwarding

## Test plan

- [x] `cargo test --features anthropic --test client_builder` — 7 passed
- [x] `check-all` — Rust fmt + clippy + tests, Python ruff + format + pytest
- [x] `./scripts/pre-push-gate.sh` — all 4 stages green, incl. 9 Rust live tests against real Anthropic API (51s)
- [x] Verified MiniMax routing unaffected (`Provider::Minimax` continues to use `minimax_base_url`, not the new field)
- [x] Existing `Client::builder().provider(Provider::Anthropic).api_key(...).build()` callers see no behaviour change (default-None path)

## Release readiness

After merge to `main`, tag `rust-v0.14.2` and push to trigger `publish-rust.yml` → crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)