### PR TITLE
feat(oauth): anthropic-oauth crate (Claude Pro/Max login)

### DIFF
--- a/.github/workflows/publish-anthropic-oauth.yml
+++ b/.github/workflows/publish-anthropic-oauth.yml
@@ -1,0 +1,29 @@
+name: publish-anthropic-oauth
+
+on:
+  push:
+    tags:
+      - "anthropic-oauth-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/rust/crates/anthropic-oauth
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: sdks/rust/crates/anthropic-oauth
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Rust v0.15.3 (crates.io) · Python v0.10.0 (PyPI)
 | Python format/lint config | `sdks/python/ruff.toml` |
 | Unified formatter config | `treefmt.toml` |
 | CI workflows | `.github/workflows/ci-rust.yml`, `ci-python.yml` |
-| Release workflows | `.github/workflows/publish-rust.yml`, `publish-python.yml`, `publish-codex-oauth.yml`, `publish-anthropic-oauth.yml` |
+| Release workflows | `.github/workflows/publish-rust.yml`, `publish-python.yml`, `publish-motosan-ai-oauth.yml`, `publish-codex-oauth.yml`, `publish-anthropic-oauth.yml` |
 | Dev shell & scripts | `devshell/default.nix`, `devshell/scripts.nix` |
 | API reference for LLMs | `llms.txt` |
 
@@ -77,6 +77,6 @@ These rules exist because motosan-chat and other downstream consumers depend on 
 
 ## Releasing
 
-Tag `rust-vX.Y.Z` triggers `publish-rust.yml` → crates.io. Tag `python-vX.Y.Z` triggers `publish-python.yml` → PyPI.
+Tag `rust-vX.Y.Z` triggers `publish-rust.yml` → crates.io. Tag `python-vX.Y.Z` triggers `publish-python.yml` → PyPI. OAuth helper crates use per-crate tags (`motosan-ai-oauth-vX.Y.Z`, `codex-oauth-vX.Y.Z`, `anthropic-oauth-vX.Y.Z`). Publish `motosan-ai-oauth` before wrapper crates that depend on its new version.
 
 Update before tagging: CHANGELOGs, version in `Cargo.toml`/`pyproject.toml`, `AGENTS.md`, `llms.txt`, `skills/motosan-ai/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Rust v0.15.3 (crates.io) · Python v0.10.0 (PyPI)
 | Type definitions (source of truth) | `specs/types.md` |
 | Rust SDK entry point | `sdks/rust/src/lib.rs` → `client.rs` |
 | Python SDK entry point | `sdks/python/motosan_ai/client.py` |
+| OAuth helper crates | `sdks/rust/crates/motosan-ai-oauth/`, `sdks/rust/crates/codex-oauth/`, `sdks/rust/crates/anthropic-oauth/` |
 | Provider implementations | `sdks/rust/src/providers/`, `sdks/python/motosan_ai/providers/` |
 | HTTP providers | Rust: `sdks/rust/src/providers/gemini.rs` (feature `gemini`), `sdks/rust/src/providers/gemini_code_assist.rs` (feature `gemini-code-assist`); Python: `sdks/python/motosan_ai/providers/gemini.py`, `gemini_code_assist.py` |
 | CLI backends | Rust: `sdks/rust/src/providers/claude_code/`, `codex_cli/`, `gemini_cli/`; Python: `sdks/python/motosan_ai/providers/claude_code.py`, `codex_cli.py`, `gemini_cli.py` |
@@ -18,7 +19,7 @@ Rust v0.15.3 (crates.io) · Python v0.10.0 (PyPI)
 | Python format/lint config | `sdks/python/ruff.toml` |
 | Unified formatter config | `treefmt.toml` |
 | CI workflows | `.github/workflows/ci-rust.yml`, `ci-python.yml` |
-| Release workflows | `.github/workflows/publish-rust.yml`, `publish-python.yml` |
+| Release workflows | `.github/workflows/publish-rust.yml`, `publish-python.yml`, `publish-codex-oauth.yml`, `publish-anthropic-oauth.yml` |
 | Dev shell & scripts | `devshell/default.nix`, `devshell/scripts.nix` |
 | API reference for LLMs | `llms.txt` |
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "sdks/rust",
+  "sdks/rust/crates/anthropic-oauth",
   "sdks/rust/crates/codex-oauth",
   "sdks/rust/crates/motosan-ai-oauth",
 ]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,39 @@ let client = Client::builder()
 let response = client.chat(vec![Message::user("Hello")]).await?;
 ```
 
+### Anthropic OAuth (Claude Pro/Max)
+
+The `anthropic-oauth` crate lets you obtain an Anthropic OAuth token tied to a
+Claude Pro/Max subscription. The resulting `sk-ant-oat01-*` token is consumed
+directly by `AnthropicProvider`, which auto-detects the prefix and applies the
+Claude Code identity headers.
+
+```rust
+use anthropic_oauth;
+use motosan_ai::providers::anthropic::AnthropicProvider;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let token = anthropic_oauth::login().await?;
+    let provider = AnthropicProvider::new(&token.access_token, None, None);
+    // Use `provider` as usual.
+    Ok(())
+}
+```
+
+**⚠️ Important ToS disclosure**
+
+This crate uses the OAuth `client_id` registered by Anthropic's Claude Code CLI.
+The resulting access token authenticates your requests **as a Claude Code CLI
+session**, not as an API-key holder. Anthropic has not published this
+`client_id` as a public app registration for third-party use; using it for
+purposes other than running `claude` CLI may be subject to change, may be rate
+limited, and may violate Anthropic's terms of service. You are responsible for
+ensuring your usage complies with Anthropic's terms.
+
+If you have an API key (`sk-ant-api03-*`), prefer that path — it does not
+require this crate.
+
 ```rust
 // 3. Claude Code CLI via unified Client::builder() (since v0.11.0)
 // Requires: cargo add motosan-ai --features claude-code

--- a/llms.txt
+++ b/llms.txt
@@ -545,7 +545,7 @@ Billing: pay-per-token. Free tier available but rate-limited. Default model `gem
 
 ```rust
 // Cargo.toml: features = ["gemini-code-assist"]
-// Also: motosan-ai-oauth = { version = "0.1", features = ["gemini"] }
+// Also: motosan-ai-oauth = { version = "0.2", features = ["gemini"] }
 
 use motosan_ai_oauth::{refresh, providers::gemini};
 
@@ -818,6 +818,46 @@ token.issued_at      // Unix timestamp of issue time
 
 ---
 
+## anthropic-oauth
+
+Standalone crate for browser-based PKCE OAuth login against `claude.ai`. Returns an `sk-ant-oat01-*` access token usable with `motosan-ai`'s `AnthropicProvider` (which auto-detects the prefix and applies Claude Code identity headers).
+
+- crates.io: https://crates.io/crates/anthropic-oauth
+- Version: 0.1.0
+
+### Install
+
+```toml
+anthropic-oauth = "0.1"
+```
+
+### API
+
+```rust
+// Login (opens browser, listens on 127.0.0.1:53692, times out after 120s).
+// The redirect URI registered with Anthropic uses hostname "localhost"; the
+// bind address is still 127.0.0.1 — the OAuthConfig handles this split.
+let token = anthropic_oauth::login().await?;
+
+// Refresh
+let token = anthropic_oauth::refresh(&token.refresh_token).await?;
+
+// Expiry check
+if token.is_expired() { /* refresh */ }
+
+// Token fields (same shape as codex-oauth)
+token.access_token   // "sk-ant-oat01-..." — Bearer for Anthropic API
+token.refresh_token  // long-lived, use with refresh()
+token.expires_in     // lifetime in seconds
+token.issued_at      // Unix timestamp of issue time
+```
+
+`Token` implements `Serialize`/`Deserialize` for disk persistence.
+
+**ToS disclosure**: this crate uses the OAuth `client_id` registered by Anthropic's Claude Code CLI. The resulting access token authenticates as a Claude Code CLI session. Anthropic has not published this `client_id` for third-party use; using it for purposes other than running `claude` CLI may be subject to change, rate limited, or violate Anthropic's terms of service. See the project README for the full disclosure.
+
+---
+
 ## Release
 
 Python and Rust SDKs are versioned and released **independently**.
@@ -829,6 +869,7 @@ Python and Rust SDKs are versioned and released **independently**.
 | Python       | `python-vX.Y.Z`       | `python-v0.4.2`       |
 | Rust         | `rust-vX.Y.Z`         | `rust-v0.3.3`         |
 | codex-oauth  | `codex-oauth-vX.Y.Z`  | `codex-oauth-v0.1.0`  |
+| anthropic-oauth | `anthropic-oauth-vX.Y.Z` | `anthropic-oauth-v0.1.0` |
 
 ### Release Steps (Python)
 
@@ -896,12 +937,31 @@ git tag -a codex-oauth-v0.1.1 -m "codex-oauth-v0.1.1 — summary"
 git push origin main codex-oauth-v0.1.1
 ```
 
