### PR TITLE
fix(rust): ollama_think serializes per input value (v0.15.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ sdks/typescript/node_modules/
 sdks/typescript/dist/
 .worktrees/
 .env
+
+# macOS
+.DS_Store
+**/.DS_Store
+
+# IDE caches (developer-local, don't need to be tracked)
+.idea/
+.vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.15.0 (crates.io) · Python v0.10.0 (PyPI)
+Rust v0.15.1 (crates.io) · Python v0.10.0 (PyPI)
 
 ## Where To Find Things
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.15.0 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.15.1 |
 | Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.9.3 |
 
 ## Install
@@ -34,7 +34,7 @@ response = await client.chat([Message.user("Hello")])
 ```toml
 # Rust (Cargo.toml)
 [dependencies]
-motosan-ai = { version = "0.15.0", features = ["anthropic"] }
+motosan-ai = { version = "0.15.1", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.10.0 · Rust 0.15.0
+- Python 0.10.0 · Rust 0.15.1
 - GitHub: https://github.com/motosan-dev/motosan-ai
 - PyPI: https://pypi.org/project/motosan-ai/
 - crates.io: https://crates.io/crates/motosan-ai
@@ -19,7 +19,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.15.0", features = ["anthropic"] }
+motosan-ai = { version = "0.15.1", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient):

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
+## [0.15.1] - 2026-05-17
+
+### Fixed
+- **`ollama_think` now serializes per input value** instead of hard-coding `body["think"] = true` for any non-None input. Pre-existing bug from before 0.15.0: `ClientBuilder::ollama_think` takes a string but `providers/ollama.rs:138-140` was flattening `ollama_think("no")` to bool `true`, silently inverting caller intent. Now:
+  - Truthy synonyms (`"true"` / `"yes"` / `"on"` / `"1"`, case-insensitive + trimmed) → JSON `true`
+  - Falsy synonyms (`"false"` / `"no"` / `"off"` / `"0"`, case-insensitive + trimmed) → JSON `false`
+  - Anything else (e.g. `"low"` / `"medium"` / `"high"`) → JSON string verbatim (so callers can opt into Ollama's newer string-valued reasoning levels)
+- Backward compatible: existing `ollama_think("yes")` / `ollama_think("on")` callers still see bool `true` on the wire.
+
+### Changed
+- `.gitignore`: added macOS `.DS_Store` patterns + `.idea` / `.vscode` IDE caches. Pure repo hygiene.
+
+### Notes
+- Four unit tests in `providers::ollama::tests` lock in the new parser behavior.
+- `tests/ollama_http_autoswitch.rs::live_ollama_think_string_parser_round_trip` is a new `#[ignore]`'d live test verifying the wire body is accepted by a real Ollama server.
+
 ## [0.15.0] - 2026-05-17
 
 ### Fixed

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -317,7 +317,7 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
 ```toml
-motosan-ai = { version = "0.15.0", features = ["claude-code"] }
+motosan-ai = { version = "0.15.1", features = ["claude-code"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -426,7 +426,7 @@ Notes:
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
 ```toml
-motosan-ai = { version = "0.15.0", features = ["codex-cli"] }
+motosan-ai = { version = "0.15.1", features = ["codex-cli"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -489,7 +489,7 @@ Notes:
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
 ```toml
-motosan-ai = { version = "0.15.0", features = ["gemini-cli"] }
+motosan-ai = { version = "0.15.1", features = ["gemini-cli"] }
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -134,9 +134,21 @@ impl OllamaProvider {
             "stream": stream,
         });
 
-        // Think mode: when set, pass think=true to Ollama
-        if self.think.is_some() {
-            body["think"] = json!(true);
+        // Think mode: parse the user-supplied string into an appropriate
+        // JSON value so callers can opt into either:
+        //   - bool true/false (truthy / falsy synonyms)
+        //   - string reasoning levels like "low" / "medium" / "high"
+        //     (newer Ollama versions accept these)
+        // Before 0.15.1 this hard-coded `true` for any non-None value,
+        // silently flattening `ollama_think("no")` to bool true. Fixed in
+        // 0.15.1 — see CHANGELOG.
+        if let Some(think_str) = &self.think {
+            let trimmed = think_str.trim();
+            body["think"] = match trimmed.to_ascii_lowercase().as_str() {
+                "true" | "yes" | "on" | "1" => json!(true),
+                "false" | "no" | "off" | "0" => json!(false),
+                _ => json!(trimmed),
+            };
         }
 
         if let Some(keep_alive) = &self.keep_alive {
@@ -530,5 +542,72 @@ impl futures_core::Stream for NdjsonStream {
                 Poll::Pending => return Poll::Pending,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ChatRequest;
+
+    fn req() -> ChatRequest {
+        ChatRequest::builder()
+            .message(crate::types::Message::user("hi"))
+            .build()
+    }
+
+    #[test]
+    fn think_truthy_strings_serialize_as_bool_true() {
+        for input in &["true", "yes", "on", "1", "YES", "True", "  yes  "] {
+            let provider =
+                OllamaProvider::new("llama3", "http://x").with_think(Some(input.to_string()));
+            let body = provider.build_request_body(&req(), false);
+            assert_eq!(
+                body["think"],
+                serde_json::json!(true),
+                "input {input:?} should serialize as bool true, got {:?}",
+                body["think"]
+            );
+        }
+    }
+
+    #[test]
+    fn think_falsy_strings_serialize_as_bool_false() {
+        for input in &["false", "no", "off", "0", "NO", "False"] {
+            let provider =
+                OllamaProvider::new("llama3", "http://x").with_think(Some(input.to_string()));
+            let body = provider.build_request_body(&req(), false);
+            assert_eq!(
+                body["think"],
+                serde_json::json!(false),
+                "input {input:?} should serialize as bool false, got {:?}",
+                body["think"]
+            );
+        }
+    }
+
+    #[test]
+    fn think_other_strings_pass_through_verbatim() {
+        for input in &["low", "medium", "high", "custom-value"] {
+            let provider =
+                OllamaProvider::new("llama3", "http://x").with_think(Some(input.to_string()));
+            let body = provider.build_request_body(&req(), false);
+            assert_eq!(
+                body["think"],
+                serde_json::json!(input),
+                "input {input:?} should pass through as string, got {:?}",
+                body["think"]
+            );
+        }
+    }
+
+    #[test]
+    fn think_not_set_omits_field_entirely() {
+        let provider = OllamaProvider::new("llama3", "http://x").with_think(None);
+        let body = provider.build_request_body(&req(), false);
+        assert!(
+            body.get("think").is_none(),
+            "think field should be absent when not set; got body: {body}"
+        );
     }
 }

--- a/sdks/rust/tests/ollama_http_autoswitch.rs
+++ b/sdks/rust/tests/ollama_http_autoswitch.rs
@@ -237,3 +237,52 @@ async fn live_ollama_auto_switch_against_real_server() {
         response.content
     );
 }
+
+#[tokio::test]
+#[ignore] // Requires `ollama serve` running on localhost:11434 + OLLAMA_MODEL env var.
+async fn live_ollama_think_string_parser_round_trip() {
+    // Verifies the 0.15.1 fix: ollama_think("yes") and ollama_think("true")
+    // both still produce a wire body the real Ollama server accepts.
+    //
+    // Scope honesty: most common pre-pulled models (llama3.1:8b, qwen2.5,
+    // mistral) don't actually support `think` — they accept the field
+    // silently and return a normal response. This test verifies "Ollama
+    // doesn't reject the new serialization shape", not "thinking actually
+    // happens". For the latter, set OLLAMA_MODEL to a think-capable model
+    // like deepseek-r1 or qwen3.
+    //
+    // To run:
+    //   OLLAMA_MODEL=llama3.1:8b cargo test --features ollama \
+    //     --test ollama_http_autoswitch live_ollama_think -- --ignored --nocapture
+
+    let model = std::env::var("OLLAMA_MODEL").expect(
+        "set OLLAMA_MODEL to any chat model you have pulled — \
+         run `ollama list` to see what's available",
+    );
+    let base_url =
+        std::env::var("OLLAMA_BASE_URL").unwrap_or_else(|_| "http://localhost:11434".to_string());
+
+    let client = Client::builder()
+        .provider(Provider::Ollama)
+        .api_key("ollama")
+        .ollama_base_url(&base_url)
+        .model(&model)
+        .ollama_think("yes") // parser maps to bool true on the wire
+        .ollama_keep_alive("30s")
+        .build()
+        .expect("build client");
+
+    let response = client
+        .chat(vec![Message::user("Reply with exactly the word: pong")])
+        .await
+        .unwrap_or_else(|e| {
+            panic!("Ollama chat failed against {base_url} with model {model} and think=yes: {e}.\nIs `ollama serve` running?")
+        });
+
+    assert!(
+        !response.content.trim().is_empty(),
+        "Ollama with think=yes returned empty content; \
+         expected a non-empty reply. Got: {:?}",
+        response.content
+    );
+}

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.10.0 / Rust 0.15.0
+Multi-provider LLM SDK — Python 0.10.0 / Rust 0.15.1
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI
 
@@ -20,7 +20,7 @@ pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.15.0", features = ["anthropic"] }
+motosan-ai = { version = "0.15.1", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-motosan-ai = { version = "0.15.0", features = ["anthropic"] }
+motosan-ai = { version = "0.15.1", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```


### PR DESCRIPTION
## Summary

Closes the pre-existing `ollama_think` boolean coercion bug noted in the header of `docs/superpowers/plans/2026-05-17-ollama-http-wiring.md`. Ships as 0.15.1 patch (purely additive — no public-API surface change).

**Before:**
```rust
if self.think.is_some() {
    body["think"] = json!(true);   // hardcoded; ignores input value
}
```

**After:**
- truthy synonyms (`true` / `yes` / `on` / `1`, case-insensitive + trimmed) → bool true
- falsy synonyms (`false` / `no` / `off` / `0`, case-insensitive + trimmed) → bool false
- anything else (e.g. `low` / `medium` / `high`) → string verbatim

Backward compatible: existing `ollama_think("yes")` callers still get bool true on the wire. New callers can opt into Ollama's string-valued reasoning levels.

Also bundles `.gitignore` macOS noise cleanup.

## Test plan

- [x] 4 new unit tests in `providers::ollama::tests` covering truthy / falsy / passthrough / unset
- [x] 1 new `#[ignore]`'d live test (`live_ollama_think_string_parser_round_trip`) covering wire compat against real Ollama
- [x] Existing `tests/ollama_native_provider.rs` integration tests still pass (use `ollama_think("on")`, which still maps to bool true)
- [x] `check-all` green
- [x] `./scripts/pre-push-gate.sh` green (incl. live Anthropic tests)
- [x] `cargo clippy --features anthropic,minimax,ollama,openai --all-targets -- -D warnings` clean

## Release readiness

After merge, tag `rust-v0.15.1` and push to trigger `publish-rust.yml` → crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
