### PR TITLE
feat(ts): port Anthropic setup-token OAuth to M4

### DIFF
--- a/sdks/typescript/src/providers/anthropic.ts
+++ b/sdks/typescript/src/providers/anthropic.ts
@@ -30,6 +30,35 @@ import type {
 } from '../types.js'
 
 const ANTHROPIC_VERSION = '2023-06-01'
+const ANTHROPIC_CLAUDE_CODE_USER_AGENT = 'claude-code/1.0.33'
+
+function isSetupToken(apiKey: string): boolean {
+  return apiKey.startsWith('sk-ant-oat01-')
+}
+
+function claudeCodeSystemBlock(): Record<string, unknown> {
+  return {
+    type: 'text',
+    text: "You are Claude Code, Anthropic's official CLI for Claude.",
+    cache_control: { type: 'ephemeral' },
+  }
+}
+
+function withOAuthSystemIdentity(body: Record<string, any>): Record<string, any> {
+  if (Array.isArray(body.system)) {
+    return { ...body, system: [claudeCodeSystemBlock(), ...body.system] }
+  }
+
+  if (typeof body.system === 'string') {
+    return { ...body, system: [claudeCodeSystemBlock(), { type: 'text', text: body.system }] }
+  }
+
+  if (body.system && typeof body.system === 'object') {
+    return { ...body, system: [claudeCodeSystemBlock(), body.system] }
+  }
+
+  return { ...body, system: [claudeCodeSystemBlock()] }
+}
 
 /**
  * Build the `anthropic-beta` header value (comma-joined, no spaces; `undefined`
@@ -148,6 +177,17 @@ export class AnthropicProvider {
   }
 
   private headers(extra?: Record<string, string>): Record<string, string> {
+    if (isSetupToken(this.apiKey)) {
+      return {
+        authorization: `Bearer ${this.apiKey}`,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'content-type': 'application/json',
+        'user-agent': ANTHROPIC_CLAUDE_CODE_USER_AGENT,
+        'x-app': 'cli',
+        ...(extra ?? {}),
+      }
+    }
+
     return {
       'x-api-key': this.apiKey,
       'anthropic-version': ANTHROPIC_VERSION,
@@ -158,7 +198,6 @@ export class AnthropicProvider {
 
   /**
    * Build per-request headers including the beta header when applicable.
-   * isOauth is always false in M4 (no setup-token path in TS).
    * adaptiveThinking is read off the serialized body, matching Rust
    * (anthropic.rs:469/802). Non-adaptive thinking enables the interleaved-thinking beta.
    */
