### PR TITLE
fix(rust): Ollama HTTP auto-switches to /api/chat for tuning fields (v0.15.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.14.3 (crates.io) · Python v0.10.0 (PyPI)
+Rust v0.15.0 (crates.io) · Python v0.10.0 (PyPI)
 
 ## Where To Find Things
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.14.3 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.15.0 |
 | Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.9.3 |
 
 ## Install
@@ -34,7 +34,7 @@ response = await client.chat([Message.user("Hello")])
 ```toml
 # Rust (Cargo.toml)
 [dependencies]
-motosan-ai = { version = "0.14.3", features = ["anthropic"] }
+motosan-ai = { version = "0.15.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.10.0 · Rust 0.14.3
+- Python 0.10.0 · Rust 0.15.0
 - GitHub: https://github.com/motosan-dev/motosan-ai
 - PyPI: https://pypi.org/project/motosan-ai/
 - crates.io: https://crates.io/crates/motosan-ai
@@ -19,7 +19,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.14.3", features = ["anthropic"] }
+motosan-ai = { version = "0.15.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient):

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
+## [0.15.0] - 2026-05-17
+
+### Fixed
+- **Ollama HTTP path now honors `ollama_keep_alive` / `ollama_num_ctx` / `ollama_think`.** Previously these three `ClientBuilder` setters were wired only to the explicit native path (`ollama_native(true)`). HTTP-path callers (the default) silently dropped them, and even forwarding them to the OpenAI-compat `/v1/chat/completions` endpoint would have been theatrical — verified against [ollama/openai.go](https://github.com/ollama/ollama/blob/main/openai/openai.go), Ollama's OpenAI-compat handler's `ChatCompletionRequest` struct silently discards these fields server-side. Fix: `dispatch_chat` and `dispatch_stream` now auto-route to `OllamaProvider` (native `/api/chat`) whenever any of the three fields is set, regardless of the `ollama_native(true)` flag. Closes followups.md §3.
+- Clippy `needless_return` cleanup: removed `return ...;` statements in `client.rs` dispatch arms. The `never_read` warning on `ollama_*` fields was auto-cleared by the routing fix. Closes followups.md §5b + §5c.
+
+### Changed (BREAKING)
+- **`ClientBuilder::build()` now returns `Err(MotosanError::Config)` if `ollama_keep_alive` / `ollama_num_ctx` / `ollama_think` are set on a non-`Provider::Ollama` client.** Previously these were silently accepted then dropped. The error message names the misused field(s). Closes followups.md §3 option B. Likely zero affected callers in practice (the silent drop was undetected), but cataloged as breaking for semver discipline.
+- **Cargo feature `ollama_native` is now an alias for `ollama`.** Previously `ollama_native` added the `bytes` dep that the native `OllamaProvider` needs. To support the new auto-routing behavior, `ollama` now pulls `bytes` too; `ollama_native` is retained as a feature name for backwards compatibility but is a no-op. Existing `Cargo.toml` files with `features = ["ollama_native"]` continue to compile unchanged. Existing `features = ["ollama"]` callers will get a small dep tree increase (`bytes` ~80 KB plus its transitive closure) even when they don't trigger the native path. No workaround if you want `ollama` without `bytes` — accept and document.
+- **`ClientBuilder::ollama_native(true)` is no longer the only way to reach the native `/api/chat` endpoint.** Setting any of the three tuning fields now also routes there. The flag remains a valid escape hatch for callers who want native dispatch without setting any tuning fields.
+- **Image-capability loss when auto-routed.** `Provider::Ollama` callers who simultaneously set any of the three tuning fields AND send image content will now get a wrapped `MotosanError::UnsupportedFeature` from `validate_request`. The OpenAI-compatible path declares `with_image()` capability; `OllamaProvider` is text-only. Affected callers should either drop the tuning field (and lose the field's effect) or drop the image input (and use a different model). The error message explains the trade-off; see also the setter docs on `ollama_think` / `ollama_keep_alive` / `ollama_num_ctx`.
+
+### Notes
+- Setter doc-comments on `ollama_think` / `ollama_keep_alive` / `ollama_num_ctx` / `ollama_native` updated to describe the auto-switch behavior and the build-time guard.
+- mockito integration tests in `tests/ollama_http_autoswitch.rs` lock in the routing behavior end-to-end for both branches (with-fields → `/api/chat`, without-fields → `/v1/chat/completions`).
+
 ## [0.14.3] - 2026-05-17
 
 ### Fixed

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -27,14 +27,19 @@ openai = [
   "dep:tokio",
 ]
 minimax = ["anthropic"]
-ollama = ["openai"]
-ollama_native = [
-  "ollama",
+ollama = [
+  "openai",
   "dep:reqwest",
   "dep:tokio",
   "dep:tokio-stream",
   "dep:bytes",
 ]
+# Retained as an alias for backwards compatibility. The `ollama_native(true)`
+# runtime flag still controls explicit routing — see ClientBuilder::ollama_native.
+# As of 0.15.0 the OllamaProvider (/api/chat) is also auto-selected whenever
+# ollama_think / ollama_keep_alive / ollama_num_ctx is set, regardless of this
+# feature, because Ollama's OpenAI-compat endpoint silently drops those fields.
+ollama_native = ["ollama"]
 claude-code = ["dep:tokio", "dep:tokio-stream", "dep:async-stream"]
 codex-cli = ["dep:tokio", "dep:tokio-stream", "dep:async-stream"]
 gemini-cli = ["dep:tokio", "dep:tokio-stream", "dep:async-stream"]

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.14.3"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -317,7 +317,7 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
 ```toml
-motosan-ai = { version = "0.14.3", features = ["claude-code"] }
+motosan-ai = { version = "0.15.0", features = ["claude-code"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -426,7 +426,7 @@ Notes:
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
 ```toml
-motosan-ai = { version = "0.14.3", features = ["codex-cli"] }
+motosan-ai = { version = "0.15.0", features = ["codex-cli"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -489,7 +489,7 @@ Notes:
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
 ```toml
-motosan-ai = { version = "0.14.3", features = ["gemini-cli"] }
+motosan-ai = { version = "0.15.0", features = ["gemini-cli"] }
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -223,7 +223,7 @@ impl Client {
                 }
             }
             Provider::Ollama => {
-                #[cfg(feature = "ollama_native")]
+                #[cfg(feature = "ollama")]
                 {
                     if self.ollama_native {
                         use crate::providers::ProviderImpl;
@@ -378,7 +378,7 @@ impl Client {
                 }
             }
             Provider::Ollama => {
-                #[cfg(feature = "ollama_native")]
+                #[cfg(feature = "ollama")]
                 {
                     if self.ollama_native {
                         use crate::providers::ProviderImpl;
@@ -568,7 +568,7 @@ impl Client {
             .with_retry_policy(self.retry_policy.clone())
     }
 
-    #[cfg(feature = "ollama_native")]
+    #[cfg(feature = "ollama")]
     fn build_ollama_native_provider(&self) -> crate::providers::ollama::OllamaProvider {
         let model = self
             .model

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -906,6 +906,29 @@ impl ClientBuilder {
             None => String::new(),
         };
 
+        // Guard: ollama_* setters only make sense when the selected
+        // provider routes through Ollama (either path — OpenAI-compat or
+        // auto-switched native). Catching this at build time prevents the
+        // silent no-op that motivated the 0.15.0 fix.
+        if !matches!(provider, crate::providers::Provider::Ollama) {
+            let mut misused: Vec<&str> = Vec::new();
+            if self.ollama_keep_alive.is_some() {
+                misused.push("ollama_keep_alive");
+            }
+            if self.ollama_num_ctx.is_some() {
+                misused.push("ollama_num_ctx");
+            }
+            if self.ollama_think.is_some() {
+                misused.push("ollama_think");
+            }
+            if !misused.is_empty() {
+                return Err(MotosanError::Config(format!(
+                    "{} can only be used with Provider::Ollama",
+                    misused.join(", ")
+                )));
+            }
+        }
+
         Ok(Client {
             provider,
             api_key,

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -186,12 +186,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_anthropic_provider();
                     p.validate_request(&request)?;
-                    return p.chat(request).await;
+                    p.chat(request).await
                 }
                 #[cfg(not(feature = "anthropic"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("anthropic"));
+                    Err(Self::feature_not_enabled("anthropic"))
                 }
             }
             Provider::OpenAI => {
@@ -200,12 +200,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_openai_provider();
                     p.validate_request(&request)?;
-                    return p.chat(request).await;
+                    p.chat(request).await
                 }
                 #[cfg(not(feature = "openai"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("openai"));
+                    Err(Self::feature_not_enabled("openai"))
                 }
             }
             Provider::Minimax => {
@@ -214,12 +214,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_minimax_provider();
                     p.validate_request(&request)?;
-                    return p.chat(request).await;
+                    p.chat(request).await
                 }
                 #[cfg(not(feature = "minimax"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("minimax"));
+                    Err(Self::feature_not_enabled("minimax"))
                 }
             }
             Provider::Ollama => {
@@ -275,12 +275,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_claude_code_provider();
                     p.validate_request(&request)?;
-                    return p.chat(request).await;
+                    p.chat(request).await
                 }
                 #[cfg(not(feature = "claude-code"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("claude-code"));
+                    Err(Self::feature_not_enabled("claude-code"))
                 }
             }
             Provider::CodexCli => {
@@ -289,12 +289,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_codex_cli_provider();
                     p.validate_request(&request)?;
-                    return p.chat(request).await;
+                    p.chat(request).await
                 }
                 #[cfg(not(feature = "codex-cli"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("codex-cli"));
+                    Err(Self::feature_not_enabled("codex-cli"))
                 }
             }
             Provider::GeminiCli => {
@@ -303,12 +303,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_gemini_cli_provider();
                     p.validate_request(&request)?;
-                    return p.chat(request).await;
+                    p.chat(request).await
                 }
                 #[cfg(not(feature = "gemini-cli"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("gemini-cli"));
