### PR TITLE
feat(rust): v0.15.4 - Anthropic streaming thinking events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.15.3 (crates.io) · Python v0.12.0 (PyPI)
+Rust v0.15.4 (crates.io) · Python v0.12.0 (PyPI)
 
 ## Where To Find Things
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.12.0 · Rust 0.15.3
+- Python 0.12.0 · Rust 0.15.4
 - GitHub: https://github.com/motosan-dev/motosan-ai
 - PyPI: https://pypi.org/project/motosan-ai/
 - crates.io: https://crates.io/crates/motosan-ai
@@ -19,7 +19,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.15.3", features = ["anthropic"] }
+motosan-ai = { version = "0.15.4", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient):
@@ -262,6 +262,9 @@ while let Some(event) = stream.next().await {
         StreamEventType::ToolCallStart => { /* event.tool_call_id, event.tool_call_name */ },
         StreamEventType::ToolCallArgs  => { /* event.tool_call_args_delta */ },
         StreamEventType::ToolCallEnd   => { /* tool call complete */ },
+        StreamEventType::Usage         => { /* event.usage */ },
+        StreamEventType::ThinkingDelta => { /* live extended-thinking chunk (Anthropic only) */ },
+        StreamEventType::ThinkingDone  => { /* full thinking text on block close (Anthropic only) */ },
     }
     if event.done { break; }
 }

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
+## [0.15.4] - 2026-05-23
+
+### Added
+
+- **`StreamEventType::ThinkingDelta` and `StreamEventType::ThinkingDone`** plus matching `StreamEvent::thinking_delta(...)` / `StreamEvent::thinking_done(...)` constructors. (`sdks/rust/src/types.rs`.) Variant count goes 5 → 7. **Wire-breaking** for any downstream that does an exhaustive `match event.event_type { ... }` on `StreamEventType` without a `_ =>` arm; internal `collect_stream` and `codex_cli` test updated. Pre-1.0 we ship as patch.
+- **Anthropic streaming thinking support.** `AnthropicStreamAdapter` (`sdks/rust/src/providers/anthropic.rs`) gains a `current_thinking_buf: Option<String>` accumulator. `content_block_start { type: "thinking" }` opens it. `content_block_delta { type: "thinking_delta", thinking: "..." }` accumulates the text **from `delta.thinking`** (a previous bug-by-omission read `delta.text` and silently dropped these) and emits `StreamEvent::thinking_delta`. `content_block_stop` for a thinking block emits `StreamEvent::thinking_done` carrying the full concatenated text and clears the accumulator. `signature_delta` and `redacted_thinking` blocks are silently consumed — no streaming surface for cryptographic re-feed signatures or redacted content, matching the non-streaming `ChatResponse.thinking` field's shape.
+- **`collect_stream` populates `ChatResponse.thinking`** from accumulated `ThinkingDelta`s, preferring `ThinkingDone`'s authoritative payload when present. Streaming and non-streaming Anthropic responses now produce the same `ChatResponse.thinking: Option<String>` shape. (`sdks/rust/src/stream.rs`.)
+
+### Notes
+
+- Fourteen new tests across `types.rs`, `tests/anthropic_stream.rs`, and `src/stream.rs` lock the behavior in: variant existence + serde round-trip; constructor field shape; SSE → event mapping for thinking-only / thinking-then-text / redacted_thinking / orphan-delta / signature-delta cases; collect_stream accumulation including the `ThinkingDelta`-without-`ThinkingDone` fallback path.
+- New `#[ignore]`'d live test `live_anthropic_streaming_thinking_emits_thinking_events` in `tests/anthropic_live.rs` hits the real API with `thinking(4000)` and asserts stream terminates, ThinkingDelta count > 0, ThinkingDone non-empty, answer non-empty, no content leak.
+- Python SDK unchanged — Anthropic streaming thinking on the Python side is a separate plan (per `CLAUDE.md` "No FFI or shared code between SDKs"). Other providers (OpenAI, Gemini, MiniMax, Ollama, Codex CLI, Claude Code CLI) do not emit `StreamEventType::ThinkingDelta`/`ThinkingDone` — only Anthropic currently has a wire format for streaming extended thinking.
+
+### Consumer impact
+
+- Unblocks `motosan-agent-loop` v0.21.4's `TODO(thinking-stream)` markers at `src/motosan_ai_impl.rs:171` and `:346` — once that crate bumps its `motosan-ai` dep to `^0.15.4` and wires the two new arms, `CoreEvent::ThinkingChunk`/`ThinkingDone` will flow end-to-end from Anthropic SSE to consumers (capo TUI).
+
 ## [0.15.3] - 2026-05-17
 
 ### Fixed

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1007,6 +1007,31 @@ impl Stream for AnthropicStreamAdapter {
                                     }
                                     continue;
                                 }