+### Release Steps (anthropic-oauth)
+
+```bash
+# 1. Bump version
+#    sdks/rust/crates/anthropic-oauth/Cargo.toml → version = "0.1.1"
+
+# 2. Update CHANGELOG
+#    sdks/rust/crates/anthropic-oauth/CHANGELOG.md → ## [0.1.1] - YYYY-MM-DD
+
+# 3. Commit
+git add sdks/rust/crates/anthropic-oauth/Cargo.toml sdks/rust/crates/anthropic-oauth/CHANGELOG.md
+git commit -m "chore: release anthropic-oauth-v0.1.1"
+
+# 4. Tag + push (triggers publish-anthropic-oauth.yml → crates.io)
+git tag -a anthropic-oauth-v0.1.1 -m "anthropic-oauth-v0.1.1 — summary"
+git push origin main anthropic-oauth-v0.1.1
+```
+
 ### CI Pipeline
 
 Tag push triggers GitHub Actions:
 - **publish-python.yml**: `uv build` → `pypa/gh-action-pypi-publish` (secret: `PYPI_API_TOKEN`)
 - **publish-rust.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test --all-features` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
 - **publish-codex-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
+- **publish-anthropic-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
 
 All Rust workflows support `workflow_dispatch` for manual trigger.
 

--- a/llms.txt
+++ b/llms.txt
@@ -868,6 +868,7 @@ Python and Rust SDKs are versioned and released **independently**.
 |--------------|-----------------------|-----------------------|
 | Python       | `python-vX.Y.Z`       | `python-v0.4.2`       |
 | Rust         | `rust-vX.Y.Z`         | `rust-v0.3.3`         |
+| motosan-ai-oauth | `motosan-ai-oauth-vX.Y.Z` | `motosan-ai-oauth-v0.2.0` |
 | codex-oauth  | `codex-oauth-vX.Y.Z`  | `codex-oauth-v0.1.0`  |
 | anthropic-oauth | `anthropic-oauth-vX.Y.Z` | `anthropic-oauth-v0.1.0` |
 
@@ -919,6 +920,27 @@ git tag -a rust-v0.4.1 -m "rust-v0.4.1 — summary"
 git push origin main rust-v0.4.1
 ```
 
+### Release Steps (motosan-ai-oauth)
+
+```bash
+# 1. Bump version
+#    sdks/rust/crates/motosan-ai-oauth/Cargo.toml → version = "0.2.0"
+
+# 2. Update CHANGELOG
+#    sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md → ## [0.2.0] - YYYY-MM-DD
+
+# 3. Commit
+git add sdks/rust/crates/motosan-ai-oauth/Cargo.toml sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
+git commit -m "chore: release motosan-ai-oauth-v0.2.0"
+
+# 4. Tag + push (triggers publish-motosan-ai-oauth.yml → crates.io)
+git tag -a motosan-ai-oauth-v0.2.0 -m "motosan-ai-oauth-v0.2.0 — summary"
+git push origin main motosan-ai-oauth-v0.2.0
+```
+
+Publish `motosan-ai-oauth` before publishing wrapper crates (`codex-oauth`,
+`anthropic-oauth`) that depend on its new version.
+
 ### Release Steps (codex-oauth)
 
 ```bash
@@ -960,6 +982,7 @@ git push origin main anthropic-oauth-v0.1.1
 Tag push triggers GitHub Actions:
 - **publish-python.yml**: `uv build` → `pypa/gh-action-pypi-publish` (secret: `PYPI_API_TOKEN`)
 - **publish-rust.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test --all-features` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
+- **publish-motosan-ai-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
 - **publish-codex-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
 - **publish-anthropic-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
 

--- a/sdks/rust/crates/anthropic-oauth/CHANGELOG.md
+++ b/sdks/rust/crates/anthropic-oauth/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to `anthropic-oauth` are documented in this file.
+
+## [0.1.0] - 2026-05-18
+
+Initial release. PKCE OAuth login and refresh for Anthropic Claude
+Pro/Max. The resulting `sk-ant-oat01-*` access token is consumed
+directly by `motosan-ai`'s `AnthropicProvider` (the setup-token code
+path applies Bearer auth + Claude Code identity headers
+automatically).
+
+See the project README for the ToS disclosure regarding use of
+Anthropic's Claude Code OAuth `client_id`.

