### PR TITLE
fix(rust): ollama_think empty/whitespace-only input omits field entirely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.15.1 (crates.io) · Python v0.10.0 (PyPI)
+Rust v0.15.2 (crates.io) · Python v0.10.0 (PyPI)
 
 ## Where To Find Things
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.15.1 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.15.2 |
 | Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.9.3 |
 
 ## Install
@@ -34,7 +34,7 @@ response = await client.chat([Message.user("Hello")])
 ```toml
 # Rust (Cargo.toml)
 [dependencies]
-motosan-ai = { version = "0.15.1", features = ["anthropic"] }
+motosan-ai = { version = "0.15.2", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.10.0 · Rust 0.15.1
+- Python 0.10.0 · Rust 0.15.2
 - GitHub: https://github.com/motosan-dev/motosan-ai
 - PyPI: https://pypi.org/project/motosan-ai/
 - crates.io: https://crates.io/crates/motosan-ai
@@ -19,7 +19,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.15.1", features = ["anthropic"] }
+motosan-ai = { version = "0.15.2", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient):

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
+## [0.15.2] - 2026-05-17
+
+### Fixed
+- **`ollama_think("")` and `ollama_think("   ")` no longer emit `body["think"] = ""`** (which Ollama rejects as an invalid think value). Empty / whitespace-only inputs are now treated as if the field was never set, matching caller intent. Edge case left undocumented by the 0.15.1 parser fix. Closes the self-review followup from PR #178.
+
+### Notes
+- Single one-line guard in `providers/ollama.rs::build_request_body` (`if !trimmed.is_empty()` before the match block).
+- New unit test `think_empty_or_whitespace_only_omits_field_entirely` covers 6 variants: empty, single space, multi-space, tab, newline, mixed whitespace.
+
 ## [0.15.1] - 2026-05-17
 
 ### Fixed

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -317,7 +317,7 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
 ```toml
-motosan-ai = { version = "0.15.1", features = ["claude-code"] }
+motosan-ai = { version = "0.15.2", features = ["claude-code"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -426,7 +426,7 @@ Notes:
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
 ```toml
-motosan-ai = { version = "0.15.1", features = ["codex-cli"] }
+motosan-ai = { version = "0.15.2", features = ["codex-cli"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -489,7 +489,7 @@ Notes:
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
 ```toml
-motosan-ai = { version = "0.15.1", features = ["gemini-cli"] }
+motosan-ai = { version = "0.15.2", features = ["gemini-cli"] }
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -144,11 +144,16 @@ impl OllamaProvider {
         // 0.15.1 — see CHANGELOG.
         if let Some(think_str) = &self.think {
             let trimmed = think_str.trim();
-            body["think"] = match trimmed.to_ascii_lowercase().as_str() {
-                "true" | "yes" | "on" | "1" => json!(true),
-                "false" | "no" | "off" | "0" => json!(false),
-                _ => json!(trimmed),
-            };
+            // Skip empty / whitespace-only inputs — caller almost
+            // certainly meant "don't set this field" rather than "send
+            // think=empty-string" (which Ollama would reject anyway).
+            if !trimmed.is_empty() {
+                body["think"] = match trimmed.to_ascii_lowercase().as_str() {
+                    "true" | "yes" | "on" | "1" => json!(true),
+                    "false" | "no" | "off" | "0" => json!(false),
+                    _ => json!(trimmed),
+                };
+            }
         }
 
         if let Some(keep_alive) = &self.keep_alive {
@@ -609,5 +614,23 @@ mod tests {
             body.get("think").is_none(),
             "think field should be absent when not set; got body: {body}"
         );
+    }
+
+    #[test]
+    fn think_empty_or_whitespace_only_omits_field_entirely() {
+        // Defensive: callers passing "" or "   " almost certainly mean
+        // "don't set this field" rather than "send think=empty-string".
+        // Emitting a JSON empty string would be rejected by Ollama as
+        // an unknown think value. Treat as unset.
+        for input in &["", " ", "   ", "\t", "\n", "\t  \n"] {
+            let provider =
+                OllamaProvider::new("llama3", "http://x").with_think(Some(input.to_string()));
+            let body = provider.build_request_body(&req(), false);
+            assert!(
+                body.get("think").is_none(),
+                "input {input:?} (trimmed empty) should omit the think field; \
+                 got body: {body}"
+            );
+        }
     }
 }

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.10.0 / Rust 0.15.1
+Multi-provider LLM SDK — Python 0.10.0 / Rust 0.15.2
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI
 
@@ -20,7 +20,7 @@ pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.15.1", features = ["anthropic"] }
+motosan-ai = { version = "0.15.2", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-motosan-ai = { version = "0.15.1", features = ["anthropic"] }
+motosan-ai = { version = "0.15.2", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```


### PR DESCRIPTION
## Summary

Tiny followup to PR #177 (0.15.1). Closes the edge case my own review flagged: `ollama_think("")` or `ollama_think("   ")` previously fell through the parser's match arms and emitted `body["think"] = ""` (JSON empty string), which Ollama rejects.

**Before (post-0.15.1):**
\`\`\`rust
if let Some(think_str) = &self.think {
    let trimmed = think_str.trim();
    body["think"] = match trimmed.to_ascii_lowercase().as_str() {
        "true" | "yes" | "on" | "1" => json!(true),
        "false" | "no" | "off" | "0" => json!(false),
        _ => json!(trimmed),  // ← empty/whitespace falls here, emits ""
    };
}
\`\`\`

**After:**
\`\`\`rust
if let Some(think_str) = &self.think {
    let trimmed = think_str.trim();
    if !trimmed.is_empty() {  // ← guard added
        body["think"] = match trimmed.to_ascii_lowercase().as_str() {
            // ... unchanged
        };
    }
}
\`\`\`

Caller intent for empty input is almost certainly "don't set this field"; treating it as unset matches that intent and avoids generating a body Ollama would reject.

## Test plan

- [x] New unit test \`think_empty_or_whitespace_only_omits_field_entirely\` covering 6 variants (empty, single space, multi-space, tab, newline, mixed whitespace) — fails before the guard, passes after
- [x] Existing 4 parser tests in \`providers::ollama::tests\` unchanged and still pass
- [x] \`check-all\` green
- [x] \`cargo clippy --features anthropic,minimax,ollama,openai --all-targets -- -D warnings\` clean
- [x] No live test needed — purely client-side serialization; no wire change for the common case

## Release decision pending

This is small enough to either:
- Bundle into the next non-trivial release (no 0.15.2)
- Ship as 0.15.2 patch on its own (full ceremony for a one-line guard)

Awaiting decision before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)