+                    Err(Self::feature_not_enabled("gemini-cli"))
                 }
             }
             Provider::Gemini => {
@@ -317,12 +317,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_gemini_provider();
                     p.validate_request(&request)?;
-                    return p.chat(request).await;
+                    p.chat(request).await
                 }
                 #[cfg(not(feature = "gemini"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("gemini"));
+                    Err(Self::feature_not_enabled("gemini"))
                 }
             }
             Provider::GeminiCodeAssist => {
@@ -331,12 +331,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_gemini_code_assist_provider();
                     p.validate_request(&request)?;
-                    return p.chat(request).await;
+                    p.chat(request).await
                 }
                 #[cfg(not(feature = "gemini-code-assist"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("gemini-code-assist"));
+                    Err(Self::feature_not_enabled("gemini-code-assist"))
                 }
             }
         }
@@ -365,12 +365,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_anthropic_provider();
                     p.validate_request(&request)?;
-                    return p.stream(request).await;
+                    p.stream(request).await
                 }
                 #[cfg(not(feature = "anthropic"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("anthropic"));
+                    Err(Self::feature_not_enabled("anthropic"))
                 }
             }
             Provider::OpenAI => {
@@ -379,12 +379,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_openai_provider();
                     p.validate_request(&request)?;
-                    return p.stream(request).await;
+                    p.stream(request).await
                 }
                 #[cfg(not(feature = "openai"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("openai"));