--- a/sdks/rust/crates/anthropic-oauth/Cargo.toml
+++ b/sdks/rust/crates/anthropic-oauth/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "anthropic-oauth"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+license = "MIT"
+description = "OAuth login for Anthropic Claude Pro/Max (Claude Code session)"
+repository = "https://github.com/motosan-dev/motosan-ai"
+homepage = "https://github.com/motosan-dev/motosan-ai"
+documentation = "https://docs.rs/anthropic-oauth"
+keywords = ["anthropic", "claude", "oauth", "authentication"]
+categories = ["authentication", "api-bindings"]
+
+[dependencies]
+motosan-ai-oauth = { path = "../motosan-ai-oauth", features = ["anthropic"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+mockito = "1"

--- a/sdks/rust/crates/anthropic-oauth/Cargo.toml
+++ b/sdks/rust/crates/anthropic-oauth/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["anthropic", "claude", "oauth", "authentication"]
 categories = ["authentication", "api-bindings"]
 
 [dependencies]
-motosan-ai-oauth = { path = "../motosan-ai-oauth", features = ["anthropic"] }
+motosan-ai-oauth = { version = "0.2", path = "../motosan-ai-oauth", features = ["anthropic"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/sdks/rust/crates/anthropic-oauth/src/lib.rs
+++ b/sdks/rust/crates/anthropic-oauth/src/lib.rs
@@ -1,0 +1,61 @@
+//! PKCE OAuth login for Anthropic Claude Pro/Max.
+//!
+//! Thin wrapper around [`motosan_ai_oauth`] with the Anthropic provider
+//! pre-configured.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! #[tokio::main]
+//! async fn main() -> Result<(), anthropic_oauth::Error> {
+//!     let token = anthropic_oauth::login().await?;
+//!     // `token.access_token` is a "sk-ant-oat01-*" string usable directly
+//!     // with motosan_ai's AnthropicProvider (which auto-detects the prefix
+//!     // and applies Claude Code identity headers).
+//!     println!("{}", token.access_token);
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Notes
+//!
+//! - Requires port 53692 to be free on localhost (registered with Anthropic's
+//!   Claude Code app).
+//! - `client_id` is hardcoded to Anthropic's Claude Code app registration and
+//!   is not configurable. See the project README for the associated ToS
+//!   disclosure before depending on this crate.
+
+pub use motosan_ai_oauth::{Error, Token};
+
+/// Open a browser-based PKCE login flow and return the resulting OAuth token.
+pub async fn login() -> Result<Token, Error> {
+    motosan_ai_oauth::login(&motosan_ai_oauth::providers::anthropic::claude_pro_max()).await
+}
+
+/// Exchange a stored refresh token for a new [`Token`].
+pub async fn refresh(refresh_token: &str) -> Result<Token, Error> {
+    motosan_ai_oauth::refresh(
+        &motosan_ai_oauth::providers::anthropic::claude_pro_max(),
+        refresh_token,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn re_exports_compile() {
+        let _: fn() -> bool = || {
+            let t = Token {
+                access_token: String::new(),
+                refresh_token: String::new(),
+                id_token: None,
+                expires_in: 0,
+                issued_at: 0,
+            };
+            t.is_expired()
+        };
+    }
+}

--- a/sdks/rust/crates/anthropic-oauth/tests/login_live.rs
+++ b/sdks/rust/crates/anthropic-oauth/tests/login_live.rs
@@ -1,0 +1,39 @@
+//! Live login smoke test.
+//!
+//! `#[ignore]`'d by default — running it pops open a browser window,
+//! requires a Claude Pro/Max account, and binds to port 53692 on
+//! localhost. It is intended to be run manually before releasing a new
+//! version of `anthropic-oauth`:
+//!
+//! ```bash
+//! cargo test -p anthropic-oauth --test login_live -- --ignored
+//! ```
+//!
+//! Success criterion: the returned `Token.access_token` starts with the
+//! `sk-ant-oat01-` prefix and the refresh token is non-empty.
+
+#[tokio::test]
+#[ignore = "interactive: opens a browser and requires Claude Pro/Max account"]
+async fn live_login_returns_setup_token() {
+    let token = anthropic_oauth::login()
+        .await
+        .expect("interactive login must succeed");
+
+    assert!(
+        token.access_token.starts_with("sk-ant-oat01-"),
+        "access_token did not have expected setup-token prefix; got: {}",
+        &token.access_token.chars().take(20).collect::<String>(),
+    );
+
+    assert!(
+        !token.refresh_token.is_empty(),
+        "refresh_token must be non-empty for subsequent refresh()"
+    );
+    assert!(
+        token.expires_in > 0,
+        "expires_in must be positive; got {}",
+        token.expires_in
+    );
+
+    eprintln!("Live login OK. expires_in={}s", token.expires_in);
+}

--- a/sdks/rust/crates/anthropic-oauth/tests/refresh_integration.rs
+++ b/sdks/rust/crates/anthropic-oauth/tests/refresh_integration.rs
@@ -5,7 +5,7 @@
 //! calling `motosan_ai_oauth::refresh` directly with a mock-server config.
 
 use mockito::Matcher;
-use motosan_ai_oauth::{OAuthConfig, TokenBodyFormat};
+use motosan_ai_oauth::{OAuthConfig, StateStrategy, TokenBodyFormat};
 
 #[tokio::test]
 async fn refresh_posts_json_body_when_token_body_is_json() {
@@ -35,6 +35,7 @@ async fn refresh_posts_json_body_when_token_body_is_json() {
         redirect_uri_host: "localhost",
         token_body: TokenBodyFormat::Json,
         extra_auth_params: &[],
+        state_strategy: StateStrategy::Random,
     };
 
     let token = motosan_ai_oauth::refresh(&cfg, "OLD_REFRESH")

--- a/sdks/rust/crates/anthropic-oauth/tests/refresh_integration.rs
+++ b/sdks/rust/crates/anthropic-oauth/tests/refresh_integration.rs
@@ -1,0 +1,46 @@
+//! Integration test: refresh() POSTs JSON to the configured token_url.
+//!
+//! We can't easily redirect `claude_pro_max().token_url` to a mock server
+//! (it's a `&'static str`), so this test exercises the same code path by
+//! calling `motosan_ai_oauth::refresh` directly with a mock-server config.
+
+use mockito::Matcher;
+use motosan_ai_oauth::{OAuthConfig, TokenBodyFormat};
+
+#[tokio::test]
+async fn refresh_posts_json_body_when_token_body_is_json() {
+    let mut server = mockito::Server::new_async().await;
+    let token_url: &'static str = Box::leak(format!("{}/token", server.url()).into_boxed_str());
+
+    let mock = server
+        .mock("POST", "/token")
+        .match_header("content-type", Matcher::Regex("application/json".into()))
+        .match_body(Matcher::JsonString(
+            r#"{"grant_type":"refresh_token","refresh_token":"OLD_REFRESH","client_id":"test-client"}"#
+                .into(),
+        ))
+        .with_status(200)
+        .with_body(r#"{"access_token":"NEW_AT","refresh_token":"NEW_RT","expires_in":3600}"#)
+        .create_async()
+        .await;
+
+    let cfg = OAuthConfig {
+        client_id: "test-client",
+        client_secret: None,
+        auth_url: "https://unused/",
+        token_url,
+        scopes: &[],
+        redirect_port: None,
+        callback_path: "/callback",
+        redirect_uri_host: "localhost",
+        token_body: TokenBodyFormat::Json,
+        extra_auth_params: &[],
+    };
+
+    let token = motosan_ai_oauth::refresh(&cfg, "OLD_REFRESH")
+        .await
+        .expect("refresh ok");
+    assert_eq!(token.access_token, "NEW_AT");
+    assert_eq!(token.refresh_token, "NEW_RT");
+    mock.assert_async().await;
+}

--- a/sdks/rust/crates/codex-oauth/CHANGELOG.md
+++ b/sdks/rust/crates/codex-oauth/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
-All notable changes to `codex-oauth` are documented here.
+All notable changes to `codex-oauth` are documented in this file.
 
-## [0.1.0] - 2026-04-20
+## [0.1.1] - 2026-05-18
 
-### Added
-- **`login()`** — browser-based PKCE OAuth flow against `auth.openai.com`. Opens the browser automatically (macOS/Linux/Windows) and falls back to printing the URL. Listens on `http://localhost:1455/auth/callback` for the redirect. Times out after 120 seconds.
-- **`refresh(refresh_token)`** — exchanges a stored refresh token for a new `Token`.
-- **`Token`** struct with `access_token`, `refresh_token`, `id_token`, `expires_in`, `issued_at` fields. Implements `Serialize`/`Deserialize` for persistence and `is_expired()` for expiry detection.
-- **`Error`** enum covering IO, HTTP, callback parsing, state mismatch, and token exchange failures.
+### Changed
+- Internal: provider config updated for `motosan-ai-oauth` v0.2.0's
+  expanded `OAuthConfig` (new `callback_path`, `redirect_uri_host`,
+  `token_body`, `extra_auth_params` fields). Values preserve previous
+  Codex behavior (form-encoded token body, `/auth/callback` path,
+  `127.0.0.1` redirect host, `access_type=offline` auth param). Public
+  API of `codex-oauth` is unchanged.
+
+## [0.1.0] - 2026-04-19
+
+Initial release.

--- a/sdks/rust/crates/codex-oauth/Cargo.toml
+++ b/sdks/rust/crates/codex-oauth/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["openai", "codex", "oauth", "authentication"]
 categories = ["authentication", "api-bindings"]
 
 [dependencies]
-motosan-ai-oauth = { path = "../motosan-ai-oauth", features = ["codex"] }
+motosan-ai-oauth = { version = "0.2", path = "../motosan-ai-oauth", features = ["codex"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/sdks/rust/crates/codex-oauth/Cargo.toml
+++ b/sdks/rust/crates/codex-oauth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-oauth"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
+++ b/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
@@ -33,6 +33,17 @@ All notable changes to `motosan-ai-oauth` are documented in this file.
   provider configs (`providers::codex`, `providers::gemini`) are updated to
   set values that preserve previous behavior; consumers using them are
   unaffected.
+- Token POST behavior aligned with `@earendil-works/pi-ai`'s reference impl
+  after empirical validation against `platform.claude.com/v1/oauth/token`:
+  - `state` is now echoed in the token-endpoint POST body (after `code`).
+    RFC 6749 §4.1.3 does not require this; most servers ignore extra
+    fields. Anthropic empirically requires it (a missing `state` field
+    returns HTTP 429 shaped as `rate_limit_error`). Codex/Gemini tolerate
+    the extra field.
+  - The previous `User-Agent: Mozilla/5.0 (compatible; motosan-ai-oauth)`
+    override is removed (reqwest's default is used instead — fake-Mozilla
+    UA strings can trip anti-abuse heuristics).
+  - `Accept: application/json` is now set explicitly on the token POST.
 
 ## [0.1.0] - 2026-04-20
 

--- a/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
+++ b/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to `motosan-ai-oauth` are documented in this file.
+
+## [0.2.0] - 2026-05-18
+
+### Added
+- `TokenBodyFormat` enum (`Form` | `Json`) controlling the body encoding
+  used by `exchange_code` and `refresh_token`.
+- `OAuthConfig::callback_path` — the HTTP path the callback server matches
+  against. Defaults vary per provider config (codex/gemini: `/auth/callback`,
+  Anthropic: `/callback`).
+- `OAuthConfig::redirect_uri_host` — the host string used inside the
+  `redirect_uri` query parameter. Separate from the bind address (which is
+  always `127.0.0.1`) so providers like Anthropic that register their
+  redirect URI as `http://localhost:...` work without changing the listen
+  socket.
+- `OAuthConfig::token_body` — selects `TokenBodyFormat::Form` (existing
+  behavior) or `Json`.
+- `OAuthConfig::extra_auth_params` — replaces the previously hardcoded
+  `access_type=offline` query parameter with a config-driven list.
+- `anthropic` feature flag exposing `providers::anthropic::claude_pro_max()`.
+
+### Changed
+- **Breaking (for out-of-tree consumers constructing `OAuthConfig` literals
+  directly):** four new required fields on `OAuthConfig`. The built-in
+  provider configs (`providers::codex`, `providers::gemini`) are updated to
+  set values that preserve previous behavior; consumers using them are
+  unaffected.
+
+## [0.1.0] - 2026-04-20
+
+Initial release: generic PKCE OAuth login + refresh with built-in Codex
+and Gemini provider configs.

--- a/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
+++ b/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
@@ -19,11 +19,17 @@ All notable changes to `motosan-ai-oauth` are documented in this file.
   behavior) or `Json`.
 - `OAuthConfig::extra_auth_params` — replaces the previously hardcoded
   `access_type=offline` query parameter with a config-driven list.
+- `OAuthConfig::state_strategy` (`StateStrategy::Random` | `EqualsVerifier`)
+  — controls how the OAuth `state` CSRF nonce is derived. Anthropic's
+  `claude.ai/oauth/authorize` empirically rejects random state values with
+  "Invalid request format"; Anthropic uses `EqualsVerifier` (reuse PKCE
+  verifier as state), matching Claude Code CLI behavior. Codex/Gemini stay
+  on `Random`.
 - `anthropic` feature flag exposing `providers::anthropic::claude_pro_max()`.
 
 ### Changed
 - **Breaking (for out-of-tree consumers constructing `OAuthConfig` literals
-  directly):** four new required fields on `OAuthConfig`. The built-in
+  directly):** five new required fields on `OAuthConfig`. The built-in
   provider configs (`providers::codex`, `providers::gemini`) are updated to
   set values that preserve previous behavior; consumers using them are
   unaffected.

--- a/sdks/rust/crates/motosan-ai-oauth/Cargo.toml
+++ b/sdks/rust/crates/motosan-ai-oauth/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["authentication", "api-bindings"]
 default = []
 codex = []
 gemini = []
+anthropic = []
 
 [dependencies]
 thiserror = "2"

--- a/sdks/rust/crates/motosan-ai-oauth/Cargo.toml
+++ b/sdks/rust/crates/motosan-ai-oauth/Cargo.toml
@@ -34,3 +34,4 @@ tokio = { version = "1", features = [
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
+mockito = "1"

--- a/sdks/rust/crates/motosan-ai-oauth/Cargo.toml
+++ b/sdks/rust/crates/motosan-ai-oauth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai-oauth"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/crates/motosan-ai-oauth/src/exchange.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/exchange.rs
@@ -137,6 +137,7 @@ mod tests {
             redirect_uri_host: "127.0.0.1",
             token_body: TokenBodyFormat::Form,
             extra_auth_params: &[],
+            state_strategy: crate::StateStrategy::Random,
         };
         let token = exchange_code(&cfg, "AUTHCODE", "VERIFIER", "http://127.0.0.1/cb")
             .await
@@ -175,6 +176,7 @@ mod tests {
             redirect_uri_host: "127.0.0.1",
             token_body: TokenBodyFormat::Json,
             extra_auth_params: &[],
+            state_strategy: crate::StateStrategy::Random,
         };
         let token = exchange_code(&cfg, "AUTHCODE", "VERIFIER", "http://127.0.0.1/cb")
             .await

--- a/sdks/rust/crates/motosan-ai-oauth/src/exchange.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/exchange.rs
@@ -31,16 +31,24 @@ impl RawTokenResponse {
 
 async fn post_token(
     token_url: &str,
+    body_format: crate::TokenBodyFormat,
     params: Vec<(&str, &str)>,
     fallback_refresh: Option<&str>,
 ) -> Result<Token, Error> {
     let client = reqwest::Client::new();
-    let resp = client
+    let req = client
         .post(token_url)
-        .header("User-Agent", "Mozilla/5.0 (compatible; motosan-ai-oauth)")
-        .form(&params)
-        .send()
-        .await?;
+        .header("User-Agent", "Mozilla/5.0 (compatible; motosan-ai-oauth)");
+
+    let req = match body_format {
+        crate::TokenBodyFormat::Form => req.form(&params),
+        crate::TokenBodyFormat::Json => {
+            let map: std::collections::HashMap<&str, &str> = params.iter().copied().collect();
+            req.json(&map)
+        }
+    };
+
+    let resp = req.send().await?;
 
     if !resp.status().is_success() {
         let status = resp.status();
@@ -70,7 +78,7 @@ pub async fn exchange_code(
     if let Some(secret) = config.client_secret {
         params.push(("client_secret", secret));
     }
-    post_token(config.token_url, params, None).await
+    post_token(config.token_url, config.token_body, params, None).await
 }
 
 pub async fn refresh_token(config: &OAuthConfig, refresh_token: &str) -> Result<Token, Error> {
@@ -82,5 +90,96 @@ pub async fn refresh_token(config: &OAuthConfig, refresh_token: &str) -> Result<
     if let Some(secret) = config.client_secret {
         params.push(("client_secret", secret));
     }
-    post_token(config.token_url, params, Some(refresh_token)).await
+    post_token(
+        config.token_url,
+        config.token_body,
+        params,
+        Some(refresh_token),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TokenBodyFormat;
+    use mockito::Matcher;
+
+    #[tokio::test]
+    async fn exchange_code_sends_form_body_when_format_is_form() {
+        let mut server = mockito::Server::new_async().await;
+        let token_url: &'static str = Box::leak(format!("{}/token", server.url()).into_boxed_str());
+
+        let mock = server
+            .mock("POST", "/token")
+            .match_header(
+                "content-type",
+                Matcher::Regex("application/x-www-form-urlencoded".into()),
+            )
+            .match_body(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("grant_type".into(), "authorization_code".into()),
+                Matcher::UrlEncoded("code".into(), "AUTHCODE".into()),
+                Matcher::UrlEncoded("client_id".into(), "test-client".into()),
+            ]))
+            .with_status(200)
+            .with_body(r#"{"access_token":"AT","refresh_token":"RT","expires_in":3600}"#)
+            .create_async()
+            .await;
+
+        let cfg = crate::OAuthConfig {
+            client_id: "test-client",
+            client_secret: None,
+            auth_url: "https://unused/",
+            token_url,
+            scopes: &[],
+            redirect_port: None,
+            callback_path: "/auth/callback",
+            redirect_uri_host: "127.0.0.1",
+            token_body: TokenBodyFormat::Form,
+            extra_auth_params: &[],
+        };
+        let token = exchange_code(&cfg, "AUTHCODE", "VERIFIER", "http://127.0.0.1/cb")
+            .await
+            .expect("ok");
+        assert_eq!(token.access_token, "AT");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn exchange_code_sends_json_body_when_format_is_json() {
+        let mut server = mockito::Server::new_async().await;
+        let token_url: &'static str = Box::leak(format!("{}/token", server.url()).into_boxed_str());
+
+        let mock = server
+            .mock("POST", "/token")
+            .match_header("content-type", Matcher::Regex("application/json".into()))
+            // Matcher::JsonString compares parsed JSON, so key order in the
+            // serialized HashMap does not matter.
+            .match_body(Matcher::JsonString(
+                r#"{"grant_type":"authorization_code","code":"AUTHCODE","redirect_uri":"http://127.0.0.1/cb","code_verifier":"VERIFIER","client_id":"test-client"}"#
+                .into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"access_token":"AT","refresh_token":"RT","expires_in":3600}"#)
+            .create_async()
+            .await;
+
+        let cfg = crate::OAuthConfig {
+            client_id: "test-client",
+            client_secret: None,
+            auth_url: "https://unused/",
+            token_url,
+            scopes: &[],
+            redirect_port: None,
+            callback_path: "/auth/callback",
+            redirect_uri_host: "127.0.0.1",
+            token_body: TokenBodyFormat::Json,
+            extra_auth_params: &[],
+        };
+        let token = exchange_code(&cfg, "AUTHCODE", "VERIFIER", "http://127.0.0.1/cb")
+            .await
+            .expect("ok");
+        assert_eq!(token.access_token, "AT");
+        mock.assert_async().await;
+    }
 }

--- a/sdks/rust/crates/motosan-ai-oauth/src/exchange.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/exchange.rs
@@ -36,9 +36,10 @@ async fn post_token(
     fallback_refresh: Option<&str>,
 ) -> Result<Token, Error> {
     let client = reqwest::Client::new();
-    let req = client
-        .post(token_url)
-        .header("User-Agent", "Mozilla/5.0 (compatible; motosan-ai-oauth)");
+    // No custom User-Agent override — reqwest's default is safer than a
+    // "Mozilla/5.0..." string (which can look like a bot to anti-abuse
+    // systems). Accept: application/json matches pi-ai's reference impl.
+    let req = client.post(token_url).header("Accept", "application/json");
 
     let req = match body_format {
         crate::TokenBodyFormat::Form => req.form(&params),
@@ -65,12 +66,19 @@ async fn post_token(
 pub async fn exchange_code(
     config: &OAuthConfig,
     code: &str,
+    state: &str,
     verifier: &str,
     redirect_uri: &str,
 ) -> Result<Token, Error> {
+    // We include `state` in the token POST body to match pi-ai's reference
+    // implementation against Anthropic. Standard OAuth (RFC 6749 §4.1.3)
+    // does not require `state` on the token endpoint — most servers ignore
+    // extra fields — but Anthropic appears to validate it. Codex/Gemini
+    // tolerate the extra field.
     let mut params = vec![
         ("grant_type", "authorization_code"),
         ("code", code),
+        ("state", state),
         ("redirect_uri", redirect_uri),
         ("code_verifier", verifier),
         ("client_id", config.client_id),
@@ -119,6 +127,7 @@ mod tests {
             .match_body(Matcher::AllOf(vec![
                 Matcher::UrlEncoded("grant_type".into(), "authorization_code".into()),
                 Matcher::UrlEncoded("code".into(), "AUTHCODE".into()),
+                Matcher::UrlEncoded("state".into(), "STATE".into()),
                 Matcher::UrlEncoded("client_id".into(), "test-client".into()),
             ]))
             .with_status(200)
@@ -139,7 +148,7 @@ mod tests {
             extra_auth_params: &[],
             state_strategy: crate::StateStrategy::Random,
         };
-        let token = exchange_code(&cfg, "AUTHCODE", "VERIFIER", "http://127.0.0.1/cb")
+        let token = exchange_code(&cfg, "AUTHCODE", "STATE", "VERIFIER", "http://127.0.0.1/cb")
             .await
             .expect("ok");
         assert_eq!(token.access_token, "AT");
@@ -157,7 +166,7 @@ mod tests {
             // Matcher::JsonString compares parsed JSON, so key order in the
             // serialized HashMap does not matter.
             .match_body(Matcher::JsonString(
-                r#"{"grant_type":"authorization_code","code":"AUTHCODE","redirect_uri":"http://127.0.0.1/cb","code_verifier":"VERIFIER","client_id":"test-client"}"#
+                r#"{"grant_type":"authorization_code","code":"AUTHCODE","state":"STATE","redirect_uri":"http://127.0.0.1/cb","code_verifier":"VERIFIER","client_id":"test-client"}"#
                 .into(),
             ))
             .with_status(200)
@@ -178,7 +187,7 @@ mod tests {
             extra_auth_params: &[],
             state_strategy: crate::StateStrategy::Random,
         };
-        let token = exchange_code(&cfg, "AUTHCODE", "VERIFIER", "http://127.0.0.1/cb")
+        let token = exchange_code(&cfg, "AUTHCODE", "STATE", "VERIFIER", "http://127.0.0.1/cb")
             .await
             .expect("ok");
         assert_eq!(token.access_token, "AT");

--- a/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
@@ -25,6 +25,7 @@ pub struct OAuthConfig {
     pub token_url: &'static str,
     pub scopes: &'static [&'static str],
     pub redirect_port: Option<u16>,
+    pub callback_path: &'static str,
     pub redirect_uri_host: &'static str,
     pub extra_auth_params: &'static [(&'static str, &'static str)],
 }
@@ -52,11 +53,8 @@ pub async fn login(config: &OAuthConfig) -> Result<Token, Error> {
     let state = URL_SAFE_NO_PAD.encode(state_bytes);
 
     let server = server::bind(config.redirect_port).await?;
-    let redirect_uri = build_redirect_uri(
-        config.redirect_uri_host,
-        server.port,
-        "/auth/callback", // Task 3 will replace this with config.callback_path
-    );
+    let redirect_uri =
+        build_redirect_uri(config.redirect_uri_host, server.port, config.callback_path);
 
     let auth_url = build_auth_url(config, &pkce.challenge, &state, &redirect_uri);
 
@@ -65,7 +63,7 @@ pub async fn login(config: &OAuthConfig) -> Result<Token, Error> {
 
     let (code, returned_state) = tokio::time::timeout(
         std::time::Duration::from_secs(LOGIN_TIMEOUT_SECS),
-        server::wait_for_callback(server),
+        server::wait_for_callback(server, config.callback_path),
     )
     .await
     .map_err(|_| {
@@ -143,6 +141,7 @@ mod tests {
             token_url: "https://auth.example.com/oauth/token",
             scopes: &["openid", "profile"],
             redirect_port: None,
+            callback_path: "/auth/callback",
             redirect_uri_host: "127.0.0.1",
             extra_auth_params: &[],
         }

--- a/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
@@ -98,7 +98,7 @@ pub async fn login(config: &OAuthConfig) -> Result<Token, Error> {
         return Err(Error::StateMismatch);
     }
 
-    exchange::exchange_code(config, &code, &pkce.verifier, &redirect_uri).await
+    exchange::exchange_code(config, &code, &state, &pkce.verifier, &redirect_uri).await
 }
 
 pub async fn refresh(config: &OAuthConfig, refresh_token: &str) -> Result<Token, Error> {

--- a/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
@@ -11,6 +11,12 @@ use rand::RngCore as _;
 
 const LOGIN_TIMEOUT_SECS: u64 = 120;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenBodyFormat {
+    Form,
+    Json,
+}
+
 #[derive(Debug, Clone)]
 pub struct OAuthConfig {
     pub client_id: &'static str,
@@ -19,6 +25,7 @@ pub struct OAuthConfig {
     pub token_url: &'static str,
     pub scopes: &'static [&'static str],
     pub redirect_port: Option<u16>,
+    pub extra_auth_params: &'static [(&'static str, &'static str)],
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -80,15 +87,19 @@ pub(crate) fn build_auth_url(
     redirect_uri: &str,
 ) -> String {
     let mut url = reqwest::Url::parse(config.auth_url).expect("auth_url must be valid");
-    url.query_pairs_mut()
-        .append_pair("client_id", config.client_id)
-        .append_pair("response_type", "code")
-        .append_pair("redirect_uri", redirect_uri)
-        .append_pair("scope", &config.scopes.join(" "))
-        .append_pair("state", state)
-        .append_pair("code_challenge", challenge)
-        .append_pair("code_challenge_method", "S256")
-        .append_pair("access_type", "offline");
+    {
+        let mut q = url.query_pairs_mut();
+        q.append_pair("client_id", config.client_id)
+            .append_pair("response_type", "code")
+            .append_pair("redirect_uri", redirect_uri)
+            .append_pair("scope", &config.scopes.join(" "))
+            .append_pair("state", state)
+            .append_pair("code_challenge", challenge)
+            .append_pair("code_challenge_method", "S256");
+        for (k, v) in config.extra_auth_params {
+            q.append_pair(k, v);
+        }
+    }
     url.to_string()
 }
 
@@ -123,6 +134,7 @@ mod tests {
             token_url: "https://auth.example.com/oauth/token",
             scopes: &["openid", "profile"],
             redirect_port: None,
+            extra_auth_params: &[],
         }
     }
 
@@ -156,6 +168,28 @@ mod tests {
         let config = dummy_config();
         let url = build_auth_url(&config, "c", "s", "http://127.0.0.1:1234/auth/callback");
         reqwest::Url::parse(&url).expect("auth URL must be valid");
+    }
+
+    #[test]
+    fn build_auth_url_appends_extra_auth_params() {
+        let config = OAuthConfig {
+            extra_auth_params: &[("foo", "bar"), ("baz", "qux")],
+            ..dummy_config()
+        };
+        let url = build_auth_url(&config, "c", "s", "http://127.0.0.1:1234/auth/callback");
+        assert!(url.contains("foo=bar"));
+        assert!(url.contains("baz=qux"));
+    }
+
+    #[test]
+    fn build_auth_url_no_longer_hardcodes_access_type() {
+        // Empty extra_auth_params should produce no access_type query pair.
+        let config = OAuthConfig {
+            extra_auth_params: &[],
+            ..dummy_config()
+        };
+        let url = build_auth_url(&config, "c", "s", "http://127.0.0.1:1234/auth/callback");
+        assert!(!url.contains("access_type="));
     }
 
     #[test]

--- a/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
@@ -27,6 +27,7 @@ pub struct OAuthConfig {
     pub redirect_port: Option<u16>,
     pub callback_path: &'static str,
     pub redirect_uri_host: &'static str,
+    pub token_body: TokenBodyFormat,
     pub extra_auth_params: &'static [(&'static str, &'static str)],
 }
 
@@ -143,6 +144,7 @@ mod tests {
             redirect_port: None,
             callback_path: "/auth/callback",
             redirect_uri_host: "127.0.0.1",
+            token_body: TokenBodyFormat::Form,
             extra_auth_params: &[],
         }
     }

--- a/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
@@ -17,6 +17,21 @@ pub enum TokenBodyFormat {
     Json,
 }
 
+/// How to derive the OAuth `state` CSRF nonce.
+///
+/// Most servers treat `state` as opaque and echo it back unchanged. Anthropic's
+/// `claude.ai/oauth/authorize` endpoint empirically rejects random `state`
+/// values with "Invalid request format"; setting `state` equal to the PKCE
+/// verifier (as the Claude Code CLI and `@earendil-works/pi-ai` both do) is
+/// accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateStrategy {
+    /// Generate a fresh random 16-byte base64url value. Standard OAuth.
+    Random,
+    /// Reuse the PKCE verifier as the state nonce. Required for Anthropic.
+    EqualsVerifier,
+}
+
 #[derive(Debug, Clone)]
 pub struct OAuthConfig {
     pub client_id: &'static str,
@@ -29,6 +44,7 @@ pub struct OAuthConfig {
     pub redirect_uri_host: &'static str,
     pub token_body: TokenBodyFormat,
     pub extra_auth_params: &'static [(&'static str, &'static str)],
+    pub state_strategy: StateStrategy,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -49,9 +65,14 @@ impl Token {
 pub async fn login(config: &OAuthConfig) -> Result<Token, Error> {
     let pkce = pkce::Pkce::generate();
 
-    let mut state_bytes = [0u8; 16];
-    rand::rng().fill_bytes(&mut state_bytes);
-    let state = URL_SAFE_NO_PAD.encode(state_bytes);
+    let state = match config.state_strategy {
+        StateStrategy::Random => {
+            let mut state_bytes = [0u8; 16];
+            rand::rng().fill_bytes(&mut state_bytes);
+            URL_SAFE_NO_PAD.encode(state_bytes)
+        }
+        StateStrategy::EqualsVerifier => pkce.verifier.clone(),
+    };
 
     let server = server::bind(config.redirect_port).await?;
     let redirect_uri =
@@ -146,6 +167,7 @@ mod tests {
             redirect_uri_host: "127.0.0.1",
             token_body: TokenBodyFormat::Form,
             extra_auth_params: &[],
+            state_strategy: StateStrategy::Random,
         }
     }
 

--- a/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/lib.rs
@@ -25,6 +25,7 @@ pub struct OAuthConfig {
     pub token_url: &'static str,
     pub scopes: &'static [&'static str],
     pub redirect_port: Option<u16>,
+    pub redirect_uri_host: &'static str,
     pub extra_auth_params: &'static [(&'static str, &'static str)],
 }
 
@@ -51,7 +52,11 @@ pub async fn login(config: &OAuthConfig) -> Result<Token, Error> {
     let state = URL_SAFE_NO_PAD.encode(state_bytes);
 
     let server = server::bind(config.redirect_port).await?;
-    let redirect_uri = format!("http://127.0.0.1:{}/auth/callback", server.port);
+    let redirect_uri = build_redirect_uri(
+        config.redirect_uri_host,
+        server.port,
+        "/auth/callback", // Task 3 will replace this with config.callback_path
+    );
 
     let auth_url = build_auth_url(config, &pkce.challenge, &state, &redirect_uri);
 
@@ -78,6 +83,10 @@ pub async fn login(config: &OAuthConfig) -> Result<Token, Error> {
 
 pub async fn refresh(config: &OAuthConfig, refresh_token: &str) -> Result<Token, Error> {
     exchange::refresh_token(config, refresh_token).await
+}
+
+pub(crate) fn build_redirect_uri(host: &str, port: u16, path: &str) -> String {
+    format!("http://{host}:{port}{path}")
 }
 
 pub(crate) fn build_auth_url(
@@ -134,6 +143,7 @@ mod tests {
             token_url: "https://auth.example.com/oauth/token",
             scopes: &["openid", "profile"],
             redirect_port: None,
+            redirect_uri_host: "127.0.0.1",
             extra_auth_params: &[],
         }
     }
@@ -190,6 +200,17 @@ mod tests {
         };
         let url = build_auth_url(&config, "c", "s", "http://127.0.0.1:1234/auth/callback");
         assert!(!url.contains("access_type="));
+    }
+
+    #[test]
+    fn build_auth_url_uses_redirect_uri_host_in_uri() {
+        // The redirect_uri is built by login(); we test the helper that constructs it.
+        // The host substring comes from config.redirect_uri_host, not from the bind addr.
+        let uri = build_redirect_uri("localhost", 53692, "/callback");
+        assert_eq!(uri, "http://localhost:53692/callback");
+
+        let uri = build_redirect_uri("127.0.0.1", 1455, "/auth/callback");
+        assert_eq!(uri, "http://127.0.0.1:1455/auth/callback");
     }
 
     #[test]

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/anthropic.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/anthropic.rs
@@ -6,7 +6,7 @@
 //! client_id as a public app registration for third-party use — see the ToS
 //! disclosure in the top-level README.
 
-use crate::{OAuthConfig, TokenBodyFormat};
+use crate::{OAuthConfig, StateStrategy, TokenBodyFormat};
 
 pub fn claude_pro_max() -> OAuthConfig {
     OAuthConfig {
@@ -27,6 +27,10 @@ pub fn claude_pro_max() -> OAuthConfig {
         redirect_uri_host: "localhost",
         token_body: TokenBodyFormat::Json,
         extra_auth_params: &[("code", "true")],
+        // Anthropic's auth endpoint rejects random `state` values with
+        // "Invalid request format"; mimicking Claude Code CLI's behavior of
+        // reusing the PKCE verifier as the state nonce is what works.
+        state_strategy: StateStrategy::EqualsVerifier,
     }
 }
 
@@ -84,5 +88,14 @@ mod tests {
     #[test]
     fn claude_pro_max_auth_url_is_claude_ai() {
         assert!(claude_pro_max().auth_url.contains("claude.ai"));
+    }
+
+    #[test]
+    fn claude_pro_max_state_strategy_is_equals_verifier() {
+        // Anthropic's auth endpoint rejects random state values.
+        assert_eq!(
+            claude_pro_max().state_strategy,
+            StateStrategy::EqualsVerifier
+        );
     }
 }

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/anthropic.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/anthropic.rs
@@ -1,0 +1,89 @@
+//! Anthropic Claude Pro/Max OAuth provider config.
+//!
+//! The `client_id` below is extracted from Anthropic's Claude Code CLI
+//! authentication flow; the same value is used by the reference
+//! implementation `@earendil-works/pi-ai`. Anthropic has not published this
+//! client_id as a public app registration for third-party use — see the ToS
+//! disclosure in the top-level README.
+
+use crate::{OAuthConfig, TokenBodyFormat};
+
+pub fn claude_pro_max() -> OAuthConfig {
+    OAuthConfig {
+        client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+        client_secret: None,
+        auth_url: "https://claude.ai/oauth/authorize",
+        token_url: "https://platform.claude.com/v1/oauth/token",
+        scopes: &[
+            "org:create_api_key",
+            "user:profile",
+            "user:inference",
+            "user:sessions:claude_code",
+            "user:mcp_servers",
+            "user:file_upload",
+        ],
+        redirect_port: Some(53692),
+        callback_path: "/callback",
+        redirect_uri_host: "localhost",
+        token_body: TokenBodyFormat::Json,
+        extra_auth_params: &[("code", "true")],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_pro_max_has_expected_client_id() {
+        assert_eq!(
+            claude_pro_max().client_id,
+            "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+        );
+    }
+
+    #[test]
+    fn claude_pro_max_has_no_client_secret() {
+        assert!(claude_pro_max().client_secret.is_none());
+    }
+
+    #[test]
+    fn claude_pro_max_redirect_port_is_53692() {
+        assert_eq!(claude_pro_max().redirect_port, Some(53692));
+    }
+
+    #[test]
+    fn claude_pro_max_callback_path_is_slash_callback() {
+        assert_eq!(claude_pro_max().callback_path, "/callback");
+    }
+
+    #[test]
+    fn claude_pro_max_redirect_uri_host_is_localhost() {
+        // Anthropic registers redirect_uri with literal "localhost", not "127.0.0.1".
+        assert_eq!(claude_pro_max().redirect_uri_host, "localhost");
+    }
+
+    #[test]
+    fn claude_pro_max_token_body_is_json() {
+        assert_eq!(claude_pro_max().token_body, TokenBodyFormat::Json);
+    }
+
+    #[test]
+    fn claude_pro_max_extra_auth_params_include_code_true() {
+        let params = claude_pro_max().extra_auth_params;
+        assert!(params.iter().any(|(k, v)| *k == "code" && *v == "true"));
+    }
+
+    #[test]
+    fn claude_pro_max_scopes_include_claude_code_session() {
+        assert!(claude_pro_max()
+            .scopes
+            .iter()
+            .any(|s| *s == "user:sessions:claude_code"));
+    }
+
+    #[test]
+    fn claude_pro_max_auth_url_is_claude_ai() {
+        assert!(claude_pro_max().auth_url.contains("claude.ai"));
+    }
+}

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/anthropic.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/anthropic.rs
@@ -78,8 +78,7 @@ mod tests {
     fn claude_pro_max_scopes_include_claude_code_session() {
         assert!(claude_pro_max()
             .scopes
-            .iter()
-            .any(|s| *s == "user:sessions:claude_code"));
+            .contains(&"user:sessions:claude_code"));
     }
 
     #[test]

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
@@ -1,4 +1,4 @@
-use crate::OAuthConfig;
+use crate::{OAuthConfig, TokenBodyFormat};
 
 pub fn codex() -> OAuthConfig {
     OAuthConfig {
@@ -10,6 +10,7 @@ pub fn codex() -> OAuthConfig {
         redirect_port: Some(1455),
         callback_path: "/auth/callback",
         redirect_uri_host: "127.0.0.1",
+        token_body: TokenBodyFormat::Form,
         extra_auth_params: &[("access_type", "offline")],
     }
 }

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
@@ -8,6 +8,7 @@ pub fn codex() -> OAuthConfig {
         token_url: "https://auth.openai.com/oauth/token",
         scopes: &["openid", "profile", "email", "offline_access"],
         redirect_port: Some(1455),
+        redirect_uri_host: "127.0.0.1",
         extra_auth_params: &[("access_type", "offline")],
     }
 }

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
@@ -8,6 +8,7 @@ pub fn codex() -> OAuthConfig {
         token_url: "https://auth.openai.com/oauth/token",
         scopes: &["openid", "profile", "email", "offline_access"],
         redirect_port: Some(1455),
+        callback_path: "/auth/callback",
         redirect_uri_host: "127.0.0.1",
         extra_auth_params: &[("access_type", "offline")],
     }

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
@@ -8,6 +8,7 @@ pub fn codex() -> OAuthConfig {
         token_url: "https://auth.openai.com/oauth/token",
         scopes: &["openid", "profile", "email", "offline_access"],
         redirect_port: Some(1455),
+        extra_auth_params: &[("access_type", "offline")],
     }
 }
 

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/codex.rs
@@ -1,4 +1,4 @@
-use crate::{OAuthConfig, TokenBodyFormat};
+use crate::{OAuthConfig, StateStrategy, TokenBodyFormat};
 
 pub fn codex() -> OAuthConfig {
     OAuthConfig {
@@ -12,6 +12,7 @@ pub fn codex() -> OAuthConfig {
         redirect_uri_host: "127.0.0.1",
         token_body: TokenBodyFormat::Form,
         extra_auth_params: &[("access_type", "offline")],
+        state_strategy: StateStrategy::Random,
     }
 }
 

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
@@ -20,6 +20,7 @@ pub fn gemini() -> OAuthConfig {
             "https://www.googleapis.com/auth/userinfo.profile",
         ],
         redirect_port: None,
+        extra_auth_params: &[("access_type", "offline")],
     }
 }
 

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
@@ -6,7 +6,7 @@
 //! installed apps, these values are intentionally distributed in client software and are
 //! not treated as confidential — embedding them in source code is the documented practice.
 
-use crate::OAuthConfig;
+use crate::{OAuthConfig, TokenBodyFormat};
 
 pub fn gemini() -> OAuthConfig {
     OAuthConfig {
@@ -22,6 +22,7 @@ pub fn gemini() -> OAuthConfig {
         redirect_port: None,
         callback_path: "/auth/callback",
         redirect_uri_host: "127.0.0.1",
+        token_body: TokenBodyFormat::Form,
         extra_auth_params: &[("access_type", "offline")],
     }
 }

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
@@ -6,7 +6,7 @@
 //! installed apps, these values are intentionally distributed in client software and are
 //! not treated as confidential — embedding them in source code is the documented practice.
 
-use crate::{OAuthConfig, TokenBodyFormat};
+use crate::{OAuthConfig, StateStrategy, TokenBodyFormat};
 
 pub fn gemini() -> OAuthConfig {
     OAuthConfig {
@@ -23,6 +23,7 @@ pub fn gemini() -> OAuthConfig {
         callback_path: "/auth/callback",
         redirect_uri_host: "127.0.0.1",
         token_body: TokenBodyFormat::Form,
+        state_strategy: StateStrategy::Random,
         extra_auth_params: &[("access_type", "offline")],
     }
 }

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
@@ -20,6 +20,7 @@ pub fn gemini() -> OAuthConfig {
             "https://www.googleapis.com/auth/userinfo.profile",
         ],
         redirect_port: None,
+        callback_path: "/auth/callback",
         redirect_uri_host: "127.0.0.1",
         extra_auth_params: &[("access_type", "offline")],
     }

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/gemini.rs
@@ -20,6 +20,7 @@ pub fn gemini() -> OAuthConfig {
             "https://www.googleapis.com/auth/userinfo.profile",
         ],
         redirect_port: None,
+        redirect_uri_host: "127.0.0.1",
         extra_auth_params: &[("access_type", "offline")],
     }
 }

--- a/sdks/rust/crates/motosan-ai-oauth/src/providers/mod.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/providers/mod.rs
@@ -3,3 +3,6 @@ pub mod codex;
 
 #[cfg(feature = "gemini")]
 pub mod gemini;
+
+#[cfg(feature = "anthropic")]
+pub mod anthropic;

--- a/sdks/rust/crates/motosan-ai-oauth/src/server.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/server.rs
@@ -34,14 +34,17 @@ pub async fn bind(port: Option<u16>) -> Result<BoundServer, Error> {
 
 /// Wait for one /auth/callback?code=...&state=... request.
 /// Returns (code, state). Ignores other requests (e.g. favicon).
-pub async fn wait_for_callback(server: BoundServer) -> Result<(String, String), Error> {
+pub async fn wait_for_callback(
+    server: BoundServer,
+    callback_path: &str,
+) -> Result<(String, String), Error> {
     let BoundServer { listener, .. } = server;
     loop {
         let (mut stream, _) = listener.accept().await?;
         let buf = read_headers(&mut stream).await?;
         let request = String::from_utf8_lossy(&buf);
 
-        if !is_callback_request(&request) {
+        if !is_callback_request(&request, callback_path) {
             let _ = stream
                 .write_all(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
                 .await;
@@ -78,7 +81,7 @@ async fn read_headers(stream: &mut tokio::net::TcpStream) -> Result<Vec<u8>, Err
     Ok(buf)
 }
 
-fn is_callback_request(request: &str) -> bool {
+fn is_callback_request(request: &str, callback_path: &str) -> bool {
     let path = request
         .lines()
         .next()
@@ -86,7 +89,7 @@ fn is_callback_request(request: &str) -> bool {
         .split_whitespace()
         .nth(1)
         .unwrap_or("");
-    path.starts_with("/auth/callback") && path.contains("code=")
+    path.starts_with(callback_path) && path.contains("code=")
 }
 
 fn parse_callback(request: &str) -> Result<(String, String), Error> {
@@ -165,15 +168,33 @@ mod tests {
 
     #[test]
     fn non_callback_path_is_not_callback() {
-        assert!(!is_callback_request(&get("/favicon.ico")));
-        assert!(!is_callback_request(&get("/")));
+        assert!(!is_callback_request(&get("/favicon.ico"), "/auth/callback"));
+        assert!(!is_callback_request(&get("/"), "/auth/callback"));
     }
 
     #[test]
     fn callback_path_with_code_is_callback() {
-        assert!(is_callback_request(&get(
-            "/auth/callback?code=abc&state=xyz"
-        )));
+        assert!(is_callback_request(
+            &get("/auth/callback?code=abc&state=xyz"),
+            "/auth/callback"
+        ));
+    }
+
+    #[test]
+    fn anthropic_callback_path_is_callback() {
+        assert!(is_callback_request(
+            &get("/callback?code=abc&state=xyz"),
+            "/callback"
+        ));
+    }
+
+    #[test]
+    fn auth_callback_path_does_not_match_anthropic_request() {
+        // A request to /callback must not be accepted when callback_path is /auth/callback.
+        assert!(!is_callback_request(
+            &get("/callback?code=abc&state=xyz"),
+            "/auth/callback"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- New `anthropic-oauth` crate: PKCE login + refresh against `claude.ai`, returns a `sk-ant-oat01-*` token usable directly with the existing `AnthropicProvider`.
- `motosan-ai-oauth` v0.2.0: `OAuthConfig` gained `callback_path`, `redirect_uri_host`, `token_body`, `extra_auth_params`, and `state_strategy` fields plus `TokenBodyFormat` and `StateStrategy` enums so Anthropic's quirks (callback at `/callback`, `redirect_uri` host string `localhost`, JSON token body, `code=true` auth param, `state == verifier`, `state` echoed in token POST body) are expressed declaratively. **Breaking** for out-of-tree consumers constructing `OAuthConfig` literals.
- `codex-oauth` v0.1.1: source-only follow-up to fill the new `OAuthConfig` fields with values preserving current behavior.

Spec: `docs/superpowers/specs/2026-05-18-anthropic-oauth-design.md`
Plan: `docs/superpowers/plans/2026-05-18-anthropic-oauth.md`

⚠️ The README adds an explicit ToS disclosure: the `client_id` is extracted from Claude Code CLI; Anthropic has not published it for third-party use.

## Test plan
- [x] CI green: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace --all-features`
- [x] Existing tests untouched in assertions: `motosan-ai-oauth`, `codex-oauth`, `sdks/rust/tests/anthropic_oauth_usage.rs`
- [x] New tests pass: `build_auth_url_appends_extra_auth_params`, `*_callback_path_*`, `exchange_code_sends_{form,json}_body_*`, all `providers::anthropic::tests::*`, `refresh_posts_json_body_*`
- [x] Live test passed locally: `cargo test -p anthropic-oauth --test login_live -- --ignored` returned a `sk-ant-oat01-` token. See PR comment for the two post-spec fixes that were required during live validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
