### PR TITLE
fix(rust): ThinkStripperStream flushes tail before terminal done event (0.15.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.15.2 (crates.io) · Python v0.10.0 (PyPI)
+Rust v0.15.3 (crates.io) · Python v0.10.0 (PyPI)
 
 ## Where To Find Things
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.15.2 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.15.3 |
 | Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.9.3 |
 
 ## Install
@@ -34,7 +34,7 @@ response = await client.chat([Message.user("Hello")])
 ```toml
 # Rust (Cargo.toml)
 [dependencies]
-motosan-ai = { version = "0.15.2", features = ["anthropic"] }
+motosan-ai = { version = "0.15.3", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.10.0 · Rust 0.15.2
+- Python 0.10.0 · Rust 0.15.3
 - GitHub: https://github.com/motosan-dev/motosan-ai
 - PyPI: https://pypi.org/project/motosan-ai/
 - crates.io: https://crates.io/crates/motosan-ai
@@ -19,7 +19,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.15.2", features = ["anthropic"] }
+motosan-ai = { version = "0.15.3", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient):

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
 ### Notes
 - Single change in `client.rs::ThinkStripperStream::poll_next`: on a terminal `done` event, flush the stripper first; if the buffered tail is non-empty, queue the done event in a new `pending: Option<StreamEvent>` field and emit the tail as a Text event on the current poll. Mid-stream `Usage` events still pass through without flushing — flushing while the buffer holds e.g. `<thin…` would leak a partial open tag.
-- Four unit tests in `think_stripper_stream_tests` lock in the regression (short reply survives, 6-char tail not lost, `<think>` still stripped when followed by Done, terminal `done` flag still observed).
+- Six unit tests in `think_stripper_stream_tests` lock in the regression: short reply survives, 6-char tail not lost, `<think>` still stripped when followed by Done, terminal `done` flag still observed, `Text → Usage → Done` (the actual claude-code wire order, per `providers/claude_code/stream_json.rs:91-104`) preserves the tail across the mid-stream Usage event, and `done_with_stop_reason` keeps its `stop_reason` field through the flush detour.
 - `tests/client_builder.rs::integration_claude_code_short_reply_not_truncated` is a new `#[ignore]`'d live test that spawns the real `claude` CLI, sends a "reply with only 'pong'" prompt, and asserts the collected content contains `pong` end-to-end. Defends against future regressions in the spawn glue / NDJSON parser / stripper wrapper interplay.
 - Python SDK (`sdks/python/motosan_ai/client.py:344-347`) already flushed-before-done correctly; no Python change needed (and `Provider::ClaudeCode` is Rust-only).
 

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
+## [0.15.3] - 2026-05-17
+
+### Fixed
+- **`ThinkStripperStream` now flushes the tail buffer before forwarding a terminal `done` event.** `ThinkStripper::feed` always retains up to 6 trailing chars in case a split `<think>` open tag is arriving in pieces. The wrapper previously only called `flush()` on `Poll::Ready(None)`, but `collect_stream` (and any normal consumer) breaks on `event.done` first — so the flush was never observed. Anthropic / OpenAI dodged it because their SSE adapters emit many small text deltas; `Provider::ClaudeCode` triggered it sharply because it emits the entire assistant turn as one Text event followed by Done. Symptom: `pong` / `ok` / `yes` (≤6 chars) disappeared entirely; `Hello, world!` collapsed to `Hello, ` — last 6 chars always lost.
+
+### Notes
+- Single change in `client.rs::ThinkStripperStream::poll_next`: on a terminal `done` event, flush the stripper first; if the buffered tail is non-empty, queue the done event in a new `pending: Option<StreamEvent>` field and emit the tail as a Text event on the current poll. Mid-stream `Usage` events still pass through without flushing — flushing while the buffer holds e.g. `<thin…` would leak a partial open tag.
+- Four unit tests in `think_stripper_stream_tests` lock in the regression (short reply survives, 6-char tail not lost, `<think>` still stripped when followed by Done, terminal `done` flag still observed).
+- `tests/client_builder.rs::integration_claude_code_short_reply_not_truncated` is a new `#[ignore]`'d live test that spawns the real `claude` CLI, sends a "reply with only 'pong'" prompt, and asserts the collected content contains `pong` end-to-end. Defends against future regressions in the spawn glue / NDJSON parser / stripper wrapper interplay.
+- Python SDK (`sdks/python/motosan_ai/client.py:344-347`) already flushed-before-done correctly; no Python change needed (and `Provider::ClaudeCode` is Rust-only).
+
 ## [0.15.2] - 2026-05-17
 
 ### Fixed

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -317,7 +317,7 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
 ```toml
-motosan-ai = { version = "0.15.2", features = ["claude-code"] }
+motosan-ai = { version = "0.15.3", features = ["claude-code"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -426,7 +426,7 @@ Notes:
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
 ```toml
-motosan-ai = { version = "0.15.2", features = ["codex-cli"] }
+motosan-ai = { version = "0.15.3", features = ["codex-cli"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -489,7 +489,7 @@ Notes:
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
 ```toml
-motosan-ai = { version = "0.15.2", features = ["gemini-cli"] }
+motosan-ai = { version = "0.15.3", features = ["gemini-cli"] }
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -175,6 +175,7 @@ impl Client {
         Box::pin(ThinkStripperStream {
             inner: raw,
             stripper: ThinkStripper::new(),
+            pending: None,
         })
     }
 
@@ -1098,6 +1099,13 @@ impl futures_core::Stream for ReadTimeoutStream {
 struct ThinkStripperStream {
     inner: BoxStream,
     stripper: ThinkStripper,
+    // Holds a terminal `done` event when the stripper had buffered text at
+    // the moment the inner stream emitted it. The buffered tail is yielded
+    // first and the done event is returned on the next poll. Without this,
+    // consumers that break on `event.done` (e.g. `collect_stream`) would
+    // never observe the flushed tail — losing up to 6 trailing chars on
+    // providers like claude-code that emit one Text event per turn.
+    pending: Option<StreamEvent>,
 }
 
 impl futures_core::Stream for ThinkStripperStream {
@@ -1109,6 +1117,9 @@ impl futures_core::Stream for ThinkStripperStream {
     ) -> std::task::Poll<Option<Self::Item>> {
         use std::task::Poll;
         loop {
+            if let Some(ev) = self.pending.take() {
+                return Poll::Ready(Some(ev));
+            }
             match self.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(event)) => {
                     if event.event_type == StreamEventType::Text && !event.content.is_empty() {
@@ -1117,6 +1128,13 @@ impl futures_core::Stream for ThinkStripperStream {
                             continue; // buffering, skip this event
                         }
                         return Poll::Ready(Some(StreamEvent::text(clean)));
+                    }
+                    if event.done {
+                        let remaining = self.stripper.flush();
+                        if !remaining.is_empty() {
+                            self.pending = Some(event);
+                            return Poll::Ready(Some(StreamEvent::text(remaining)));
+                        }
                     }
                     return Poll::Ready(Some(event));
                 }
@@ -1130,6 +1148,75 @@ impl futures_core::Stream for ThinkStripperStream {
                 Poll::Pending => return Poll::Pending,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod think_stripper_stream_tests {
+    use super::*;
+    use crate::types::StreamEvent;
+    use tokio_stream::StreamExt;
+
+    fn mock(events: Vec<StreamEvent>) -> BoxStream {
+        Box::pin(tokio_stream::iter(events))
+    }
+
+    async fn collect_until_done(mut stream: BoxStream) -> String {
+        let mut content = String::new();
+        let mut saw_done = false;
+        while let Some(ev) = stream.next().await {
+            if ev.done {
+                saw_done = true;
+                break;
+            }
+            content.push_str(&ev.content);
+        }
+        assert!(saw_done, "stream ended without a done event");
+        content
+    }
+
+    // Reproduces the claude-code regression: provider emits the entire turn
+    // as one Text event followed by Done. The 6-char tail buffer must be
+    // flushed before the done event reaches the consumer (`collect_stream`
+    // breaks on `event.done`), otherwise short replies vanish.
+    #[tokio::test]
+    async fn short_response_survives_when_followed_by_done() {
+        let raw = mock(vec![StreamEvent::text("pong"), StreamEvent::done()]);
+        let wrapped = Client::wrap_with_think_stripper(raw);
+        assert_eq!(collect_until_done(wrapped).await, "pong");
+    }
+
+    #[tokio::test]
+    async fn long_response_does_not_lose_six_char_tail() {
+        let raw = mock(vec![
+            StreamEvent::text("Hello, world!"),
+            StreamEvent::done(),
+        ]);
+        let wrapped = Client::wrap_with_think_stripper(raw);
+        assert_eq!(collect_until_done(wrapped).await, "Hello, world!");
+    }
+
+    #[tokio::test]
+    async fn think_block_still_stripped_with_terminal_done() {
+        let raw = mock(vec![
+            StreamEvent::text("<think>secret</think>visible"),
+            StreamEvent::done(),
+        ]);
+        let wrapped = Client::wrap_with_think_stripper(raw);
+        assert_eq!(collect_until_done(wrapped).await, "visible");
+    }
+
+    #[tokio::test]
+    async fn flush_does_not_swallow_done_flag() {
+        let raw = mock(vec![StreamEvent::text("ok"), StreamEvent::done()]);
+        let mut wrapped = Client::wrap_with_think_stripper(raw);
+        let mut events = Vec::new();
+        while let Some(ev) = wrapped.next().await {
+            events.push(ev);
+        }
+        // Must see both the buffered text and the terminal done event.
+        assert!(events.iter().any(|e| e.content == "ok" && !e.done));
+        assert!(events.iter().any(|e| e.done));
     }
 }
 

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1154,7 +1154,7 @@ impl futures_core::Stream for ThinkStripperStream {
 #[cfg(test)]
 mod think_stripper_stream_tests {
     use super::*;
-    use crate::types::StreamEvent;
+    use crate::types::{StreamEvent, Usage};
     use tokio_stream::StreamExt;
 
     fn mock(events: Vec<StreamEvent>) -> BoxStream {
@@ -1217,6 +1217,68 @@ mod think_stripper_stream_tests {
         // Must see both the buffered text and the terminal done event.
         assert!(events.iter().any(|e| e.content == "ok" && !e.done));
         assert!(events.iter().any(|e| e.done));
+    }
+
+    // Mirrors the actual claude-code wire order (Text → Usage → Done, per
+    // providers/claude_code/stream_json.rs). The Usage event arrives while
+    // the stripper still holds the 6-char tail; it must pass through without
+    // disturbing the buffer, and the tail must still be flushed on the
+    // subsequent Done.
+    #[tokio::test]
+    async fn usage_between_text_and_done_does_not_lose_tail() {
+        let raw = mock(vec![
+            StreamEvent::text("Hello, world!"),
+            StreamEvent::usage(Usage {
+                input_tokens: 12,
+                output_tokens: 8,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+            }),
+            StreamEvent::done(),
+        ]);
+        let mut wrapped = Client::wrap_with_think_stripper(raw);
+        let mut content = String::new();
+        let mut saw_usage = false;
+        let mut saw_done = false;
+        while let Some(ev) = wrapped.next().await {
+            if ev.done {
+                saw_done = true;
+                break;
+            }
+            if ev.event_type == StreamEventType::Usage {
+                saw_usage = true;
+                let u = ev.usage.expect("usage event carries Usage payload");
+                assert_eq!(u.input_tokens, 12);
+                assert_eq!(u.output_tokens, 8);
+                continue;
+            }
+            content.push_str(&ev.content);
+        }
+        assert_eq!(content, "Hello, world!");
+        assert!(saw_usage, "Usage event must reach the consumer");
+        assert!(saw_done, "Done event must reach the consumer");
+    }
+
+    // The deferred done event must keep its stop_reason field. Guards against
+    // a future refactor that synthesizes a fresh `StreamEvent::done()` instead
+    // of queuing the original event into `pending`.
+    #[tokio::test]
+    async fn deferred_done_preserves_stop_reason() {
+        use crate::types::StopReason;
+        let raw = mock(vec![
+            StreamEvent::text("pong"),
+            StreamEvent::done_with_stop_reason(StopReason::EndTurn),
+        ]);
+        let mut wrapped = Client::wrap_with_think_stripper(raw);
+        let mut events = Vec::new();
+        while let Some(ev) = wrapped.next().await {
+            events.push(ev);
+        }
+        let done = events
+            .iter()
+            .find(|e| e.done)
+            .expect("terminal done event must be observed");
+        assert_eq!(done.stop_reason.as_ref(), Some(&StopReason::EndTurn));
     }
 }
 

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -315,6 +315,47 @@ async fn integration_client_dispatches_to_claude_code_stream() {
     );
 }
 
+#[cfg(feature = "claude-code")]
+#[tokio::test]
+#[ignore] // Requires `claude` CLI installed + auth.
+async fn integration_claude_code_short_reply_not_truncated() {
+    // Regression guard for the 0.15.3 ThinkStripper flush-before-done fix.
+    // Pre-fix: claude-code emits the entire assistant turn as one Text
+    // event followed by Done; `ThinkStripperStream` only flushed on
+    // `Poll::Ready(None)`, but `collect_stream` (used by `chat_with`)
+    // breaks on `event.done`, so the 6-char tail buffer was never
+    // observed. A 4-char reply like "pong" disappeared entirely. The
+    // sibling `integration_client_dispatches_to_claude_code_stream` test
+    // would still have passed under the bug (a tail-truncated Text event
+    // is still non-empty) — this test pins the round-trip content.
+    use motosan_ai::{ChatRequest, ClaudeCodeProvider};
+
+    let client = Client::builder()
+        .provider(Provider::ClaudeCode)
+        .claude_code(ClaudeCodeProvider::new().model("sonnet"))
+        .build()
+        .expect("build client");
+
+    let request = ChatRequest::builder()
+        .message(Message::user(
+            "Reply with only the four letters 'pong' (no punctuation, no whitespace, nothing else).",
+        ))
+        .build();
+
+    let response = client
+        .chat_with(request)
+        .await
+        .expect("claude chat should succeed via Client dispatch");
+
+    let trimmed = response.content.trim();
+    assert!(
+        trimmed.contains("pong"),
+        "claude reply should contain 'pong' end-to-end via collect_stream — got: {trimmed:?}. \
+         If this fails with content \"\" or a tail-stripped string, the \
+         ThinkStripperStream flush-before-done fix in src/client.rs has regressed."
+    );
+}
+
 #[cfg(feature = "codex-cli")]
 #[tokio::test]
 #[ignore] // Requires `codex` CLI installed + auth.

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.10.0 / Rust 0.15.2
+Multi-provider LLM SDK — Python 0.10.0 / Rust 0.15.3
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI
 
@@ -20,7 +20,7 @@ pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.15.2", features = ["anthropic"] }
+motosan-ai = { version = "0.15.3", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-motosan-ai = { version = "0.15.2", features = ["anthropic"] }
+motosan-ai = { version = "0.15.3", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```


### PR DESCRIPTION
Cuts **0.15.3** with the ThinkStripper streaming fix + live regression backstop.

## Summary
- `ThinkStripper.feed()` keeps up to 6 trailing chars buffered (waiting for a possibly-split `<think>` open tag). `ThinkStripperStream::poll_next` previously only called `flush()` on `Poll::Ready(None)`, but `collect_stream` breaks on `event.done` first — so the flush was never observed.
- Anthropic / OpenAI dodged it because their SSE adapters emit many small text deltas. `Provider::ClaudeCode` triggered it sharply because it emits the entire assistant turn as one Text event followed by Done.

Symptoms:

| Provider reply  | What consumer saw |
|-----------------|-------------------|
| `pong`          | `""`              |
| `ok`            | `""`              |
| `Hello, world!` | `"Hello, "`       |

## Fix
On a terminal `done` event in `ThinkStripperStream::poll_next`, flush the stripper first; if there's buffered text, queue the done event in a new `pending: Option<StreamEvent>` field and emit the tail as a Text event on the current poll. Mid-stream `Usage` events still pass through without flushing — flushing while the buffer holds e.g. `<thin…` would leak a partial open tag.

The Python SDK already does this correctly at `sdks/python/motosan_ai/client.py:344-347`; no Python change needed (and `Provider::ClaudeCode` is Rust-only).

## Commits
1. `fix(rust): ThinkStripperStream flushes tail before terminal done event` — the fix + 4 unit tests
2. `test(rust): live claude-code test for short-reply round-trip` — `#[ignore]`'d backstop
3. `chore(rust): bump 0.15.2 -> 0.15.3 + CHANGELOG + release-checklist docs`
4. `test(rust): cover Usage-mid-stream and stop_reason in ThinkStripperStream` — self-review follow-up

## Test plan
- [x] `cargo test --lib think_stripper_stream_tests` — 6 unit tests, all pass
  - `short_response_survives_when_followed_by_done` (`pong` → `pong`)
  - `long_response_does_not_lose_six_char_tail` (`Hello, world!` → `Hello, world!`)
  - `think_block_still_stripped_with_terminal_done` (`<think>secret</think>visible` → `visible`)
  - `flush_does_not_swallow_done_flag` (consumer still observes terminal `done: true`)
  - `usage_between_text_and_done_does_not_lose_tail` (actual claude-code wire order)
  - `deferred_done_preserves_stop_reason` (`done_with_stop_reason` survives flush detour)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo test --all-features` — 441 passed, 16 ignored (+2 vs main)
- [x] New `#[ignore]`'d live test compiled and registered (verified via `cargo test ... -- --ignored --list`)
- [x] **Live test executed against real `claude` CLI:** `integration_claude_code_short_reply_not_truncated ... ok` (6.05s, 1 API call). The "pong" reply survived end-to-end through `chat_with` → `collect_stream` after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)