+                                Some("thinking_delta") => {
+                                    // The thinking text lives in `delta.thinking`,
+                                    // NOT `delta.text`. Accumulate into the buffer
+                                    // (so content_block_stop can emit ThinkingDone
+                                    // with the full text in Task 4) and forward as
+                                    // a ThinkingDelta event.
+                                    let text = delta
+                                        .get("thinking")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or_default();
+                                    if text.is_empty() {
+                                        continue;
+                                    }
+                                    if let Some(buf) = self.current_thinking_buf.as_mut() {
+                                        buf.push_str(text);
+                                    }
+                                    return Poll::Ready(Some(StreamEvent::thinking_delta(text)));
+                                }
+                                Some("signature_delta") => {
+                                    // Cryptographic signature for re-feeding thinking
+                                    // blocks. Not surfaced in the streaming API (the
+                                    // non-streaming ChatResponse.thinking field is
+                                    // also signature-less). Silently consume.
+                                    continue;
+                                }
                                 _ => {
                                     // text_delta or untyped delta with "text" field
                                     let text = delta

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -811,6 +811,7 @@ impl ProviderImpl for AnthropicProvider {
             pending: std::collections::VecDeque::new(),
             current_tool_id: None,
             current_stop_reason: None,
+            current_thinking_buf: None,
         };
 
         Ok(Box::pin(adapter))
@@ -835,6 +836,17 @@ struct AnthropicStreamAdapter {
     /// terminal `message_stop` event so callers see the reason in the
     /// final `done` `StreamEvent`.
     current_stop_reason: Option<crate::types::StopReason>,
+    /// Accumulator for the in-flight thinking block, if any.
+    ///
+    /// - `None` = not currently inside a `thinking` content block.
+    /// - `Some(buf)` = open thinking block; each `thinking_delta` appends
+    ///   to `buf`, and `content_block_stop` emits a `ThinkingDone` event
+    ///   carrying `buf.clone()` and resets to `None`.
+    ///
+    /// `redacted_thinking` blocks are silently consumed and do **not**
+    /// open this accumulator (we don't surface redacted content as
+    /// thinking deltas).
+    current_thinking_buf: Option<String>,
 }
 
 impl Stream for AnthropicStreamAdapter {
@@ -938,17 +950,37 @@ impl Stream for AnthropicStreamAdapter {
                         "content_block_start" => {
                             let block = payload.get("content_block");
                             if let Some(block) = block {
-                                if block.get("type").and_then(Value::as_str) == Some("tool_use") {
-                                    let id =
-                                        block.get("id").and_then(Value::as_str).unwrap_or_default();
-                                    let name = block
-                                        .get("name")
-                                        .and_then(Value::as_str)
-                                        .unwrap_or_default();
-                                    self.current_tool_id = Some(id.to_string());
-                                    return Poll::Ready(Some(StreamEvent::tool_call_start(
-                                        id, name,
-                                    )));
+                                let block_type =
+                                    block.get("type").and_then(Value::as_str).unwrap_or("");
+                                match block_type {
+                                    "tool_use" => {
+                                        let id = block
+                                            .get("id")
+                                            .and_then(Value::as_str)
+                                            .unwrap_or_default();
+                                        let name = block
+                                            .get("name")
+                                            .and_then(Value::as_str)
+                                            .unwrap_or_default();
+                                        self.current_tool_id = Some(id.to_string());
+                                        return Poll::Ready(Some(StreamEvent::tool_call_start(
+                                            id, name,
+                                        )));
+                                    }
+                                    "thinking" => {
+                                        // Open the thinking accumulator. Deltas append
+                                        // to it; content_block_stop emits ThinkingDone
+                                        // with the full text and clears it (Task 4).
+                                        // No event is emitted at start — the loop-side
+                                        // event protocol does not have a ThinkingStart.
+                                        self.current_thinking_buf = Some(String::new());
+                                    }
+                                    "redacted_thinking" => {
+                                        // Silently consume; we do not surface redacted
+                                        // content. The block_stop will be a no-op
+                                        // because current_thinking_buf stays None.
+                                    }
+                                    _ => {}
                                 }
                             }
                             continue;

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1049,6 +1049,16 @@ impl Stream for AnthropicStreamAdapter {
                             if let Some(id) = self.current_tool_id.take() {
                                 return Poll::Ready(Some(StreamEvent::tool_call_end_with_id(id)));
                             }
+                            if let Some(buf) = self.current_thinking_buf.take() {
+                                // Closing a thinking block: emit ThinkingDone with
+                                // the full concatenated text. Note we emit even if
+                                // buf is empty — consumers can distinguish "thinking
+                                // block existed but produced nothing" from "no
+                                // thinking block" by the presence/absence of the
+                                // event. This matches the contract documented on
+                                // StreamEventType::ThinkingDone.
+                                return Poll::Ready(Some(StreamEvent::thinking_done(buf)));
+                            }
                             continue;
                         }
                         "message_stop" => {

--- a/sdks/rust/src/stream.rs
+++ b/sdks/rust/src/stream.rs
@@ -40,6 +40,12 @@ pub async fn collect_stream(mut stream: BoxStream) -> crate::types::ChatResponse
     let mut cache_creation_input_tokens: Option<u32> = None;
     let mut cache_read_input_tokens: Option<u32> = None;
     let mut explicit_stop_reason: Option<StopReason> = None;
+    // Thinking accumulation. `thinking_delta_buf` collects every
+    // ThinkingDelta as a fallback in case the provider does not emit
+    // ThinkingDone. `thinking_done_buf` holds the explicit final text
+    // from the most recent ThinkingDone and takes priority on assembly.
+    let mut thinking_delta_buf = String::new();
+    let mut thinking_done_buf: Option<String> = None;
 
     while let Some(event) = stream.next().await {
         if event.done {
@@ -88,10 +94,16 @@ pub async fn collect_stream(mut stream: BoxStream) -> crate::types::ChatResponse
                 });
                 current_tc_args.clear();
             }
-            StreamEventType::ThinkingDelta | StreamEventType::ThinkingDone => {
-                // Placeholder; real handling lands in Task 6 of the
-                // anthropic-thinking-stream-events plan. Do not commit
-                // this past Task 6.
+            StreamEventType::ThinkingDelta => {
+                thinking_delta_buf.push_str(&event.content);
+            }
+            StreamEventType::ThinkingDone => {
+                // ThinkingDone carries the full text. Prefer it over the
+                // delta accumulator when available — the provider knows
+                // the authoritative concatenation. Also clear the delta
+                // buffer so a second thinking block starts fresh.
+                thinking_done_buf = Some(event.content.clone());
+                thinking_delta_buf.clear();
             }
         }
     }
@@ -102,9 +114,16 @@ pub async fn collect_stream(mut stream: BoxStream) -> crate::types::ChatResponse
         None => StopReason::ToolUse,
     };
 
+    let thinking = match thinking_done_buf {
+        Some(text) if !text.is_empty() => Some(text),
+        Some(_) => None, // explicit empty thinking block -> treat as none
+        None if !thinking_delta_buf.is_empty() => Some(thinking_delta_buf),
+        None => None,
+    };
+
     ChatResponse {
         content,
-        thinking: None,
+        thinking,
         model: String::new(),
         usage: Usage {
             input_tokens,
@@ -114,5 +133,65 @@ pub async fn collect_stream(mut stream: BoxStream) -> crate::types::ChatResponse
         },
         stop_reason,
         tool_calls,
+    }
+}
+
+#[cfg(test)]
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+))]
+mod thinking_collect_tests {
+    use super::*;
+    use crate::types::StreamEvent;
+    use tokio_stream::iter;
+
+    #[tokio::test]
+    async fn collect_stream_accumulates_thinking_into_response_thinking() {
+        let events = vec![
+            StreamEvent::thinking_delta("Let me "),
+            StreamEvent::thinking_delta("think..."),
+            StreamEvent::thinking_done("Let me think..."),
+            StreamEvent::text("Answer: "),
+            StreamEvent::text("42"),
+            StreamEvent::done(),
+        ];
+        let stream: BoxStream = Box::pin(iter(events));
+        let resp = collect_stream(stream).await;
+        assert_eq!(resp.content, "Answer: 42");
+        assert_eq!(
+            resp.thinking.as_deref(),
+            Some("Let me think..."),
+            "thinking field must come from ThinkingDone (or accumulated deltas if no Done)"
+        );
+    }
+
+    #[tokio::test]
+    async fn collect_stream_no_thinking_keeps_thinking_none() {
+        let events = vec![StreamEvent::text("hello"), StreamEvent::done()];
+        let stream: BoxStream = Box::pin(iter(events));
+        let resp = collect_stream(stream).await;
+        assert_eq!(resp.content, "hello");
+        assert!(resp.thinking.is_none());
+    }
+
+    #[tokio::test]
+    async fn collect_stream_falls_back_to_accumulated_deltas_if_no_done() {
+        // Defensive: if a provider somehow emits ThinkingDelta but skips
+        // ThinkingDone, collect_stream still produces a thinking field
+        // from the accumulated deltas.
+        let events = vec![
+            StreamEvent::thinking_delta("A "),
+            StreamEvent::thinking_delta("B"),
+            StreamEvent::text("ok"),
+            StreamEvent::done(),
+        ];
+        let stream: BoxStream = Box::pin(iter(events));
+        let resp = collect_stream(stream).await;
+        assert_eq!(resp.thinking.as_deref(), Some("A B"));
+        assert_eq!(resp.content, "ok");
     }
 }

