### PR TITLE
fix(rust): claude_code .stream() emits text again (v0.14.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.14.2 (crates.io) · Python v0.10.0 (PyPI)
+Rust v0.14.3 (crates.io) · Python v0.10.0 (PyPI)
 
 ## Where To Find Things
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.14.2 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.14.3 |
 | Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.9.3 |
 
 ## Install
@@ -34,7 +34,7 @@ response = await client.chat([Message.user("Hello")])
 ```toml
 # Rust (Cargo.toml)
 [dependencies]
-motosan-ai = { version = "0.14.2", features = ["anthropic"] }
+motosan-ai = { version = "0.14.3", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```

--- a/docs/superpowers/notes/2026-05-16-cli-provider-smoke-debug.md
+++ b/docs/superpowers/notes/2026-05-16-cli-provider-smoke-debug.md
@@ -70,9 +70,13 @@ echo "Reply with exactly the word: pong" | codex exec --json --skip-git-repo-che
 
 Codex with `codex-cli 0.130.0` emits the expected events under motosan-ai's exact spawn args. If capo continues to see empty output for `--provider codex-cli` after the claude fix lands, the next investigation step is parser shape: do motosan-ai's `codex_cli/mod.rs` and `codex_cli/event.rs` correctly map `item.completed` events with `item.type=="agent_message"` to a `StreamEvent::Text`? That's an in-repo audit worth ~30 minutes; out of scope for this round.
 
-## Fix scope (claude_code)
+## Fix scope (claude_code) — turned out to be TWO bugs, not one
 
-Single-line change in `claude_code/mod.rs:396`:
+**Update 2026-05-17 (during implementation):** the `--verbose` fix was necessary but **not sufficient**. After adding it, the live integration test still failed with zero Text events. Investigation found a *second* bug: the NDJSON parser only recognised the legacy `{"type":"text","text":"..."}` event shape. Modern `claude` (≥ 2.1.x) emits assistant text inside `{"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}` — which the old parser dropped as `Other`. Both bugs had to be fixed together for any text to reach consumers.
+
+### Bug 1: missing `--verbose` flag
+
+In `claude_code/mod.rs:396`:
 
 ```diff
 - cmd.arg("--print").arg("--output-format").arg("stream-json");
@@ -81,8 +85,20 @@ Single-line change in `claude_code/mod.rs:396`:
 
 `--verbose` has been a stable flag in the `claude` CLI long before the requirement was added, so this is backwards-compatible with older binaries.
 
-Also worth fixing in the same commit:
-- `mod.rs:452`: `let _ = child.wait().await;` silently swallows non-zero exit codes. Should at minimum log or yield a `StreamEvent::Error` when the child exits non-zero AND no events were emitted. (Separate paragraph in the fix; not blocking.)
+### Bug 2: stale NDJSON parser
+
+In `claude_code/stream_json.rs`, the `ClaudeStreamEvent` enum only matched `Text` and `Result`. Added `Assistant { message: AssistantMessage }` variant + `AssistantContentBlock` enum that walks `message.content[]`, extracts text from `text`-typed blocks, and skips `thinking`/`tool_use`/etc via `#[serde(other)]`. Multiple text blocks in a single assistant turn are concatenated.
+
+Three unit tests added:
+- `parse_assistant_event_with_single_text_block`
+- `assistant_event_skips_thinking_keeps_text`
+- `assistant_event_with_only_non_text_blocks_is_dropped`
+
+Plus the live integration test (`integration_client_dispatches_to_claude_code_stream` in `tests/client_builder.rs`) now passes against the real `claude` binary.
+
+### Secondary issue (deferred, NOT fixed in 0.14.3)
+
+- `mod.rs:452`: `let _ = child.wait().await;` silently swallows non-zero exit codes. The `--verbose`/parser bugs were both symptoms whose detection would have been much faster if a non-zero exit yielded a `StreamEvent::Error`. Fix is straightforward but introduces a new event variant for callers to handle — separate PR worth a small design conversation.
 
 ## Test plan
 

--- a/docs/superpowers/notes/2026-05-16-cli-provider-smoke-debug.md
+++ b/docs/superpowers/notes/2026-05-16-cli-provider-smoke-debug.md
@@ -1,0 +1,107 @@
+# CLI Provider Empty-Output Debug — 2026-05-16
+
+**Investigation per** `docs/superpowers/specs/2026-05-16-motosan-ai-followups.md` §2.
+
+**Symptom (from capo PR #11 manual smoke):** `cargo run -- --provider claude-code -p "Reply with exactly the word: pong"` and the codex equivalent both exit 0 but emit no final assistant text. capo prints its `[thinking]` preamble, then nothing.
+
+## TL;DR
+
+| Provider | Verdict | Fix lives in |
+|----------|---------|--------------|
+| `Provider::ClaudeCode` `.stream()` | 🚨 **motosan-ai bug** — missing `--verbose` flag | motosan-ai (this repo) |
+| `Provider::ClaudeCode` `.chat()` | ✅ Clean | n/a |
+| `Provider::CodexCli` `.stream()` / `.chat()` | ✅ Clean in isolation — if capo still sees empty output, the bug is downstream (capo's invocation) or in a parser shape mismatch we didn't surface here | downstream / further investigation |
+
+## How the bug surfaces (claude_code `.stream()`)
+
+`sdks/rust/src/providers/claude_code/mod.rs:396` spawns:
+
+```rust
+cmd.arg("--print").arg("--output-format").arg("stream-json");
+```
+
+`claude` 2.1.143 (current) **rejects this combination** at startup:
+
+```
+$ echo "Reply with exactly the word: pong" | claude --print --output-format stream-json -
+Error: When using --print, --output-format=stream-json requires --verbose
+```
+
+Claude exits non-zero, stdout is empty, motosan-ai's stream code at `mod.rs:427-449` reads zero lines from stdout, the `async_stream::stream!` block falls through without yielding any events, and the stream closes cleanly with no events and no error. capo's consumer loop receives nothing.
+
+The `child.wait().await` at `mod.rs:452` *would* see the non-zero exit code, but its return value is `_`-discarded. So motosan-ai swallows the failure silently.
+
+## Verification
+
+```bash
+# Direct invocation matching motosan-ai's exact spawn args — empty output:
+echo "Reply with exactly the word: pong" | claude --print --output-format stream-json -
+# → Error: When using --print, --output-format=stream-json requires --verbose
+
+# With --verbose added — works:
+echo "Reply with exactly the word: pong" | claude --print --output-format stream-json --verbose -
+# → Proper NDJSON including:
+#   {"type":"assistant","message":{...,"content":[{"type":"text","text":"pong"}],...}}
+#   {"type":"result","subtype":"success","result":"pong",...}
+
+# .chat() path (no stream-json) — already works without --verbose:
+echo "Reply with exactly the word: pong" | claude --print -
+# → pong
+```
+
+## Codex side (acquitted)
+
+`sdks/rust/src/providers/codex_cli/mod.rs:385` and `spawn.rs:227` spawn:
+
+```rust
+cmd.arg("exec").arg("--json").arg("--skip-git-repo-check");
+```
+
+Direct invocation:
+
+```bash
+echo "Reply with exactly the word: pong" | codex exec --json --skip-git-repo-check -
+# → Proper NDJSON:
+#   {"type":"thread.started",...}
+#   {"type":"turn.started"}
+#   {"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"pong"}}
+#   {"type":"turn.completed","usage":{...}}
+```
+
+Codex with `codex-cli 0.130.0` emits the expected events under motosan-ai's exact spawn args. If capo continues to see empty output for `--provider codex-cli` after the claude fix lands, the next investigation step is parser shape: do motosan-ai's `codex_cli/mod.rs` and `codex_cli/event.rs` correctly map `item.completed` events with `item.type=="agent_message"` to a `StreamEvent::Text`? That's an in-repo audit worth ~30 minutes; out of scope for this round.
+
+## Fix scope (claude_code)
+
+Single-line change in `claude_code/mod.rs:396`:
+
+```diff
+- cmd.arg("--print").arg("--output-format").arg("stream-json");
++ cmd.arg("--print").arg("--output-format").arg("stream-json").arg("--verbose");
+```
+
+`--verbose` has been a stable flag in the `claude` CLI long before the requirement was added, so this is backwards-compatible with older binaries.
+
+Also worth fixing in the same commit:
+- `mod.rs:452`: `let _ = child.wait().await;` silently swallows non-zero exit codes. Should at minimum log or yield a `StreamEvent::Error` when the child exits non-zero AND no events were emitted. (Separate paragraph in the fix; not blocking.)
+
+## Test plan
+
+Add a `tests/claude_code_smoke.rs` integration test gated behind `#[ignore]` (requires `claude` binary + auth, like the existing codex live test) that:
+1. Builds a `Client` with `Provider::ClaudeCode`
+2. Calls `.stream()` with a "Reply with exactly the word: pong" prompt
+3. Asserts at least one `StreamEvent::Text` arrives with non-empty text
+
+This locks in the regression — if a future refactor drops `--verbose`, the test fails immediately.
+
+Unit-test alternative (no live calls): add a test that spawns `claude --print --output-format stream-json --verbose -` directly and asserts the argv printed in `format!("{:?}", cmd)` contains `"--verbose"`. Cheaper but less safe than the live test.
+
+## Release classification
+
+Per `docs/superpowers/specs/2026-05-16-motosan-ai-followups.md` §190 ("§2 might add additional spawn-arg changes"):
+
+- This is a **bug fix**, additive flag, no API surface change → **0.14.3 patch**.
+- Bundle with §4 (CLI docs) which also touches claude_code/mod.rs, and §5a (unused field cleanup). Keep §3 (Ollama, breaking) and §5b (clippy mass cleanup) for 0.15.0 minor as the spec already plans.
+
+## Capo coordination
+
+Once 0.14.3 lands on crates.io, capo can bump its `motosan-ai` dep and re-run the manual smoke. If `--provider claude-code` now produces text but `--provider codex-cli` still doesn't, hand off the codex side to a separate investigation per the "Codex side (acquitted)" section above.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.10.0 · Rust 0.14.2
+- Python 0.10.0 · Rust 0.14.3
 - GitHub: https://github.com/motosan-dev/motosan-ai
 - PyPI: https://pypi.org/project/motosan-ai/
 - crates.io: https://crates.io/crates/motosan-ai
@@ -19,7 +19,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.14.2", features = ["anthropic"] }
+motosan-ai = { version = "0.14.3", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient):

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
+## [0.14.3] - 2026-05-17
+
+### Fixed
+- **`Provider::ClaudeCode` `.stream()` emitted zero events under `claude` ≥ 2.1.x.** Two compounding bugs were silently producing empty streams for capo / motosan-agent-loop / any downstream stream consumer:
+  1. **Missing `--verbose` flag.** Modern `claude` requires `--verbose` when combining `--print` with `--output-format=stream-json`; without it the CLI exits non-zero with `Error: When using --print, --output-format=stream-json requires --verbose` and emits no NDJSON. Fixed in `sdks/rust/src/providers/claude_code/mod.rs:396`.
+  2. **Stale NDJSON parser.** Even with `--verbose` producing output, the parser in `claude_code/stream_json.rs` only matched the legacy `{"type":"text","text":"..."}` event shape. Modern `claude` emits assistant text inside `{"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}`, which the parser dropped as `Other`. Added an `Assistant` variant + `AssistantContentBlock` enum that walks `message.content[]`, extracts text from `text`-typed blocks, and skips `thinking` / `tool_use` via `#[serde(other)]`. Multiple text blocks in one assistant turn are concatenated.
+
+### Added
+- `tests/client_builder.rs::integration_client_dispatches_to_claude_code_stream` — live regression test (gated `#[ignore]`, requires `claude` binary + auth) that fails fast if either fix regresses.
+- Three unit tests in `claude_code/stream_json.rs` covering the new assistant-event parsing (single text block, mixed thinking+text, tool-use-only).
+- "Streaming vs Blocking" module-level documentation on both `providers::claude_code` and `providers::codex_cli`, clarifying that `.chat()` and `.stream()` spawn the CLI in different modes (unlike HTTP providers where they share an engine).
+
+### Notes
+- Investigation notes at `docs/superpowers/notes/2026-05-16-cli-provider-smoke-debug.md` with full repro commands.
+- Codex side acquitted under motosan-ai's exact spawn args — emits the expected NDJSON shape. No codex-side change in this release.
+- Deferred to a future release: `claude_code/mod.rs:452` silently discards the child process exit code via `let _ = child.wait().await`. If the stream is empty AND the child exited non-zero, we should yield a `StreamEvent::Error` — but that introduces a new event variant for callers to handle, so it's worth a small design conversation.
+
 ## [0.14.2] - 2026-05-16
 
 ### Added

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -317,7 +317,7 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
 ```toml
-motosan-ai = { version = "0.14.2", features = ["claude-code"] }
+motosan-ai = { version = "0.14.3", features = ["claude-code"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -426,7 +426,7 @@ Notes:
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
 ```toml
-motosan-ai = { version = "0.14.2", features = ["codex-cli"] }
+motosan-ai = { version = "0.14.3", features = ["codex-cli"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -489,7 +489,7 @@ Notes:
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
 ```toml
-motosan-ai = { version = "0.14.2", features = ["gemini-cli"] }
+motosan-ai = { version = "0.14.3", features = ["gemini-cli"] }
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/rust/src/providers/claude_code/mod.rs
+++ b/sdks/rust/src/providers/claude_code/mod.rs
@@ -6,6 +6,29 @@
 //! the same shape as [`codex_cli`](super::codex_cli) and
 //! [`gemini_cli`](super::gemini_cli) so all three CLI backends are
 //! interchangeable via `Box<dyn ProviderImpl>`.
+//!
+//! # Streaming vs Blocking
+//!
+//! Unlike the HTTP providers (Anthropic, OpenAI, etc.) where `.chat()`
+//! and `.stream()` are two views over the same SSE engine, CLI backends
+//! spawn the binary in **different modes** for each path:
+//!
+//! - [`chat`](ClaudeCodeProvider) spawns `claude --print -` (no
+//!   `--output-format`), waits for the subprocess to exit, collects the
+//!   complete stdout, and returns a single [`ChatResponse`]. No
+//!   intermediate events are surfaced. Token usage is `0`/`0` unless
+//!   `agent_mode` is enabled (which adds `--output-format json`).
+//! - [`stream`](ClaudeCodeProvider) spawns
+//!   `claude --print --output-format stream-json --verbose -`, reads
+//!   NDJSON lines from stdout as they arrive, and yields one
+//!   [`StreamEvent`] per parsed line. The `--verbose` flag is **required**
+//!   by `claude` ≥ 2.1.x for this format and is enforced by this crate.
+//!
+//! Callers should prefer `stream()` for any UI that benefits from
+//! incremental output, and `chat()` only when they need the whole reply
+//! as a single string.
+//!
+//! [`StreamEvent`]: crate::StreamEvent
 
 pub mod prompt;
 mod spawn;
@@ -393,7 +416,15 @@ impl ClaudeCodeProvider {
         let config = self.build_spawn_config(request.model, append_system_prompt);
 
         let mut cmd = Command::new(&config.binary_path);
-        cmd.arg("--print").arg("--output-format").arg("stream-json");
+        // `--verbose` is required by `claude` ≥ 2.1.x when combining `--print`
+        // with `--output-format=stream-json`. Without it the CLI exits with
+        // "Error: When using --print, --output-format=stream-json requires
+        // --verbose" and emits zero NDJSON — our stream then yields no events
+        // and capo's downstream consumer sees nothing.
+        cmd.arg("--print")
+            .arg("--output-format")
+            .arg("stream-json")
+            .arg("--verbose");
         cmd.args(spawn::common_args(&config));
         cmd.arg("-");
 

--- a/sdks/rust/src/providers/claude_code/stream_json.rs
+++ b/sdks/rust/src/providers/claude_code/stream_json.rs
@@ -5,17 +5,47 @@ use crate::types::{StreamEvent, Usage};
 #[derive(Deserialize)]
 #[serde(tag = "type")]
 pub enum ClaudeStreamEvent {
+    // Legacy shape emitted by claude < 2.1.x. Kept for backward compatibility
+    // with older binaries; never observed under current claude releases.
     #[serde(rename = "text")]
     Text { text: String },
 
+    // Current shape (claude ≥ 2.1.x): assistant turns ship one event per
+    // turn with a `message.content` array of typed blocks. We pull text out
+    // of the `text` blocks and ignore `thinking` / `tool_use` for now.
+    #[serde(rename = "assistant")]
+    Assistant { message: AssistantMessage },
+
     #[serde(rename = "result")]
     Result {
+        // The `result` field on a terminal `result` event duplicates what
+        // we already yielded as Text from the preceding `assistant` event.
+        // Kept parsed so the variant matches the wire shape, deliberately
+        // ignored to avoid double-emission.
         #[allow(dead_code)]
         result: String,
         #[serde(default)]
         usage: Option<ClaudeStreamUsage>,
     },
 
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize)]
+pub struct AssistantMessage {
+    pub content: Vec<AssistantContentBlock>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+pub enum AssistantContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+
+    // `thinking`, `tool_use`, etc — ignored for now; capo doesn't surface
+    // these to the user and motosan-ai's CLI bridge has no Stream variant
+    // for them yet.
     #[serde(other)]
     Other,
 }
@@ -42,6 +72,21 @@ pub fn parse_ndjson_line(line: &str) -> Option<NdjsonAction> {
     match event {
         ClaudeStreamEvent::Text { text } if !text.is_empty() => {
             Some(NdjsonAction::Text(StreamEvent::text(text)))
+        }
+        ClaudeStreamEvent::Assistant { message } => {
+            let combined: String = message
+                .content
+                .iter()
+                .filter_map(|block| match block {
+                    AssistantContentBlock::Text { text } => Some(text.as_str()),
+                    AssistantContentBlock::Other => None,
+                })
+                .collect();
+            if combined.is_empty() {
+                None
+            } else {
+                Some(NdjsonAction::Text(StreamEvent::text(combined)))
+            }
         }
         ClaudeStreamEvent::Result { usage, .. } => {
             let usage_event = usage.map(|u| {
@@ -124,6 +169,41 @@ mod tests {
     #[test]
     fn ignore_empty_text() {
         let line = r#"{"type":"text","text":""}"#;
+        assert!(parse_ndjson_line(line).is_none());
+    }
+
+    #[test]
+    fn parse_assistant_event_with_single_text_block() {
+        // Wire shape emitted by claude ≥ 2.1.x in stream-json mode.
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"pong"}]}}"#;
+        let action = parse_ndjson_line(line).expect("should parse");
+        match action {
+            NdjsonAction::Text(event) => {
+                assert_eq!(event.content, "pong");
+                assert!(!event.done);
+            }
+            _ => panic!("expected Text action"),
+        }
+    }
+
+    #[test]
+    fn assistant_event_skips_thinking_keeps_text() {
+        // Mixed content with a thinking block before the text block. Only the
+        // text portion should reach motosan-ai's stream consumers.
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"pong"}]}}"#;
+        let action = parse_ndjson_line(line).expect("should parse");
+        match action {
+            NdjsonAction::Text(event) => {
+                assert_eq!(event.content, "pong");
+            }
+            _ => panic!("expected Text action"),
+        }
+    }
+
+    #[test]
+    fn assistant_event_with_only_non_text_blocks_is_dropped() {
+        // tool_use-only assistant turn: nothing to surface as text.
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"x","input":{}}]}}"#;
         assert!(parse_ndjson_line(line).is_none());
     }
 }

--- a/sdks/rust/src/providers/codex_cli/mod.rs
+++ b/sdks/rust/src/providers/codex_cli/mod.rs
@@ -12,6 +12,29 @@
 //! authentication, tool execution, sandboxing, and approvals internally; we
 //! just surface the final `agent_message` text plus token usage.
 //!
+//! # Streaming vs Blocking
+//!
+//! Unlike the HTTP providers (Anthropic, OpenAI, etc.) where `.chat()`
+//! and `.stream()` are two views over the same SSE engine, the codex CLI
+//! always emits NDJSON regardless of which path is used:
+//!
+//! - [`chat`](CodexCliProvider) spawns `codex exec --json
+//!   --skip-git-repo-check`, waits for the subprocess to exit, collects
+//!   the full NDJSON output, and extracts the final `agent_message` plus
+//!   `turn.completed` usage into a single [`ChatResponse`]. Intermediate
+//!   events are discarded.
+//! - [`stream`](CodexCliProvider) spawns the same command but reads
+//!   NDJSON lines as they arrive, yielding one [`StreamEvent`] per
+//!   meaningful event (`item.completed` of type `agent_message` becomes
+//!   `Text`; `turn.completed` becomes the terminal `done` event with
+//!   usage).
+//!
+//! Callers should prefer `stream()` for any UI that benefits from
+//! incremental output, and `chat()` only when they need the whole reply
+//! as a single string.
+//!
+//! [`StreamEvent`]: crate::StreamEvent
+//!
 //! # Why it lives outside `providers/`
 //!
 //! HTTP providers share request/response serialization machinery. A CLI-based

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -242,6 +242,49 @@ fn client_builder_still_requires_api_key_for_http_providers() {
     assert!(matches!(result, Err(MotosanError::Config(_))));
 }
 
+#[cfg(feature = "claude-code")]
+#[tokio::test]
+#[ignore] // Requires `claude` CLI installed + auth.
+async fn integration_client_dispatches_to_claude_code_stream() {
+    // Regression guard for the 0.14.3 fix: claude --print --output-format
+    // stream-json now requires --verbose (claude ≥ 2.1.x). Without the
+    // --verbose arg in claude_code/mod.rs the CLI errors at startup, stdout
+    // is empty, and this stream yields ZERO events — which is exactly what
+    // capo's manual smoke surfaced. This test fails fast if the regression
+    // ever returns: the stream must produce at least one non-empty Text
+    // event for a trivial "pong" prompt.
+    use motosan_ai::{ChatRequest, ClaudeCodeProvider, StreamEventType};
+    use tokio_stream::StreamExt;
+
+    let client = Client::builder()
+        .provider(Provider::ClaudeCode)
+        .claude_code(ClaudeCodeProvider::new().model("sonnet"))
+        .build()
+        .expect("build client");
+
+    let request = ChatRequest::builder()
+        .message(Message::user("Reply with only the word 'pong'."))
+        .build();
+
+    let mut stream = client
+        .stream_with(request)
+        .await
+        .expect("claude stream should succeed via Client dispatch");
+
+    let mut saw_non_empty_text = false;
+    while let Some(event) = stream.next().await {
+        if matches!(event.event_type, StreamEventType::Text) && !event.content.trim().is_empty() {
+            saw_non_empty_text = true;
+        }
+    }
+
+    assert!(
+        saw_non_empty_text,
+        "claude_code .stream() emitted no non-empty Text events — \
+         did `--verbose` get dropped from claude_code/mod.rs?"
+    );
+}
+
 #[cfg(feature = "codex-cli")]
 #[tokio::test]
 #[ignore] // Requires `codex` CLI installed + auth.

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.10.0 / Rust 0.14.2
+Multi-provider LLM SDK — Python 0.10.0 / Rust 0.14.3
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI
 
@@ -20,7 +20,7 @@ pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.14.2", features = ["anthropic"] }
+motosan-ai = { version = "0.14.3", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-motosan-ai = { version = "0.14.2", features = ["anthropic"] }
+motosan-ai = { version = "0.14.3", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```


### PR DESCRIPTION
## Summary

- **Fixes capo's M2 smoke regression**: `Provider::ClaudeCode` `.stream()` emitted zero events under modern `claude` ≥ 2.1.x, causing `--provider claude-code` to exit 0 with no text. Two compounding bugs identified and fixed:
  1. **Missing `--verbose`** in `claude_code/mod.rs:396` — modern `claude` requires it when combining `--print` with `--output-format=stream-json`, otherwise the CLI exits non-zero and emits zero NDJSON.
  2. **Stale NDJSON parser** in `claude_code/stream_json.rs` — only recognised the legacy `{"type":"text",...}` shape; modern `claude` emits text inside `{"type":"assistant","message":{"content":[{"type":"text",...}]}}` which was being dropped as `Other`.
- Bundled per `followups.md` sequencing: §4 docs (chat-vs-stream asymmetry on both CLI modules) + §5a (`#[allow(dead_code)]` on `Result.result` now has a real comment).
- Investigation notes at `docs/superpowers/notes/2026-05-16-cli-provider-smoke-debug.md`.

## Commits

- `0cadd98` docs: investigation notes
- `d96cfc8` fix: --verbose + parser + §4 docs + §5a + version bump 0.14.2 → 0.14.3

## Test plan

- [x] New live regression test `integration_client_dispatches_to_claude_code_stream` (gated `#[ignore]`) — verified passing against real `claude` binary
- [x] Three new unit tests for assistant-event parser shapes (single text, mixed thinking+text, tool-use-only)
- [x] All pre-existing parser unit tests still pass
- [x] `check-all` green
- [x] `./scripts/pre-push-gate.sh` — all 4 stages green, incl. 9 Anthropic live tests (~41s)
- [x] Verified codex side unaffected (acquitted via direct invocation in §2.1 investigation)

## Release readiness

After merge, tag `rust-v0.14.3` and push to trigger `publish-rust.yml` → crates.io. capo can then bump its `motosan-ai` dep and re-run the `--provider claude-code` smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)