@@ -166,13 +205,14 @@ export class AnthropicProvider {
     const hasMcp = requestHasMcp(req)
     const hasThinking = body?.thinking !== undefined
     const adaptiveThinking = body?.thinking?.type === 'adaptive'
-    const beta = buildBetaHeader(hasMcp, false, adaptiveThinking, hasThinking)
+    const beta = buildBetaHeader(hasMcp, isSetupToken(this.apiKey), adaptiveThinking, hasThinking)
     return this.headers(beta ? { 'anthropic-beta': beta } : {})
   }
 
   async chat(request: ChatRequest): Promise<ChatResponse> {
     const model = request.model ?? this.model
-    const body = serializeAnthropicRequest(request, model)
+    const serialized = serializeAnthropicRequest(request, model)
+    const body = isSetupToken(this.apiKey) ? withOAuthSystemIdentity(serialized) : serialized
     const headers = this.requestHeaders(request, body)
     const payload = await withRetry(
       this.retryPolicy,
@@ -218,10 +258,11 @@ export class AnthropicProvider {
 
   private async *streamImpl(request: ChatRequest) {
     const model = request.model ?? this.model
-    const body = {
+    const serialized = {
       ...serializeAnthropicRequest(request, model),
       stream: true,
     }
+    const body = isSetupToken(this.apiKey) ? withOAuthSystemIdentity(serialized) : serialized
     const headers = this.requestHeaders(request, body)
     let attempt = 0
     let responseBody: ReadableStream<Uint8Array>

--- a/sdks/typescript/tests/providers-anthropic.test.ts
+++ b/sdks/typescript/tests/providers-anthropic.test.ts
@@ -560,6 +560,18 @@ describe('AnthropicProvider beta headers (M4)', () => {
     )
   })
 
+  it('merges OAuth, MCP, and interleaved-thinking betas for setup-token requests', async () => {
+    const provider = new AnthropicProvider('sk-ant-oat01-k', 'claude-sonnet-4-6')
+    await provider.chat({
+      messages: [{ role: 'user', content: 'hi' }],
+      mcpServers: [{ type: 'url', url: 'https://m.example/sse', name: 'm' }],
+      thinking: { budgetTokens: 1024 },
+    })
+    expect(captured?.headers['anthropic-beta']).toBe(
+      'mcp-client-2025-11-20,claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14',
+    )
+  })
+
   it('omits anthropic-beta for a plain request', async () => {
     const provider = new AnthropicProvider('k', 'claude-sonnet-4-6')
     await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })

--- a/sdks/typescript/tests/providers-anthropic.test.ts
+++ b/sdks/typescript/tests/providers-anthropic.test.ts
@@ -68,6 +68,55 @@ describe('AnthropicProvider chat', () => {
     expect(response.stopReason).toBe('end_turn')
   })
 
+  it('uses bearer auth and OAuth beta headers for setup tokens', async () => {
+    const provider = new AnthropicProvider(
+      'sk-ant-oat01-test-token',
+      'claude-3-5-sonnet-20241022',
+      'https://api.anthropic.com',
+    )
+
+    await provider.chat({ messages: [{ role: 'user', content: 'Hello' }] })
+
+    expect(capturedRequest?.headers['x-api-key']).toBeUndefined()
+    expect(capturedRequest?.headers.authorization).toBe('Bearer sk-ant-oat01-test-token')
+    expect(capturedRequest?.headers['anthropic-beta']).toContain('claude-code-20250219')
+    expect(capturedRequest?.headers['anthropic-beta']).toContain('oauth-2025-04-20')
+    expect(capturedRequest?.headers['anthropic-beta']).toContain(
+      'fine-grained-tool-streaming-2025-05-14',
+    )
+    expect(capturedRequest?.headers['user-agent']).toBe('claude-code/1.0.33')
+    expect(capturedRequest?.headers['x-app']).toBe('cli')
+    expect(capturedRequest?.body.system).toEqual([
+      {
+        type: 'text',
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+        cache_control: { type: 'ephemeral' },
+      },
+    ])
+  })
+
+  it('preserves the user system prompt after OAuth Claude Code identity', async () => {
+    const provider = new AnthropicProvider(
+      'sk-ant-oat01-test-token',
+      'claude-3-5-sonnet-20241022',
+      'https://api.anthropic.com',
+    )
+
+    await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+      system: 'Reply tersely.',
+    })
+
+    expect(capturedRequest?.body.system).toEqual([
+      {
+        type: 'text',
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+        cache_control: { type: 'ephemeral' },
+      },
+      { type: 'text', text: 'Reply tersely.' },
+    ])
+  })
+
   it('parses cache tokens from a non-streaming usage block', async () => {
     vi.stubGlobal(
       'fetch',
@@ -178,7 +227,10 @@ describe('AnthropicProvider stream', () => {
     vi.unstubAllGlobals()
   })
 
-  function streamFromTranscript(sse: string): void {
+  function streamFromTranscript(
+    sse: string,
+    onRequest?: (url: string, options?: RequestInit) => void,
+  ): void {
     const bytes = new TextEncoder().encode(sse)
     const mockStream = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -188,14 +240,50 @@ describe('AnthropicProvider stream', () => {
     })
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () =>
-        new Response(mockStream, {
+      vi.fn(async (url: string, options?: RequestInit) => {
+        onRequest?.(url, options)
+        return new Response(mockStream, {
           status: 200,
           headers: { 'content-type': 'text/event-stream' },
-        }),
-      ),
+        })
+      }),
     )
   }
+
+  it('uses bearer auth and OAuth beta headers for setup token streams', async () => {
+    let capturedHeaders: Record<string, string> = {}
+    let capturedBody: any = null
+    streamFromTranscript(
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+      (_url, options) => {
+        capturedHeaders = (options?.headers as Record<string, string>) ?? {}
+        capturedBody = JSON.parse(String(options?.body ?? '{}'))
+      },
+    )
+
+    const provider = new AnthropicProvider(
+      'sk-ant-oat01-stream-token',
+      'claude-3-5-sonnet-20241022',
+    )
+    const events: StreamEvent[] = []
+    for await (const event of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      events.push(event)
+    }
+
+    expect(events.some((event) => event.done)).toBe(true)
+    expect(capturedHeaders['x-api-key']).toBeUndefined()
+    expect(capturedHeaders.authorization).toBe('Bearer sk-ant-oat01-stream-token')
+    expect(capturedHeaders['anthropic-beta']).toContain('oauth-2025-04-20')
+    expect(capturedHeaders['user-agent']).toBe('claude-code/1.0.33')
+    expect(capturedHeaders['x-app']).toBe('cli')
+    expect(capturedBody.system).toEqual([
+      {
+        type: 'text',
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+        cache_control: { type: 'ephemeral' },
+      },
+    ])
+  })
 
   it('maps a full thinking + text + tool_use + usage transcript to StreamEvents', async () => {
     const sse =
@@ -462,6 +550,14 @@ describe('AnthropicProvider beta headers (M4)', () => {
       thinking: { budgetTokens: 1024 },
     })
     expect('anthropic-beta' in (captured?.headers ?? {})).toBe(false)
+  })
+
+  it('uses exactly the OAuth betas for a plain setup-token request', async () => {
+    const provider = new AnthropicProvider('sk-ant-oat01-k', 'claude-sonnet-4-6')
+    await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(captured?.headers['anthropic-beta']).toBe(
+      'claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14',
+    )
   })
 
   it('omits anthropic-beta for a plain request', async () => {


### PR DESCRIPTION
## Summary
- Port the Anthropic setup-token (`sk-ant-oat01-*`) OAuth auth path onto M4's TypeScript `anthropic.ts` wiring.
- Use `Authorization: Bearer`, Claude Code user-agent, and `x-app: cli` for setup tokens while preserving the existing `x-api-key` path.
- Feed `isSetupToken(this.apiKey)` into `buildBetaHeader()` so OAuth betas flow through M4's merged beta-header path.
- Add Claude Code system identity wrapping for setup-token chat and stream requests.
- Preserve the three setup-token tests from `feab995` and add an exact plain OAuth beta regression check.

## Verification
- `cd sdks/typescript && npm run build`
- `cd sdks/typescript && npm run test`
- `git diff --check && cd sdks/typescript && npm run build && npm run test`
- Pre-push hook passed:
  - Python unit tests
  - Rust unit tests
  - Python live Anthropic tests
  - Rust live Anthropic tests