--- a/sdks/rust/src/stream.rs
+++ b/sdks/rust/src/stream.rs
@@ -88,6 +88,11 @@ pub async fn collect_stream(mut stream: BoxStream) -> crate::types::ChatResponse
                 });
                 current_tc_args.clear();
             }
+            StreamEventType::ThinkingDelta | StreamEventType::ThinkingDone => {
+                // Placeholder; real handling lands in Task 6 of the
+                // anthropic-thinking-stream-events plan. Do not commit
+                // this past Task 6.
+            }
         }
     }
 

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -644,6 +644,40 @@ pub enum StreamEventType {
     ToolCallArgs,
     ToolCallEnd,
     Usage,
+    /// A partial extended-thinking delta from the LLM, emitted as the
+    /// model reasons before producing its final answer. The `content`
+    /// field of the parent [`StreamEvent`] carries the delta text.
+    /// Currently only the Anthropic provider emits this (sourced from
+    /// the SSE `content_block_delta { type: "thinking_delta" }` event).
+    /// Other providers never emit it. Consumers can render these live;
+    /// the high-level [`collect_stream`](crate::stream::collect_stream)
+    /// concatenates them into [`ChatResponse::thinking`].
+    ///
+    /// # Forward compatibility
+    ///
+    /// `StreamEventType` is intentionally not `#[non_exhaustive]` so
+    /// callers can rely on exhaustive matching for the current variants,
+    /// but the set may grow as more providers gain streaming-thinking
+    /// wire formats (e.g. signature/re-feed metadata, structured block
+    /// boundaries, per-block effort hints). New thinking-related variants
+    /// will be additive (`ThinkingSignature`, `ThinkingStart`, etc.) —
+    /// never repurposing `ThinkingDelta`/`ThinkingDone`. **Consumers that
+    /// match on `StreamEventType` should always include a `_ =>` arm**
+    /// so future patch releases adding new variants do not break their
+    /// build. The same rule applies to [`ThinkingDone`](Self::ThinkingDone).
+    ThinkingDelta,
+    /// Marks the end of a thinking content block, carrying the full
+    /// concatenated thinking text in the parent [`StreamEvent`]'s
+    /// `content` field. Always preceded by zero or more
+    /// [`ThinkingDelta`](Self::ThinkingDelta) events for the same block,
+    /// and always precedes any [`Text`](Self::Text) events for the
+    /// final answer. Sourced from Anthropic's `content_block_stop`
+    /// event when the corresponding `content_block_start` was a
+    /// `thinking` block.
+    ///
+    /// See [`ThinkingDelta`](Self::ThinkingDelta) for the forward-
+    /// compatibility contract (include `_ =>` when matching).
+    ThinkingDone,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -808,6 +842,41 @@ impl StreamEvent {
             tool_call_name: None,
             tool_call_args_delta: None,
             event_type: StreamEventType::ToolCallEnd,
+            usage: None,
+            stop_reason: None,
+        }
+    }
+
+    /// Build a `ThinkingDelta` event carrying a partial extended-thinking
+    /// text fragment. Used by the Anthropic stream adapter when it
+    /// receives a `content_block_delta { type: "thinking_delta" }` SSE
+    /// event. See [`StreamEventType::ThinkingDelta`].
+    pub fn thinking_delta(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            done: false,
+            tool_call_id: None,
+            tool_call_name: None,
+            tool_call_args_delta: None,
+            event_type: StreamEventType::ThinkingDelta,
+            usage: None,
+            stop_reason: None,
+        }
+    }
+
+    /// Build a `ThinkingDone` event carrying the full concatenated
+    /// thinking text for a just-closed thinking block. Used by the
+    /// Anthropic stream adapter on `content_block_stop` when the
+    /// corresponding `content_block_start` opened a `thinking` block.
+    /// See [`StreamEventType::ThinkingDone`].
+    pub fn thinking_done(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            done: false,
+            tool_call_id: None,
+            tool_call_name: None,
+            tool_call_args_delta: None,
+            event_type: StreamEventType::ThinkingDone,
             usage: None,
             stop_reason: None,
         }
