### PR TITLE
test(rust): live Ollama auto-switch test (gated #[ignore])

### DIFF
--- a/sdks/rust/tests/ollama_http_autoswitch.rs
+++ b/sdks/rust/tests/ollama_http_autoswitch.rs
@@ -192,14 +192,26 @@ async fn live_ollama_auto_switch_against_real_server() {
     //   cargo test --features ollama --test ollama_http_autoswitch \
     //     live_ollama_auto_switch_against_real_server -- --ignored --nocapture
     //
-    // Configuration (env vars, all optional):
-    //   OLLAMA_BASE_URL — defaults to http://localhost:11434
-    //   OLLAMA_MODEL    — defaults to llama3.2 (must be pulled via
-    //                     `ollama pull <model>` first)
+    // Configuration:
+    //   OLLAMA_MODEL    — REQUIRED. Name of any chat model you have
+    //                     pulled (`ollama list` to check, `ollama pull
+    //                     <model>` to add). No default because pulled
+    //                     models vary by machine — defaulting to a
+    //                     specific tag would silently fail for most
+    //                     readers.
+    //   OLLAMA_BASE_URL — optional, defaults to http://localhost:11434
+    //
+    // Forensic note: manual run on 2026-05-17 against `llama3.1:8b`
+    // confirmed `num_ctx=512` was actually honored by the server (log
+    // line: `llama_context: n_ctx_seq (512) < n_ctx_train (131072)`).
+    // Re-verify the same way if the routing logic changes.
 
+    let model = std::env::var("OLLAMA_MODEL").expect(
+        "set OLLAMA_MODEL to any chat model you have pulled — \
+         run `ollama list` to see what's available",
+    );
     let base_url =
         std::env::var("OLLAMA_BASE_URL").unwrap_or_else(|_| "http://localhost:11434".to_string());
-    let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "llama3.2".to_string());
 
     let client = Client::builder()
         .provider(Provider::Ollama)
@@ -215,10 +227,7 @@ async fn live_ollama_auto_switch_against_real_server() {
         .chat(vec![Message::user("Reply with exactly the word: pong")])
         .await
         .unwrap_or_else(|e| {
-            panic!(
-                "Ollama chat failed against {base_url} with model {model}: {e}.\n\
-                 Is `ollama serve` running and `ollama pull {model}` done?"
-            )
+            panic!("Ollama chat failed against {base_url} with model {model}: {e}.\nIs `ollama serve` running?")
         });
 
     assert!(

--- a/sdks/rust/tests/ollama_http_autoswitch.rs
+++ b/sdks/rust/tests/ollama_http_autoswitch.rs
@@ -171,3 +171,60 @@ async fn ollama_with_tuning_field_plus_image_returns_wrapped_error() {
         other => panic!("expected UnsupportedFeature, got: {other:?}"),
     }
 }
+
+#[tokio::test]
+#[ignore] // Requires `ollama serve` running on localhost:11434 with at least one model pulled.
+async fn live_ollama_auto_switch_against_real_server() {
+    // Real end-to-end verification of the §3 fix. The mockito tests above
+    // only prove motosan-ai's request shape is correct; this one proves
+    // a real Ollama server actually accepts the request and returns text
+    // — i.e. the auto-switched /api/chat path works against the live
+    // binary, not just our mocks.
+    //
+    // Scope honesty: this test proves "Ollama accepts the request and
+    // responds non-empty" — it does NOT prove Ollama HONORS keep_alive
+    // and num_ctx in observable ways (verifying those would need server
+    // logs / process inspection). For that level of verification, run
+    // this with `OLLAMA_VERBOSE_LOGS=1 ollama serve` in another terminal
+    // and watch the server log lines for the request body.
+    //
+    // To run:
+    //   cargo test --features ollama --test ollama_http_autoswitch \
+    //     live_ollama_auto_switch_against_real_server -- --ignored --nocapture
+    //
+    // Configuration (env vars, all optional):
+    //   OLLAMA_BASE_URL — defaults to http://localhost:11434
+    //   OLLAMA_MODEL    — defaults to llama3.2 (must be pulled via
+    //                     `ollama pull <model>` first)
+
+    let base_url =
+        std::env::var("OLLAMA_BASE_URL").unwrap_or_else(|_| "http://localhost:11434".to_string());
+    let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "llama3.2".to_string());
+
+    let client = Client::builder()
+        .provider(Provider::Ollama)
+        .api_key("ollama") // ignored by Ollama but required by ClientBuilder
+        .ollama_base_url(&base_url)
+        .model(&model)
+        .ollama_keep_alive("30s") // short pin so the test doesn't tie up the GPU
+        .ollama_num_ctx(512)
+        .build()
+        .expect("build client");
+
+    let response = client
+        .chat(vec![Message::user("Reply with exactly the word: pong")])
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "Ollama chat failed against {base_url} with model {model}: {e}.\n\
+                 Is `ollama serve` running and `ollama pull {model}` done?"
+            )
+        });
+
+    assert!(
+        !response.content.trim().is_empty(),
+        "Ollama auto-switched /api/chat returned empty content; \
+         expected a non-empty reply. Got: {:?}",
+        response.content
+    );
+}


