### PR TITLE
test(anthropic): guard cache_control on cached user message

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1124,6 +1124,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn cached_user_message_serializes_cache_control_both_auth_modes() {
+        // oauth does NOT branch the cached-USER path, so this pins oauth-invariance
+        // of the user-cache breakpoint.
+        for oauth in [false, true] {
+            // Build a ChatRequest whose single user message has cache = true.
+            let req = ChatRequest::builder()
+                .message(crate::types::Message::user_with_cache("hi"))
+                .build();
+            let body =
+                AnthropicRequestBuilder::new(req, "claude-opus-4-8".to_string(), oauth).build();
+
+            let msgs = body["messages"].as_array().expect("messages array");
+            let last = msgs.last().expect("a message");
+            let blocks = last["content"].as_array().expect("content must be a block array");
+            let cc = &blocks.last().expect("a content block")["cache_control"]["type"];
+            assert_eq!(cc, "ephemeral", "oauth={oauth}");
+        }
+    }
+
+    #[test]
     fn capabilities_are_full_by_default() {
         let p = AnthropicProvider::new("key", None, None);
         let caps = p.capabilities();

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1144,6 +1144,37 @@ mod tests {
     }
 
     #[test]
+    fn cached_multimodal_user_message_serializes_cache_control_on_last_block() {
+        // The content_blocks (image/document/multimodal) user arm places
+        // cache_control on the LAST block. oauth does NOT branch this arm, so
+        // this pins oauth-invariance of the multimodal-user cache breakpoint.
+        // A single text block is enough to hit the content_blocks arm.
+        for oauth in [false, true] {
+            let req = ChatRequest::builder()
+                .message(
+                    crate::types::Message::user_with_blocks(vec![
+                        crate::types::ContentBlock::Text {
+                            text: "describe this".to_string(),
+                        },
+                    ])
+                    .with_cache(),
+                )
+                .build();
+            let body =
+                AnthropicRequestBuilder::new(req, "claude-opus-4-8".to_string(), oauth).build();
+
+            let msgs = body["messages"].as_array().expect("messages array");
+            let blocks = msgs
+                .last()
+                .expect("a message")["content"]
+                .as_array()
+                .expect("content blocks");
+            let cc = &blocks.last().expect("a content block")["cache_control"]["type"];
+            assert_eq!(cc, "ephemeral", "oauth={oauth}");
+        }
+    }
+
+    #[test]
     fn capabilities_are_full_by_default() {
         let p = AnthropicProvider::new("key", None, None);
         let caps = p.capabilities();


### PR DESCRIPTION
## What
Test-only. Pins the existing behavior that a user message with `cache = true` serializes to wire `content:[{…,"cache_control":{"type":"ephemeral"}}]` under **both** API-key and OAuth auth.

## Why
This is the exact wire hop the engine's new `prompt_caching` feature (motosan-agent-loop) relies on. An adversarial review found an earlier design that tried to cache via a `Role::System` message was a silent no-op (the system flag is dropped during extraction); the **user-message** path is the one that works. This guard prevents a regression that would silently uncache the prefix.

## Notes
- No production change.
- The `anthropic` module is feature-gated — run with `--features anthropic`.
- `cargo test -p motosan-ai --features anthropic` passes; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