@@ -1099,5 +1168,62 @@ mod capabilities_tests {
         let caps = ProviderCapabilities::full();
         assert!(caps.supports_image);
         assert!(caps.supports_document);
+    }
+}
+
+#[cfg(test)]
+mod stream_event_thinking_tests {
+    use super::*;
+
+    #[test]
+    fn stream_event_type_has_thinking_variants() {
+        // Compile-time exhaustive guard: any addition/removal will require updating.
+        let _all: [StreamEventType; 7] = [
+            StreamEventType::Text,
+            StreamEventType::ToolCallStart,
+            StreamEventType::ToolCallArgs,
+            StreamEventType::ToolCallEnd,
+            StreamEventType::Usage,
+            StreamEventType::ThinkingDelta,
+            StreamEventType::ThinkingDone,
+        ];
+    }
+
+    #[test]
+    fn stream_event_thinking_delta_constructor_sets_fields() {
+        let ev = StreamEvent::thinking_delta("Let me think...");
+        assert_eq!(ev.content, "Let me think...");
+        assert_eq!(ev.event_type, StreamEventType::ThinkingDelta);
+        assert!(!ev.done);
+        assert!(ev.tool_call_id.is_none());
+        assert!(ev.usage.is_none());
+        assert!(ev.stop_reason.is_none());
+    }
+
+    #[test]
+    fn stream_event_thinking_done_constructor_sets_fields() {
+        let ev = StreamEvent::thinking_done("complete thought");
+        assert_eq!(ev.content, "complete thought");
+        assert_eq!(ev.event_type, StreamEventType::ThinkingDone);
+        assert!(!ev.done);
+        assert!(ev.tool_call_id.is_none());
+        assert!(ev.usage.is_none());
+        assert!(ev.stop_reason.is_none());
+    }
+
+    #[test]
+    fn stream_event_type_thinking_delta_serializes_snake_case() {
+        let s = serde_json::to_string(&StreamEventType::ThinkingDelta).unwrap();
+        assert_eq!(s, "\"thinking_delta\"");
+        let d: StreamEventType = serde_json::from_str("\"thinking_delta\"").unwrap();
+        assert_eq!(d, StreamEventType::ThinkingDelta);
+    }
+
+    #[test]
+    fn stream_event_type_thinking_done_serializes_snake_case() {
+        let s = serde_json::to_string(&StreamEventType::ThinkingDone).unwrap();
+        assert_eq!(s, "\"thinking_done\"");
+        let d: StreamEventType = serde_json::from_str("\"thinking_done\"").unwrap();
+        assert_eq!(d, StreamEventType::ThinkingDone);
     }
 }