+                    Err(Self::feature_not_enabled("openai"))
                 }
             }
             Provider::Minimax => {
@@ -393,12 +393,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_minimax_provider();
                     p.validate_request(&request)?;
-                    return p.stream(request).await;
+                    p.stream(request).await
                 }
                 #[cfg(not(feature = "minimax"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("minimax"));
+                    Err(Self::feature_not_enabled("minimax"))
                 }
             }
             Provider::Ollama => {
@@ -443,12 +443,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_claude_code_provider();
                     p.validate_request(&request)?;
-                    return p.stream(request).await;
+                    p.stream(request).await
                 }
                 #[cfg(not(feature = "claude-code"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("claude-code"));
+                    Err(Self::feature_not_enabled("claude-code"))
                 }
             }
             Provider::CodexCli => {
@@ -457,12 +457,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_codex_cli_provider();
                     p.validate_request(&request)?;
-                    return p.stream(request).await;
+                    p.stream(request).await
                 }
                 #[cfg(not(feature = "codex-cli"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("codex-cli"));
+                    Err(Self::feature_not_enabled("codex-cli"))
                 }
             }
             Provider::GeminiCli => {
@@ -471,12 +471,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_gemini_cli_provider();
                     p.validate_request(&request)?;
-                    return p.stream(request).await;
+                    p.stream(request).await
                 }
                 #[cfg(not(feature = "gemini-cli"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("gemini-cli"));
+                    Err(Self::feature_not_enabled("gemini-cli"))
                 }
             }
             Provider::Gemini => {
@@ -485,12 +485,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_gemini_provider();
                     p.validate_request(&request)?;
-                    return p.stream(request).await;
+                    p.stream(request).await
                 }
                 #[cfg(not(feature = "gemini"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("gemini"));