### PR DESCRIPTION
## Summary

Adds a live integration test for the v0.15.0 Ollama auto-switch fix (closing the verification gap I flagged after release — mockito tests only prove motosan-ai's request shape; nothing automated proved a real Ollama server actually accepts the auto-switched request).

**Manually verified on 2026-05-17** against \`ollama serve\` running \`llama3.1:8b\`: 22.87s pass, and server log line \`llama_context: n_ctx_seq (512) < n_ctx_train (131072)\` confirms \`num_ctx\` is HONORED end-to-end (not just emitted).

## Process note (why this is a PR now)

These two commits (\`45bb3fc\` and \`48dcda9\`) were originally pushed direct to main, which broke the project's pattern of routing all \`.rs\` changes through PR + GitHub Actions CI (\`rust\` + \`rust-msrv-no-features\` checks). User correctly pointed out the precedent break — direct-to-main is only appropriate for docs-only spec/notes updates. Reverted on main in \`737b6e6\` + \`510e859\`, then cherry-picked back here as a proper PR. Going forward, every non-docs change goes through PR.

## Commits

- \`808e025\` test: live Ollama auto-switch test (gated #[ignore])
- \`79bda2e\` test: require OLLAMA_MODEL env var in live Ollama test (no default)

(Identical content to the original \`45bb3fc\` + \`48dcda9\` — cherry-picked with new SHAs because the revert intervened.)

## What the test does

- Builds a \`Client\` with \`Provider::Ollama\` + \`ollama_keep_alive("30s")\` + \`ollama_num_ctx(512)\` — both fields together trigger the auto-switch to \`/api/chat\`.
- Sends a 1-prompt chat, asserts non-empty response.
- Configurable via \`OLLAMA_BASE_URL\` (defaults to localhost) and \`OLLAMA_MODEL\` (required — pulled models vary by machine, defaulting to a specific tag silently failed for most readers).
- Gated \`#[ignore]\` so CI doesn't try to reach a non-existent Ollama server.

## Test plan

- [x] Build clean: \`cargo build --features ollama --tests\`
- [x] 4 existing mockito tests in this file still pass
- [x] Missing env var → fast panic in 0.00s with helpful message
- [x] Live run (manual): \`OLLAMA_MODEL=llama3.1:8b cargo test --features ollama --test ollama_http_autoswitch live_ollama_auto_switch_against_real_server -- --ignored --nocapture\` → PASS in 22.87s
- [x] Server log inspection confirmed \`n_ctx=512\` honored

## How to run

\`\`\`bash
ollama list                                    # confirm what's pulled
OLLAMA_MODEL=llama3.1:8b cargo test --features ollama --test ollama_http_autoswitch \\
    live_ollama_auto_switch_against_real_server -- --ignored --nocapture
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)