--- a/sdks/rust/tests/anthropic_live.rs
+++ b/sdks/rust/tests/anthropic_live.rs
@@ -389,3 +389,92 @@ async fn live_collect_stream_records_max_tokens_on_chat_response() {
 
     cooldown().await;
 }
+
+// ---------------------------------------------------------------------------
+// Live streaming-thinking test
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "live API; run with `cargo test -p motosan-ai --features anthropic --test anthropic_live live_anthropic_streaming_thinking_emits_thinking_events -- --ignored` and ANTHROPIC_API_KEY set"]
+async fn live_anthropic_streaming_thinking_emits_thinking_events() {
+    let api_key = match std::env::var("ANTHROPIC_API_KEY") {
+        Ok(k) if !k.is_empty() => k,
+        _ => {
+            eprintln!("skipping: ANTHROPIC_API_KEY not set");
+            return;
+        }
+    };
+
+    let client = Client::builder()
+        .provider(Provider::Anthropic)
+        .api_key(api_key)
+        .build()
+        .expect("client");
+
+    // Use a model + budget that reliably produces thinking output.
+    // claude-sonnet-4-5 with 4000 budget tokens is a known-good baseline;
+    // adjust if Anthropic deprecates it.
+    let req = ChatRequest::builder()
+        .model("claude-sonnet-4-5")
+        .message(Message::user(
+            "Think step-by-step about whether 17 is prime, then answer yes or no.",
+        ))
+        .thinking(4000)
+        .max_tokens(2048)
+        .build();
+
+    let mut stream = client.stream_with(req).await.expect("stream start");
+
+    let mut thinking_chunks = 0usize;
+    let mut thinking_done_text: Option<String> = None;
+    let mut answer = String::new();
+    let mut done_seen = false;
+
+    while let Some(ev) = stream.next().await {
+        if ev.done {
+            done_seen = true;
+            break;
+        }
+        match ev.event_type {
+            StreamEventType::ThinkingDelta => {
+                thinking_chunks += 1;
+            }
+            StreamEventType::ThinkingDone => {
+                thinking_done_text = Some(ev.content.clone());
+            }
+            StreamEventType::Text => {
+                answer.push_str(&ev.content);
+            }
+            _ => {}
+        }
+    }
+
+    assert!(done_seen, "stream must terminate with done");
+    assert!(
+        thinking_chunks > 0,
+        "Anthropic should have emitted at least one ThinkingDelta for a step-by-step prompt"
+    );
+    assert!(
+        thinking_done_text
+            .as_deref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        "ThinkingDone must carry the full concatenated thinking text"
+    );
+    assert!(
+        !answer.is_empty(),
+        "the model must produce a final answer after thinking"
+    );
+    // Sanity: thinking content should not leak into the answer.
+    if let Some(t) = thinking_done_text.as_deref() {
+        // First 30 chars of thinking should not appear verbatim in answer
+        // (loose check; thinking is reasoning, answer is conclusion).
+        let probe = t.chars().take(30).collect::<String>();
+        if !probe.is_empty() {
+            assert!(
+                !answer.contains(&probe),
+                "thinking content leaked into answer — bug in adapter"
+            );
+        }
+    }
+}

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -417,3 +417,56 @@ async fn anthropic_stream_propagates_unknown_stop_reason_as_other() {
     let done = anthropic_stream_with_message_delta_stop_reason("something_new").await;
     assert_eq!(done.stop_reason, Some(StopReason::Other));
 }