+                    Err(Self::feature_not_enabled("gemini"))
                 }
             }
             Provider::GeminiCodeAssist => {
@@ -499,12 +499,12 @@ impl Client {
                     use crate::providers::ProviderImpl;
                     let p = self.build_gemini_code_assist_provider();
                     p.validate_request(&request)?;
-                    return p.stream(request).await;
+                    p.stream(request).await
                 }
                 #[cfg(not(feature = "gemini-code-assist"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("gemini-code-assist"));
+                    Err(Self::feature_not_enabled("gemini-code-assist"))
                 }
             }
         }

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -404,24 +404,37 @@ impl Client {
             Provider::Ollama => {
                 #[cfg(feature = "ollama")]
                 {
-                    if self.ollama_native {
-                        use crate::providers::ProviderImpl;
-                        let p = self.build_ollama_native_provider();
-                        p.validate_request(&request)?;
-                        return p.stream(request).await;
-                    }
-                }
-                #[cfg(feature = "ollama")]
-                {
                     use crate::providers::ProviderImpl;
-                    let p = self.build_ollama_provider();
-                    p.validate_request(&request)?;
-                    return p.stream(request).await;
+                    // Same auto-switch + capability trade-off as
+                    // dispatch_chat — keep the routing condition
+                    // identical so chat and stream are never split.
+                    let needs_native = self.ollama_native
+                        || self.ollama_keep_alive.is_some()
+                        || self.ollama_num_ctx.is_some()
+                        || self.ollama_think.is_some();
+                    if needs_native {
+                        let p = self.build_ollama_native_provider();
+                        p.validate_request(&request).map_err(|e| match e {
+                            MotosanError::UnsupportedFeature(msg) => MotosanError::UnsupportedFeature(format!(
+                                "{msg} — Provider::Ollama was auto-routed to the native /api/chat endpoint \
+                                 because one of ollama_keep_alive / ollama_num_ctx / ollama_think is set, \
+                                 and the native endpoint is text-only. Either remove the tuning field(s) to \
+                                 stay on the OpenAI-compat path (which supports images), or remove the image \
+                                 input."
+                            )),
+                            other => other,
+                        })?;
+                        p.stream(request).await
+                    } else {
+                        let p = self.build_ollama_provider();
+                        p.validate_request(&request)?;
+                        p.stream(request).await
+                    }
                 }
                 #[cfg(not(feature = "ollama"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("ollama"));
+                    Err(Self::feature_not_enabled("ollama"))
                 }
             }
             Provider::ClaudeCode => {

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -225,24 +225,48 @@ impl Client {
             Provider::Ollama => {
                 #[cfg(feature = "ollama")]
                 {
-                    if self.ollama_native {
-                        use crate::providers::ProviderImpl;
-                        let p = self.build_ollama_native_provider();
-                        p.validate_request(&request)?;
-                        return p.chat(request).await;
-                    }
-                }
-                #[cfg(feature = "ollama")]
-                {
                     use crate::providers::ProviderImpl;
-                    let p = self.build_ollama_provider();
-                    p.validate_request(&request)?;
-                    return p.chat(request).await;
+                    // Auto-route to OllamaProvider (native /api/chat) when
+                    // ollama_native is explicitly enabled OR any of the
+                    // Ollama-specific tuning fields is set, since the
+                    // OpenAI-compat /v1/chat/completions endpoint silently
+                    // drops keep_alive / options.num_ctx / think
+                    // server-side. Otherwise stay on the OpenAI-compat
+                    // path for backwards compatibility.
+                    //
+                    // Capability trade-off: OllamaProvider is text-only
+                    // (no image capability) while the OpenAI-compat path
+                    // declares with_image(). Auto-switching strips image
+                    // capability — the wrapped validate_request error
+                    // below tells the caller WHY their image input
+                    // stopped working.
+                    let needs_native = self.ollama_native
+                        || self.ollama_keep_alive.is_some()
+                        || self.ollama_num_ctx.is_some()
+                        || self.ollama_think.is_some();
+                    if needs_native {
+                        let p = self.build_ollama_native_provider();
+                        p.validate_request(&request).map_err(|e| match e {
+                            MotosanError::UnsupportedFeature(msg) => MotosanError::UnsupportedFeature(format!(
+                                "{msg} — Provider::Ollama was auto-routed to the native /api/chat endpoint \
+                                 because one of ollama_keep_alive / ollama_num_ctx / ollama_think is set, \
+                                 and the native endpoint is text-only. Either remove the tuning field(s) to \
+                                 stay on the OpenAI-compat path (which supports images), or remove the image \
+                                 input."
+                            )),
+                            other => other,
+                        })?;
+                        p.chat(request).await
+                    } else {
+                        let p = self.build_ollama_provider();
+                        p.validate_request(&request)?;
+                        p.chat(request).await
+                    }
                 }
                 #[cfg(not(feature = "ollama"))]
                 {
                     let _ = request;
-                    return Err(Self::feature_not_enabled("ollama"));
+                    Err(Self::feature_not_enabled("ollama"))
                 }
             }
             Provider::ClaudeCode => {

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -797,21 +797,86 @@ impl ClientBuilder {
         self
     }
 
+    /// Force the Ollama provider to use the native `/api/chat` endpoint
+    /// instead of the OpenAI-compatible `/v1/chat/completions` path.
+    ///
+    /// As of 0.15.0, setting this explicitly is **only required** when you
+    /// want the native endpoint without setting any tuning fields. Setting
+    /// `ollama_think` / `ollama_keep_alive` / `ollama_num_ctx` auto-selects
+    /// the native endpoint regardless of this flag, since the OpenAI-compat
+    /// endpoint silently drops those fields.
+    ///
+    /// **Capability trade-off:** the native endpoint is text-only — image
+    /// inputs will be rejected. The OpenAI-compatible default supports
+    /// images.
     pub fn ollama_native(mut self, native: bool) -> Self {
         self.ollama_native = Some(native);
         self
     }
 
+    /// Set Ollama's `think` parameter controlling whether the model emits
+    /// a thinking block. Forwarded only via the native `/api/chat`
+    /// endpoint — Ollama's OpenAI-compatible `/v1/chat/completions`
+    /// endpoint silently drops this field (verified against
+    /// [ollama/openai.go](https://github.com/ollama/ollama/blob/main/openai/openai.go)).
+    ///
+    /// **Side effect (since 0.15.0):** setting this auto-routes the client
+    /// to OllamaProvider (native `/api/chat`) regardless of whether
+    /// `ollama_native(true)` was called.
+    ///
+    /// **Capability trade-off:** OllamaProvider is text-only. If you set
+    /// this AND send image content in the request, `validate_request`
+    /// will reject the request with a wrapped error explaining the
+    /// auto-switch context.
+    ///
+    /// `ClientBuilder::build()` will return `Err(MotosanError::Config)` if you
+    /// set this on a non-`Provider::Ollama` client.
+    ///
+    /// **Known limitation:** OllamaProvider currently emits this as a
+    /// boolean `think: true` regardless of the input string value (see
+    /// `providers/ollama.rs:138-140`). The string is accepted for forward
+    /// compatibility but not differentiated server-side.
     pub fn ollama_think(mut self, think: impl Into<String>) -> Self {
         self.ollama_think = Some(think.into());
         self
     }
 
+    /// Set Ollama's `keep_alive` duration (e.g. `"5m"`, `"-1"` for forever).
+    /// Controls how long Ollama keeps the model loaded after a request.
+    /// Forwarded only via the native `/api/chat` endpoint — the
+    /// OpenAI-compatible endpoint silently drops this field (verified
+    /// against ollama/openai.go).
+    ///
+    /// **Side effect (since 0.15.0):** setting this auto-routes the client
+    /// to OllamaProvider regardless of `ollama_native(true)`.
+    ///
+    /// **Capability trade-off:** OllamaProvider is text-only. If you set
+    /// this AND send image content in the request, `validate_request`
+    /// will reject the request with a wrapped error explaining the
+    /// auto-switch context.
+    ///
+    /// `ClientBuilder::build()` will return `Err(MotosanError::Config)` if you
+    /// set this on a non-`Provider::Ollama` client.
     pub fn ollama_keep_alive(mut self, duration: impl Into<String>) -> Self {
         self.ollama_keep_alive = Some(duration.into());
         self
     }
 
+    /// Set Ollama's `options.num_ctx` (context window size in tokens).
+    /// Forwarded only via the native `/api/chat` endpoint — the
+    /// OpenAI-compatible endpoint silently drops nested `options` fields
+    /// (verified against ollama/openai.go).
+    ///
+    /// **Side effect (since 0.15.0):** setting this auto-routes the client
+    /// to OllamaProvider regardless of `ollama_native(true)`.
+    ///
+    /// **Capability trade-off:** OllamaProvider is text-only. If you set
+    /// this AND send image content in the request, `validate_request`
+    /// will reject the request with a wrapped error explaining the
+    /// auto-switch context.
+    ///
+    /// `ClientBuilder::build()` will return `Err(MotosanError::Config)` if you
+    /// set this on a non-`Provider::Ollama` client.
     pub fn ollama_num_ctx(mut self, tokens: u32) -> Self {
         self.ollama_num_ctx = Some(tokens);
         self

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -298,7 +298,7 @@ pub mod anthropic;
 #[cfg(feature = "openai")]
 pub mod openai;
 
-#[cfg(feature = "ollama_native")]
+#[cfg(feature = "ollama")]
 pub mod ollama;
 
 #[cfg(feature = "claude-code")]

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -174,6 +174,36 @@ fn builder_defaults_openai_options_and_allows_override() {
     assert_eq!(reset_to_bearer_client.openai_auth_header(), None);
 }
 
+#[test]
+fn build_rejects_ollama_fields_with_non_ollama_provider() {
+    // ollama_keep_alive set but provider is OpenAI — should error at build()
+    // rather than silently dropping the value at runtime.
+    let result = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .ollama_keep_alive("10m")
+        .build();
+    let err = result.expect_err("should reject ollama_* on non-Ollama provider");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("ollama_keep_alive") && msg.contains("Provider::Ollama"),
+        "error message should name the field + correct provider, got: {msg}"
+    );
+}
+
+#[test]
+fn build_accepts_ollama_fields_with_ollama_provider() {
+    // Sanity guard: the validation should NOT fire for the correct provider.
+    let result = Client::builder()
+        .provider(Provider::Ollama)
+        .api_key("ollama")
+        .ollama_keep_alive("10m")
+        .ollama_num_ctx(8192)
+        .ollama_think("yes")
+        .build();
+    assert!(result.is_ok(), "valid combo should build");
+}
+
 #[tokio::test]
 async fn chat_and_stream_exist_and_dispatch() {
     let client = Client::builder()

--- a/sdks/rust/tests/ollama_http_autoswitch.rs
+++ b/sdks/rust/tests/ollama_http_autoswitch.rs
@@ -1,0 +1,43 @@
+#![cfg(feature = "ollama")]
+
+use mockito::Matcher;
+use motosan_ai::{Client, Message, Provider};
+
+#[tokio::test]
+async fn ollama_with_keep_alive_routes_to_api_chat_endpoint() {
+    // With ollama_keep_alive set, the client must POST to /api/chat
+    // (native) rather than /v1/chat/completions (OpenAI-compat), because
+    // the OpenAI-compat endpoint silently drops keep_alive server-side.
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/api/chat")
+        .match_body(Matcher::Regex(r#"\"keep_alive\"\s*:\s*\"10m\""#.to_string()))
+        .with_status(200)
+        .with_body(
+            serde_json::json!({
+                "model": "llama3",
+                "message": {"role": "assistant", "content": "ok"},
+                "done": true,
+                "done_reason": "stop",
+                "prompt_eval_count": 1,
+                "eval_count": 1
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .provider(Provider::Ollama)
+        .api_key("ollama")
+        .ollama_base_url(server.url())
+        .ollama_keep_alive("10m")
+        .build()
+        .expect("build client");
+
+    let _ = client
+        .chat(vec![Message::user("hi")])
+        .await
+        .expect("chat against mock should succeed");
+    mock.assert_async().await;
+}

--- a/sdks/rust/tests/ollama_http_autoswitch.rs
+++ b/sdks/rust/tests/ollama_http_autoswitch.rs
@@ -41,3 +41,45 @@ async fn ollama_with_keep_alive_routes_to_api_chat_endpoint() {
         .expect("chat against mock should succeed");
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn ollama_with_num_ctx_streams_from_api_chat_endpoint() {
+    use tokio_stream::StreamExt;
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/api/chat")
+        .match_body(Matcher::Regex(
+            r#"\"options\"\s*:\s*\{[^}]*\"num_ctx\"\s*:\s*4096"#.to_string(),
+        ))
+        .match_body(Matcher::Regex(r#"\"stream\"\s*:\s*true"#.to_string()))
+        .with_status(200)
+        // Minimal NDJSON: one chunk + a done marker.
+        .with_body(
+            "{\"model\":\"llama3\",\"message\":{\"role\":\"assistant\",\"content\":\"hi\"},\"done\":false}\n\
+             {\"model\":\"llama3\",\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,\"done_reason\":\"stop\",\"prompt_eval_count\":1,\"eval_count\":1}\n",
+        )
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .provider(Provider::Ollama)
+        .api_key("ollama")
+        .ollama_base_url(server.url())
+        .ollama_num_ctx(4096)
+        .build()
+        .expect("build client");
+
+    let mut stream = client
+        .stream(vec![Message::user("hi")])
+        .await
+        .expect("stream against mock should open");
+    let mut seen_text = false;
+    while let Some(event) = stream.next().await {
+        if !event.content.is_empty() {
+            seen_text = true;
+        }
+    }
+    assert!(seen_text, "stream should yield at least one text chunk");
+    mock.assert_async().await;
+}

--- a/sdks/rust/tests/ollama_http_autoswitch.rs
+++ b/sdks/rust/tests/ollama_http_autoswitch.rs
@@ -83,3 +83,83 @@ async fn ollama_with_num_ctx_streams_from_api_chat_endpoint() {
     assert!(seen_text, "stream should yield at least one text chunk");
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn ollama_without_tuning_fields_stays_on_openai_compat_endpoint() {
+    // Regression guard: callers who don't set any of the 3 tuning fields
+    // and don't enable ollama_native(true) should continue to hit the
+    // OpenAI-compat /v1/chat/completions endpoint as in 0.14.x. This
+    // preserves backwards compatibility for the common case.
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(
+            serde_json::json!({
+                "model": "llama3",
+                "choices": [{
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .provider(Provider::Ollama)
+        .api_key("ollama")
+        .ollama_base_url(server.url())
+        .build()
+        .expect("build client");
+
+    let _ = client
+        .chat(vec![Message::user("hi")])
+        .await
+        .expect("chat should succeed on the openai-compat fallback");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn ollama_with_tuning_field_plus_image_returns_wrapped_error() {
+    // When the auto-switch fires AND the request has image content, the
+    // text-only OllamaProvider's validate_request rejects it. The
+    // dispatch arm wraps that rejection with the auto-switch context so
+    // the caller knows WHY images stopped working.
+    use motosan_ai::MotosanError;
+
+    // No mockito server needed — validate_request fires before any HTTP
+    // call, so the request never leaves the client.
+    let client = Client::builder()
+        .provider(Provider::Ollama)
+        .api_key("ollama")
+        .ollama_base_url("http://example.invalid")
+        .ollama_keep_alive("5m") // triggers auto-switch
+        .build()
+        .expect("build client");
+
+    let request = motosan_ai::ChatRequest::builder()
+        .message(Message::user_with_image("describe this", "abc123", "image/png"))
+        .build();
+
+    let err = client
+        .chat_with(request)
+        .await
+        .expect_err("validate_request should reject image on text-only OllamaProvider");
+
+    match err {
+        MotosanError::UnsupportedFeature(msg) => {
+            assert!(
+                msg.contains("auto-routed") && msg.contains("text-only"),
+                "wrapped error should explain the auto-switch context, got: {msg}"
+            );
+            assert!(
+                msg.contains("ollama_keep_alive") || msg.contains("ollama_num_ctx") || msg.contains("ollama_think"),
+                "wrapped error should mention the field that triggered the switch, got: {msg}"
+            );
+        }
+        other => panic!("expected UnsupportedFeature, got: {other:?}"),
+    }
+}

--- a/sdks/rust/tests/ollama_http_autoswitch.rs
+++ b/sdks/rust/tests/ollama_http_autoswitch.rs
@@ -11,7 +11,9 @@ async fn ollama_with_keep_alive_routes_to_api_chat_endpoint() {
     let mut server = mockito::Server::new_async().await;
     let mock = server
         .mock("POST", "/api/chat")
-        .match_body(Matcher::Regex(r#"\"keep_alive\"\s*:\s*\"10m\""#.to_string()))
+        .match_body(Matcher::Regex(
+            r#"\"keep_alive\"\s*:\s*\"10m\""#.to_string(),
+        ))
         .with_status(200)
         .with_body(
             serde_json::json!({
@@ -141,7 +143,11 @@ async fn ollama_with_tuning_field_plus_image_returns_wrapped_error() {
         .expect("build client");
 
     let request = motosan_ai::ChatRequest::builder()
-        .message(Message::user_with_image("describe this", "abc123", "image/png"))
+        .message(Message::user_with_image(
+            "describe this",
+            "abc123",
+            "image/png",
+        ))
         .build();
 
     let err = client
@@ -156,7 +162,9 @@ async fn ollama_with_tuning_field_plus_image_returns_wrapped_error() {
                 "wrapped error should explain the auto-switch context, got: {msg}"
             );
             assert!(
-                msg.contains("ollama_keep_alive") || msg.contains("ollama_num_ctx") || msg.contains("ollama_think"),
+                msg.contains("ollama_keep_alive")
+                    || msg.contains("ollama_num_ctx")
+                    || msg.contains("ollama_think"),
                 "wrapped error should mention the field that triggered the switch, got: {msg}"
             );
         }

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.10.0 / Rust 0.14.3
+Multi-provider LLM SDK — Python 0.10.0 / Rust 0.15.0
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI
 
@@ -20,7 +20,7 @@ pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.14.3", features = ["anthropic"] }
+motosan-ai = { version = "0.15.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-motosan-ai = { version = "0.14.3", features = ["anthropic"] }
+motosan-ai = { version = "0.15.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```


### PR DESCRIPTION
## Summary

Closes followups.md §3 + §5b + §5c. Ships as 0.15.0 minor bump because of three breaking surfaces.

- **§3 fix**: `Provider::Ollama` dispatch now auto-routes to `OllamaProvider` (native `/api/chat`) whenever any of `ollama_keep_alive` / `ollama_num_ctx` / `ollama_think` is set. The original spec recommended forwarding fields through the OpenAI-compat path; reading [ollama/openai.go](https://github.com/ollama/ollama/blob/main/openai/openai.go) confirmed Ollama silently drops those fields server-side (Go's `encoding/json` discards them because `ChatCompletionRequest` doesn't declare them), so a transport switch is the only honest fix.
- **§3 option B**: `ClientBuilder::build()` now returns `Err(MotosanError::Config)` listing the misused field names when `ollama_*` setters are used with a non-Ollama provider.
- **§3 option C**: Setter doc-comments updated to describe the auto-switch and reference ollama/openai.go. Image-capability trade-off (OllamaProvider is text-only) documented loudly.
- **Cargo feature change**: `ollama_native` collapses into `ollama` (alias for backwards compat). The `bytes` dep moves up; `ollama` callers see a small dep tree increase.
- **§5b**: 10 `needless_return` clippy warnings in `client.rs` removed.
- **§5c**: `never_read` warning on `ollama_*` fields auto-cleared by the routing fix.

## Commits

- `51c78e5` refactor: make OllamaProvider available under the 'ollama' Cargo feature
- `2053365` fix: chat() auto-routes Ollama to native /api/chat when tuning fields set
- `8c1bac1` fix: stream() auto-routes Ollama to native /api/chat when tuning fields set
- `59c8a89` test: backwards-compat + wrapped-error tests for Ollama auto-switch
- `cccfd48` feat!: ClientBuilder::build() rejects ollama_* on non-Ollama provider
- `c2e6f66` docs: document the 0.15.0 Ollama auto-switch behavior on all 4 setters
- `ccc7e83` style: drop remaining unneeded return statements in client.rs dispatch
- `ce1c427` chore: bump 0.14.3 -> 0.15.0 + CHANGELOG + release-checklist docs
- `aab3b84` style: apply rustfmt to ollama_http_autoswitch.rs

## Test plan

- [x] mockito test: Ollama + ollama_keep_alive → POSTs to /api/chat with keep_alive in body
- [x] mockito test: Ollama + ollama_num_ctx (stream) → POSTs to /api/chat with options.num_ctx and stream:true
- [x] mockito test (backwards-compat): Ollama with NO tuning fields → still POSTs to /v1/chat/completions
- [x] mockito test (image capability): Ollama + tuning field + image → wrapped UnsupportedFeature error explaining the auto-switch
- [x] Unit tests: ClientBuilder::build() rejects ollama_* on non-Ollama provider (positive + negative)
- [x] cargo build clean under --features ollama, --features ollama_native, --all-features
- [x] Existing tests/ollama_native_provider.rs still passes
- [x] check-all green
- [x] ./scripts/pre-push-gate.sh green (incl. 9 live Anthropic tests, ~47s)
- [x] cargo clippy --features anthropic,minimax,ollama,openai --all-targets -- -D warnings clean

## Release readiness

After merge, tag rust-v0.15.0 and push to trigger publish-rust.yml → crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)