+
+#[tokio::test]
+async fn thinking_block_start_then_immediate_stop_emits_nothing_yet() {
+    // Pre-Task-3/4 state check: opening and immediately closing a thinking
+    // block with no deltas must not crash and must not leak any spurious
+    // events. After Task 4 the closing block will emit ThinkingDone(""),
+    // and this test will be updated then.
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"text\":\"ok\"}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+    let mut stream = provider.stream(request).await.expect("stream");
+
+    let mut text_seen = String::new();
+    let mut done_seen = false;
+    while let Some(ev) = stream.next().await {
+        if ev.done {
+            done_seen = true;
+            break;
+        }
+        if ev.event_type == StreamEventType::Text {
+            text_seen.push_str(&ev.content);
+        }
+    }
+
+    assert!(done_seen, "must terminate");
+    assert_eq!(
+        text_seen, "ok",
+        "text after the thinking block must survive"
+    );
+    mock.assert_async().await;
+}

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -639,3 +639,117 @@ async fn thinking_done_not_emitted_for_non_thinking_block_stop() {
     );
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn redacted_thinking_block_is_silently_consumed() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"redacted_thinking\",\"data\":\"encrypted_blob_xyz\"}}\n\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"text\":\"answer\"}}\n\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+    let mut stream = provider.stream(request).await.expect("stream");
+
+    let mut events: Vec<StreamEventType> = Vec::new();
+    let mut content = String::new();
+    let mut done_seen = false;
+    while let Some(ev) = stream.next().await {
+        if ev.done {
+            done_seen = true;
+            break;
+        }
+        events.push(ev.event_type.clone());
+        if ev.event_type == StreamEventType::Text {
+            content.push_str(&ev.content);
+        }
+    }
+
+    assert!(done_seen);
+    assert_eq!(content, "answer");
+    assert!(
+        !events.contains(&StreamEventType::ThinkingDelta),
+        "redacted_thinking must not produce ThinkingDelta events"
+    );
+    assert!(
+        !events.contains(&StreamEventType::ThinkingDone),
+        "redacted_thinking must not produce a ThinkingDone event"
+    );
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn orphan_thinking_delta_without_start_does_not_crash() {
+    // Malformed/unexpected stream: a thinking_delta arrives without a
+    // preceding content_block_start. Defensive Task-3 code emits the
+    // event without crashing or polluting the accumulator.
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"orphan\"}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+    let mut stream = provider.stream(request).await.expect("stream");
+
+    let mut saw_thinking_delta = false;
+    let mut saw_thinking_done = false;
+    let mut done_seen = false;
+    while let Some(ev) = stream.next().await {
+        if ev.done {
+            done_seen = true;
+            break;
+        }
+        match ev.event_type {
+            StreamEventType::ThinkingDelta => {
+                saw_thinking_delta = true;
+                assert_eq!(ev.content, "orphan");
+            }
+            StreamEventType::ThinkingDone => saw_thinking_done = true,
+            _ => {}
+        }
+    }
+
+    assert!(done_seen);
+    assert!(
+        saw_thinking_delta,
+        "orphan ThinkingDelta should still be emitted"
+    );
+    assert!(
+        !saw_thinking_done,
+        "no thinking block was opened or closed; no ThinkingDone expected"
+    );
+    mock.assert_async().await;
+}

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -520,3 +520,122 @@ async fn thinking_delta_events_emitted_in_order() {
     );
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn thinking_done_emitted_with_full_text_after_deltas() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"A \"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"B \"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"C\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"sig...\"}}\n\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"text\":\"answer\"}}\n\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+    let mut stream = provider.stream(request).await.expect("stream");
+
+    let mut labels: Vec<String> = Vec::new();
+    let mut done_seen = false;
+    while let Some(ev) = stream.next().await {
+        if ev.done {
+            done_seen = true;
+            break;
+        }
+        match ev.event_type {
+            StreamEventType::ThinkingDelta => labels.push(format!("td:{}", ev.content)),
+            StreamEventType::ThinkingDone => labels.push(format!("tD:{}", ev.content)),
+            StreamEventType::Text => labels.push(format!("t:{}", ev.content)),
+            _ => {}
+        }
+    }
+
+    assert!(done_seen, "stream must terminate");
+    assert_eq!(
+        labels,
+        vec![
+            "td:A ".to_string(),
+            "td:B ".to_string(),
+            "td:C".to_string(),
+            "tD:A B C".to_string(),
+            "t:answer".to_string(),
+        ],
+        "Per-turn order: ThinkingDelta* -> ThinkingDone(full) -> Text*"
+    );
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn thinking_done_not_emitted_for_non_thinking_block_stop() {
+    // Regression guard: a content_block_stop that closes a tool_use or
+    // text block must NOT emit a stray ThinkingDone. Only triggers when
+    // current_thinking_buf was Some.
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"text\":\"hi\"}}\n\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+    let mut stream = provider.stream(request).await.expect("stream");
+
+    let mut saw_thinking_done = false;
+    let mut done_seen = false;
+    while let Some(ev) = stream.next().await {
+        if ev.done {
+            done_seen = true;
+            break;
+        }
+        if ev.event_type == StreamEventType::ThinkingDone {
+            saw_thinking_done = true;
+        }
+    }
+
+    assert!(done_seen);
+    assert!(
+        !saw_thinking_done,
+        "no thinking block was opened; no ThinkingDone expected"
+    );
+    mock.assert_async().await;
+}

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -470,3 +470,53 @@ async fn thinking_block_start_then_immediate_stop_emits_nothing_yet() {
     );
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn thinking_delta_events_emitted_in_order() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me \"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"think...\"}}\n\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+    let mut stream = provider.stream(request).await.expect("stream");
+
+    let mut thinking_chunks: Vec<String> = Vec::new();
+    let mut done_seen = false;
+    while let Some(ev) = stream.next().await {
+        if ev.done {
+            done_seen = true;
+            break;
+        }
+        if ev.event_type == StreamEventType::ThinkingDelta {
+            thinking_chunks.push(ev.content);
+        }
+    }
+
+    assert!(done_seen, "stream must terminate");
+    assert_eq!(
+        thinking_chunks,
+        vec!["Let me ".to_string(), "think...".to_string()],
+        "ThinkingDelta events must arrive in order with exact content"
+    );
+    mock.assert_async().await;
+}

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.12.0 / Rust 0.15.3
+Multi-provider LLM SDK — Python 0.12.0 / Rust 0.15.4
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI
 
@@ -20,7 +20,7 @@ pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.15.3", features = ["anthropic"] }
+motosan-ai = { version = "0.15.4", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli


### PR DESCRIPTION
## Summary

- Adds `StreamEventType::ThinkingDelta` / `ThinkingDone` variants + `StreamEvent::thinking_delta` / `thinking_done` constructors so consumers can render Anthropic's streaming extended-thinking content live.
- `AnthropicStreamAdapter` parses `content_block_delta { type: thinking_delta }` correctly (reads `delta.thinking`, **not** `delta.text` — fixing a silent-drop bug); opens/closes a `current_thinking_buf` accumulator; emits `ThinkingDone` on `content_block_stop` with the full text. `signature_delta` and `redacted_thinking` blocks are silently consumed.
- `collect_stream` now populates `ChatResponse.thinking` from accumulated thinking events, so streaming and non-streaming Anthropic responses produce the same shape.
- Bumps `motosan-ai` to **v0.15.4**. Unblocks `motosan-agent-loop` v0.21.4's TODO markers at `src/motosan_ai_impl.rs:171, :346`.

## Wire-breaking note

`StreamEventType` is not `#[non_exhaustive]`. Adding two variants is technically breaking for any downstream that does an exhaustive `match` without `_ =>`. Internal `collect_stream` and `codex_cli` sites updated. Pre-1.0 → shipped as **patch** (mirrors `motosan-agent-loop` 0.21.3 → 0.21.4 precedent). New docstring on `ThinkingDelta` documents a forward-compatibility contract telling consumers to include `_ =>` arms.

## Test plan

- [x] 14 new mocked tests (`types.rs` x5, `tests/anthropic_stream.rs` x6, `src/stream.rs` x3) — all pass under `cargo test --all-features` (455 total pass, 18 ignored)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo publish --dry-run -p motosan-ai --all-features` succeeds
- [x] `cargo doc --all-features --no-deps` no warnings
- [x] **Live test passed** — `live_anthropic_streaming_thinking_emits_thinking_events` hit real Anthropic API with `thinking(4000)`: stream terminated, ThinkingDelta count > 0, ThinkingDone non-empty, answer non-empty, no content leak (6.07s)
- [x] All 9 pre-existing live tests still pass (no regression)

## Out of scope

Python SDK unchanged. `motosan-agent-loop` wiring is a follow-up plan once this publishes. `signature_delta` / `redacted_thinking` not surfaced (matches non-streaming `ChatResponse.thinking` shape). No other provider gains streaming-thinking — only Anthropic has a wire format for it today.

Plan: `docs/superpowers/plans/2026-05-23-anthropic-thinking-stream-events.md`