### PR TITLE
feat(ts): add Ollama provider (M5)

### DIFF
--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -12,7 +12,9 @@ import { collectStream, type BoxStream } from './stream.js'
 import { stripThink } from './think_stripper.js'
 import { AnthropicProvider } from './providers/anthropic.js'
 import { MinimaxProvider } from './providers/minimax.js'
+import { OllamaProvider } from './providers/ollama.js'
 import { OpenAIProvider, type OpenAIAuthStyle } from './providers/openai.js'
+import { DEFAULT_OLLAMA_MODEL } from './models.js'
 import type { ChatRequest, ChatResponse, StreamEvent } from './types.js'
 
 export type ProviderName = Provider
@@ -34,6 +36,9 @@ const ENV_KEY_BY_PROVIDER: Record<ProviderName, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
   minimax: 'MINIMAX_API_KEY',
+  // Ollama needs no env key; '' keeps the Record total and
+  // process.env[''] yields undefined (harmless — apiKey not required).
+  ollama: '',
 }
 
 function asDispatchProvider(provider: ProviderLike): DispatchProvider {
@@ -64,6 +69,11 @@ export class ClientBuilder {
   protected _openaiChatUrl?: string
   protected _openaiResponsesFallback = false
   protected _openaiResponsesUrl?: string
+  protected _ollamaBaseUrl?: string
+  protected _ollamaNative?: boolean
+  protected _ollamaThink?: string
+  protected _ollamaKeepAlive?: string
+  protected _ollamaNumCtx?: number
 
   provider(p: Provider): this {
     this._provider = p
@@ -131,6 +141,31 @@ export class ClientBuilder {
     return this
   }
 
+  ollamaBaseUrl(u: string): this {
+    this._ollamaBaseUrl = u
+    return this
+  }
+
+  ollamaNative(native: boolean): this {
+    this._ollamaNative = native
+    return this
+  }
+
+  ollamaThink(think: string): this {
+    this._ollamaThink = think
+    return this
+  }
+
+  ollamaKeepAlive(duration: string): this {
+    this._ollamaKeepAlive = duration
+    return this
+  }
+
+  ollamaNumCtx(tokens: number): this {
+    this._ollamaNumCtx = tokens
+    return this
+  }
+
   /**
    * Construct the configured provider with its existing constructor signature,
    * then chain Task 5's mutating `withRetryPolicy(policy): this` setter.
@@ -158,6 +193,37 @@ export class ClientBuilder {
       }
       return openai
     }
+    if (provider === 'ollama') {
+      const ollamaBaseUrl = this._ollamaBaseUrl ?? 'http://localhost:11434'
+
+      // Auto-routing (contract §4 / client.rs:245-248). The SAME constructed
+      // instance serves chat and stream, so routing can never split.
+      const needsNative =
+        this._ollamaNative === true ||
+        this._ollamaKeepAlive !== undefined ||
+        this._ollamaNumCtx !== undefined ||
+        this._ollamaThink !== undefined
+
+      if (needsNative) {
+        // Native /api/chat (text-only). Mirrors build_ollama_native_provider
+        // (client.rs:610-621).
+        const model = this._model ?? DEFAULT_OLLAMA_MODEL
+        return new OllamaProvider(model, ollamaBaseUrl)
+          .withThink(this._ollamaThink)
+          .withKeepAlive(this._ollamaKeepAlive)
+          .withNumCtx(this._ollamaNumCtx)
+          .withRetryPolicy(this._retryPolicy)
+      }
+
+      // OpenAI-compat /v1/chat/completions (reuses OpenAIProvider, empty key,
+      // Bearer). Mirrors build_ollama_provider (client.rs:599-607). Declares
+      // withImage() capabilities (model-dependent accuracy).
+      const model = this._model ?? DEFAULT_OLLAMA_MODEL
+      return new OpenAIProvider('', model)
+        .withChatUrl(`${ollamaBaseUrl.replace(/\/+$/, '')}/v1/chat/completions`)
+        .withAuthStyle({ kind: 'bearer' })
+        .withRetryPolicy(this._retryPolicy)
+    }
     return new MinimaxProvider(apiKey, this._model, this._minimaxBaseUrl).withRetryPolicy(
       this._retryPolicy,
     )
@@ -173,6 +239,16 @@ export class ClientBuilder {
     const apiKey = this._apiKey ?? process.env[ENV_KEY_BY_PROVIDER[this._provider]]
     if (apiKeyRequired && !apiKey) {
       throw new ConfigError(`Missing API key for provider ${this._provider}`)
+    }
+
+    if (this._provider !== 'ollama') {
+      const misused: string[] = []
+      if (this._ollamaKeepAlive !== undefined) misused.push('ollama_keep_alive')
+      if (this._ollamaNumCtx !== undefined) misused.push('ollama_num_ctx')
+      if (this._ollamaThink !== undefined) misused.push('ollama_think')
+      if (misused.length > 0) {
+        throw new ConfigError(`${misused.join(', ')} can only be used with Provider::Ollama`)
+      }
     }
 
     const provider = this.buildProvider(this._provider, apiKey ?? '')
@@ -226,16 +302,24 @@ export class Client {
 
     const provider = opts.provider
     const apiKey = opts.apiKey ?? process.env[ENV_KEY_BY_PROVIDER[provider]]
-    if (!apiKey) {
+    if (!apiKey && provider !== 'ollama') {
       throw new ConfigError(`Missing API key for provider ${provider}`)
     }
 
+    const resolvedApiKey = apiKey ?? ''
     if (provider === 'anthropic') {
-      this.provider = new AnthropicProvider(apiKey, opts.model)
+      this.provider = new AnthropicProvider(resolvedApiKey, opts.model)
     } else if (provider === 'openai') {
-      this.provider = new OpenAIProvider(apiKey, opts.model)
+      this.provider = new OpenAIProvider(resolvedApiKey, opts.model)
+    } else if (provider === 'ollama') {
+      // Legacy ctor has no tuning fields → OpenAI-compat path (empty key,
+      // Bearer) against the default Ollama base URL. For native/tuning, use
+      // Client.builder().
+      this.provider = new OpenAIProvider(resolvedApiKey, opts.model ?? DEFAULT_OLLAMA_MODEL)
+        .withChatUrl('http://localhost:11434/v1/chat/completions')
+        .withAuthStyle({ kind: 'bearer' })
     } else {
-      this.provider = new MinimaxProvider(apiKey, opts.model, opts.minimaxBaseUrl)
+      this.provider = new MinimaxProvider(resolvedApiKey, opts.model, opts.minimaxBaseUrl)
     }
   }
 

--- a/sdks/typescript/src/http/ndjson.ts
+++ b/sdks/typescript/src/http/ndjson.ts
@@ -6,7 +6,12 @@
  * incomplete lines, splits on \n boundaries, and JSON-parses each non-empty line.
  * Malformed JSON lines are silently skipped.
  *
- * Basic implementation for M1; finalized in M5.
+ * Finalized in M5: verified sufficient for Ollama native /api/chat NDJSON.
+ * The parser is provider-agnostic — it yields each parsed object (including
+ * any {done:true} object) and never inspects `done`. Termination on
+ * {done:true} is the Ollama stream adapter's responsibility (providers/ollama.ts),
+ * mirroring Rust where NdjsonStream only splits lines (ollama.rs:500-551) and
+ * OllamaStreamAdapter decides done (ollama.rs:441-447).
  */
 
 /**

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -6,6 +6,7 @@ export * from './client.js'
 export * from './providers/anthropic.js'
 export * from './providers/openai.js'
 export * from './providers/minimax.js'
+export * from './providers/ollama.js'
 
 export { RetryPolicy } from './retry.js'
 export { ThinkStripper, stripThink } from './think_stripper.js'
@@ -13,6 +14,7 @@ export {
   DEFAULT_ANTHROPIC_MODEL,
   DEFAULT_OPENAI_MODEL,
   DEFAULT_MINIMAX_MODEL,
+  DEFAULT_OLLAMA_MODEL,
   ANTHROPIC_MODELS,
   OPENAI_MODELS,
   MINIMAX_MODELS,

--- a/sdks/typescript/src/models.ts
+++ b/sdks/typescript/src/models.ts
@@ -26,3 +26,6 @@ export const MINIMAX_MODELS = ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'] as cons
 
 /** Default MiniMax model (models.rs convention, first element) */
 export const DEFAULT_MINIMAX_MODEL = 'MiniMax-M2.7'
+
+/** Default Ollama model (models.rs:3) */
+export const DEFAULT_OLLAMA_MODEL = 'llama3.2'

--- a/sdks/typescript/src/provider.ts
+++ b/sdks/typescript/src/provider.ts
@@ -90,8 +90,14 @@ export function validateRequest(req: ChatRequest, caps: ProviderCapabilities): v
   }
 }
 
-/** String-tagged provider discriminator. Extend with 'ollama' | 'gemini' in M5/M6. */
-export type Provider = 'anthropic' | 'openai' | 'minimax'
+/**
+ * String-tagged provider discriminator. 'ollama' added in M5. Extend with
+ * 'gemini' in M6. Auto-routing between Ollama's native /api/chat and the
+ * OpenAI-compat path is decided at provider-construction time in
+ * ClientBuilder.buildProvider (see client.ts) — dispatchChat/dispatchStream
+ * stay provider-agnostic, so NO 'ollama' arm is added here.
+ */
+export type Provider = 'anthropic' | 'openai' | 'minimax' | 'ollama'
 
 /**
  * Minimal shape a provider must expose to be dispatched: a capability reshape

--- a/sdks/typescript/src/providers/ollama.ts
+++ b/sdks/typescript/src/providers/ollama.ts
@@ -1,0 +1,367 @@
+import { isRetryableNetworkError, isRetryableStatus } from '../error.js'
+import { postJson, postStream } from '../http/fetch.js'
+import { parseNdjson } from '../http/ndjson.js'
+import { DEFAULT_OLLAMA_MODEL } from '../models.js'
+import { textOnly, type ProviderCapabilities } from '../provider.js'
+import { RetryPolicy, withRetry, type RetryClassification } from '../retry.js'
+import {
+  doneEvent,
+  textEvent,
+  toolCallArgsWithId,
+  toolCallEndWithId,
+  toolCallStart,
+  type BoxStream,
+} from '../stream.js'
+import type { ChatRequest, ChatResponse, StopReason, ToolCall } from '../types.js'
+
+/** Same classify shape as providers/openai.ts:38-51 / providers/minimax.ts. */
+function classifyHttpError(result: unknown): RetryClassification {
+  if (result instanceof Error) {
+    const error = result as { status?: number; retryAfterMs?: number }
+    const status = error.status
+    if (
+      (status !== undefined && isRetryableStatus(status)) ||
+      isRetryableNetworkError(result)
+    ) {
+      return { retryable: true, retryAfterMs: error.retryAfterMs }
+    }
+    throw result
+  }
+  return { retryable: false }
+}
+
+/**
+ * A native-API tool call before id-defaulting. Mirrors Rust ToolCall but
+ * `input` may be any JSON value (string fallback on parse failure), matching
+ * Rust's `Value::String(s)` keep-raw behavior (ollama.rs:225-227).
+ */
+interface NativeToolCall {
+  id: string
+  name: string
+  input: unknown
+}
+
+/**
+ * Native Ollama provider hitting `/api/chat` with NDJSON streaming.
+ * Mirrors Rust `OllamaProvider` (providers/ollama.rs). Text-only; no auth header.
+ * The OpenAI-compat path is NOT here — it reuses OpenAIProvider (wired in
+ * client.ts buildProvider). Constructor `(model, baseUrl)` mirrors
+ * `OllamaProvider::new` (ollama.rs:29-39).
+ */
+export class OllamaProvider {
+  private readonly model: string
+  private readonly baseUrl: string
+  private think?: string
+  private keepAlive?: string
+  private numCtx?: number
+  private retryPolicy: RetryPolicy
+
+  constructor(model: string, baseUrl: string) {
+    this.model = model
+    this.baseUrl = baseUrl.replace(/\/+$/, '') // trim trailing slash(es)
+    this.retryPolicy = RetryPolicy.default()
+  }
+
+  withThink(think?: string): this {
+    this.think = think
+    return this
+  }
+
+  withKeepAlive(keepAlive?: string): this {
+    this.keepAlive = keepAlive
+    return this
+  }
+
+  withNumCtx(numCtx?: number): this {
+    this.numCtx = numCtx
+    return this
+  }
+
+  withRetryPolicy(policy: RetryPolicy): this {
+    this.retryPolicy = policy
+    return this
+  }
+
+  capabilities(): ProviderCapabilities {
+    // text_only(); supportsMcp:false comes for free via the M4 factory.
+    return textOnly()
+  }
+
+  private endpoint(): string {
+    return `${this.baseUrl}/api/chat`
+  }
+
+  /** Native /api/chat body. stream=false for chat(), true for stream(). */
+  private buildRequestBody(req: ChatRequest, stream: boolean): Record<string, unknown> {
+    const model = req.model ?? this.model
+    const messages: Array<Record<string, unknown>> = []
+
+    // 1. System first: systemBlocks priority over system string.
+    if (req.systemBlocks) {
+      const joined = req.systemBlocks.map((b) => b.text).join('\n').trim()
+      if (joined) messages.push({ role: 'system', content: joined })
+    } else if (req.system) {
+      const trimmed = req.system.trim()
+      if (trimmed) messages.push({ role: 'system', content: trimmed })
+    }
+
+    // 2. Then each message by role.
+    for (const message of req.messages) {
+      switch (message.role) {
+        case 'system': {
+          const trimmed = message.content.trim()
+          if (trimmed) messages.push({ role: 'system', content: trimmed })
+          break
+        }
+        case 'user': {
+          // Native path is text-only: flat string content (images rejected
+          // by validate before reaching here).
+          messages.push({ role: 'user', content: message.content })
+          break
+        }
+        case 'assistant': {
+          if (!message.toolCalls || message.toolCalls.length === 0) {
+            messages.push({ role: 'assistant', content: message.content })
+          } else {
+            const toolCalls = message.toolCalls.map((tc) => ({
+              // arguments is the PARSED OBJECT tc.input directly (NOT a JSON
+              // string — contrast OpenAI). No top-level id/type.
+              function: { name: tc.name, arguments: tc.input },
+            }))
+            messages.push({
+              role: 'assistant',
+              content: message.content,
+              tool_calls: toolCalls,
+            })
+          }
+          break
+        }
+        case 'tool': {
+          // NO tool_call_id on the native path (contrast OpenAI compat).
+          messages.push({ role: 'tool', content: message.content })
+          break
+        }
+      }
+    }
+
+    const body: Record<string, unknown> = { model, messages, stream }
+
+    // think coercion (ollama.rs:145-157): trim; omit if blank.
+    if (this.think !== undefined) {
+      const trimmed = this.think.trim()
+      if (trimmed) {
+        switch (trimmed.toLowerCase()) {
+          case 'true':
+          case 'yes':
+          case 'on':
+          case '1':
+            body.think = true
+            break
+          case 'false':
+          case 'no':
+          case 'off':
+          case '0':
+            body.think = false
+            break
+          default:
+            // verbatim ORIGINAL trimmed casing (e.g. "low"/"medium"/"high")
+            body.think = trimmed
+        }
+      }
+    }
+
+    // keep_alive verbatim string at root.
+    if (this.keepAlive !== undefined) {
+      body.keep_alive = this.keepAlive
+    }
+
+    // options object — OMIT entirely if empty.
+    const options: Record<string, unknown> = {}
+    if (req.temperature !== undefined) options.temperature = req.temperature
+    if (this.numCtx !== undefined) options.num_ctx = this.numCtx
+    if (req.stopSequences && req.stopSequences.length > 0) options.stop = req.stopSequences
+    if (Object.keys(options).length > 0) body.options = options
+
+    // tools — only set if non-empty. TS Tool fields optional; match the
+    // serialize/openai.ts defaults (openai.ts:151-152).
+    if (req.tools) {
+      const mapped = req.tools.map((tool) => ({
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description ?? '',
+          parameters: tool.inputSchema ?? { type: 'object', properties: {} },
+        },
+      }))
+      if (mapped.length > 0) body.tools = mapped
+    }
+
+    // providerOptions merged into root LAST (Object.assign).
+    if (req.providerOptions && typeof req.providerOptions === 'object') {
+      Object.assign(body, req.providerOptions)
+    }
+
+    return body
+  }
+
+  /** Shared by chat + stream (ollama.rs:212-242). */
+  private static extractToolCalls(message: any): NativeToolCall[] {
+    const calls = message?.tool_calls
+    if (!Array.isArray(calls)) return []
+    const out: NativeToolCall[] = []
+    calls.forEach((call: any, idx: number) => {
+      const fn = call?.function
+      if (!fn) return // skip if missing
+      const name = fn?.name
+      if (typeof name !== 'string') return // skip if missing
+      const args = fn?.arguments
+      let input: unknown
+      if (typeof args === 'string') {
+        try {
+          input = JSON.parse(args)
+        } catch {
+          input = args // keep raw string on parse failure (Value::String)
+        }
+      } else if (args === undefined || args === null) {
+        input = {}
+      } else {
+        input = args
+      }
+      const id =
+        typeof call?.id === 'string' && call.id.length > 0 ? call.id : `call_${idx}`
+      out.push({ id, name, input })
+    })
+    return out
+  }
+
+  async chat(req: ChatRequest): Promise<ChatResponse> {
+    const body = this.buildRequestBody(req, false)
+    const payload = await withRetry(
+      this.retryPolicy,
+      async () => postJson<any>(this.endpoint(), {}, body),
+      classifyHttpError,
+    )
+
+    const message = payload?.message
+    const content =
+      typeof message?.content === 'string' ? message.content : ''
+    const thinking =
+      typeof message?.thinking === 'string' ? message.thinking : ''
+
+    // final_content thinking-fold (ollama.rs:302-309).
+    let finalContent: string
+    if (content === '' && thinking !== '') {
+      finalContent = thinking
+    } else if (thinking !== '') {
+      finalContent = `<think>${thinking}</think>\n\n${content}`
+    } else {
+      finalContent = content
+    }
+
+    const native = message ? OllamaProvider.extractToolCalls(message) : []
+    const toolCalls: ToolCall[] = native.map((tc) => ({
+      id: tc.id,
+      name: tc.name,
+      // extractToolCalls keeps the RAW string when JSON.parse fails (Rust
+      // Value::String fallback, ollama.rs), so tc.input may be a string. The
+      // cast is a deliberate escape hatch; ToolCall.input stays Record<...>
+      // (a post-M5 widening of ToolCall.input to unknown is the clean fix).
+      input: tc.input as Record<string, unknown>,
+    }))
+
+    let stopReason: StopReason
+    if (toolCalls.length > 0) {
+      stopReason = 'tool_use'
+    } else {
+      stopReason = payload?.done === true ? 'stop' : 'other'
+    }
+
+    const model = String(payload?.model ?? DEFAULT_OLLAMA_MODEL)
+    const inputTokens = Number(payload?.prompt_eval_count ?? 0)
+    const outputTokens = Number(payload?.eval_count ?? 0)
+
+    return {
+      content: finalContent,
+      // native chat() folds thinking into content via <think>; it does NOT
+      // populate ChatResponse.thinking (ollama.rs never calls .thinking()).
+      thinking: undefined,
+      toolCalls,
+      model,
+      usage: { inputTokens, outputTokens },
+      stopReason,
+    }
+  }
+
+  stream(req: ChatRequest): BoxStream {
+    return this.streamImpl(req)
+  }
+
+  private async *streamImpl(req: ChatRequest) {
+    const body = this.buildRequestBody(req, true)
+
+    // Retry ONLY the initial postStream fetch (mirrors openai.ts:326-351).
+    let attempt = 0
+    let responseBody: ReadableStream<Uint8Array>
+    while (true) {
+      try {
+        responseBody = await postStream(this.endpoint(), {}, body)
+        break
+      } catch (error) {
+        const status = (error as { status?: number }).status
+        const retryable =
+          (status !== undefined && isRetryableStatus(status)) ||
+          isRetryableNetworkError(error)
+        if (!retryable || attempt >= this.retryPolicy.maxRetries) {
+          throw error
+        }
+        attempt += 1
+        const retryAfterMs = (error as { retryAfterMs?: number }).retryAfterMs
+        const delay = this.retryPolicy.respectRetryAfter
+          ? retryAfterMs ?? this.retryPolicy.delayForAttempt(attempt)
+          : this.retryPolicy.delayForAttempt(attempt)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
+
+    // Adapter over parseNdjson: decide termination on done:true.
+    for await (const obj of parseNdjson(responseBody)) {
+      const done = (obj as { done?: unknown }).done === true
+      if (done) {
+        // Rust StreamEvent::done() carries NO stop_reason — plain doneEvent.
+        yield doneEvent()
+        return
+      }
+
+      const message = (obj as { message?: any }).message
+      const content =
+        typeof message?.content === 'string' ? message.content : ''
+      const thinking =
+        typeof message?.thinking === 'string' ? message.thinking : ''
+
+      // text selection (ollama.rs:459-465). Streamed thinking is surfaced as
+      // a plain textEvent (folded into the text stream).
+      let text: string
+      if (thinking !== '' && content === '') {
+        text = thinking
+      } else if (content !== '') {
+        text = content
+      } else {
+        text = ''
+      }
+      if (text !== '') {
+        yield textEvent(text)
+      }
+
+      // 3-event pattern per tool call (ollama.rs:471-483).
+      if (message) {
+        for (const tc of OllamaProvider.extractToolCalls(message)) {
+          yield toolCallStart(tc.id, tc.name)
+          yield toolCallArgsWithId(tc.id, JSON.stringify(tc.input))
+          yield toolCallEndWithId(tc.id)
+        }
+      }
+    }
+    // EOF without done:true — let the generator end (NO synthesized done),
+    // matching Rust Poll::Ready(None). collectStream fabricates a stop_reason.
+  }
+}

--- a/sdks/typescript/src/providers/ollama.ts
+++ b/sdks/typescript/src/providers/ollama.ts
@@ -262,11 +262,9 @@ export class OllamaProvider {
     const toolCalls: ToolCall[] = native.map((tc) => ({
       id: tc.id,
       name: tc.name,
-      // extractToolCalls keeps the RAW string when JSON.parse fails (Rust
-      // Value::String fallback, ollama.rs), so tc.input may be a string. The
-      // cast is a deliberate escape hatch; ToolCall.input stays Record<...>
-      // (a post-M5 widening of ToolCall.input to unknown is the clean fix).
-      input: tc.input as Record<string, unknown>,
+      // extractToolCalls keeps the RAW JSON value when JSON.parse fails (Rust
+      // Value::String fallback, ollama.rs), so tc.input may be a string.
+      input: tc.input,
     }))
 
     let stopReason: StopReason
@@ -284,7 +282,6 @@ export class OllamaProvider {
       content: finalContent,
       // native chat() folds thinking into content via <think>; it does NOT
       // populate ChatResponse.thinking (ollama.rs never calls .thinking()).
-      thinking: undefined,
       toolCalls,
       model,
       usage: { inputTokens, outputTokens },
@@ -324,42 +321,48 @@ export class OllamaProvider {
     }
 
     // Adapter over parseNdjson: decide termination on done:true.
-    for await (const obj of parseNdjson(responseBody)) {
-      const done = (obj as { done?: unknown }).done === true
-      if (done) {
-        // Rust StreamEvent::done() carries NO stop_reason — plain doneEvent.
-        yield doneEvent()
-        return
-      }
+    try {
+      for await (const obj of parseNdjson(responseBody)) {
+        const done = (obj as { done?: unknown }).done === true
+        if (done) {
+          // Rust StreamEvent::done() carries NO stop_reason — plain doneEvent.
+          yield doneEvent()
+          return
+        }
 
-      const message = (obj as { message?: any }).message
-      const content =
-        typeof message?.content === 'string' ? message.content : ''
-      const thinking =
-        typeof message?.thinking === 'string' ? message.thinking : ''
+        const message = (obj as { message?: any }).message
+        const content =
+          typeof message?.content === 'string' ? message.content : ''
+        const thinking =
+          typeof message?.thinking === 'string' ? message.thinking : ''
 
-      // text selection (ollama.rs:459-465). Streamed thinking is surfaced as
-      // a plain textEvent (folded into the text stream).
-      let text: string
-      if (thinking !== '' && content === '') {
-        text = thinking
-      } else if (content !== '') {
-        text = content
-      } else {
-        text = ''
-      }
-      if (text !== '') {
-        yield textEvent(text)
-      }
+        // text selection (ollama.rs:459-465). Streamed thinking is surfaced as
+        // a plain textEvent (folded into the text stream).
+        let text: string
+        if (thinking !== '' && content === '') {
+          text = thinking
+        } else if (content !== '') {
+          text = content
+        } else {
+          text = ''
+        }
+        if (text !== '') {
+          yield textEvent(text)
+        }
 
-      // 3-event pattern per tool call (ollama.rs:471-483).
-      if (message) {
-        for (const tc of OllamaProvider.extractToolCalls(message)) {
-          yield toolCallStart(tc.id, tc.name)
-          yield toolCallArgsWithId(tc.id, JSON.stringify(tc.input))
-          yield toolCallEndWithId(tc.id)
+        // 3-event pattern per tool call (ollama.rs:471-483).
+        if (message) {
+          for (const tc of OllamaProvider.extractToolCalls(message)) {
+            yield toolCallStart(tc.id, tc.name)
+            yield toolCallArgsWithId(tc.id, JSON.stringify(tc.input))
+            yield toolCallEndWithId(tc.id)
+          }
         }
       }
+    } catch {
+      // Ignore post-start stream body errors, matching Rust's partial-success
+      // stream semantics: end without synthesizing a terminal done event.
+      return
     }
     // EOF without done:true — let the generator end (NO synthesized done),
     // matching Rust Poll::Ready(None). collectStream fabricates a stop_reason.

--- a/sdks/typescript/src/stream.ts
+++ b/sdks/typescript/src/stream.ts
@@ -153,9 +153,9 @@ export async function collectStream(stream: BoxStream): Promise<ChatResponse> {
         break
 
       case 'tool_call_end': {
-        let input: Record<string, unknown> = {}
+        let input: unknown = {}
         try {
-          input = JSON.parse(currentToolArgs) as Record<string, unknown>
+          input = JSON.parse(currentToolArgs) as unknown
         } catch {
           // Fallback to empty object on parse failure
         }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -28,12 +28,13 @@ export type ContentBlock =
 
 /**
  * A tool/function call requested by the model. The arguments field is `input`
- * (NOT `args`/`params`) per project convention, kept as a parsed object.
+ * (NOT `args`/`params`) per project convention, kept as the parsed JSON value
+ * returned by the provider.
  */
 export interface ToolCall {
   id: string
   name: string
-  input: Record<string, unknown>
+  input: unknown
 }
 
 /** A tool definition exposed to the model. */

--- a/sdks/typescript/tests/capabilities.test.ts
+++ b/sdks/typescript/tests/capabilities.test.ts
@@ -5,6 +5,7 @@ import {
   fullCaps,
   minimaxCaps,
   validateRequest,
+  type Provider,
   type ProviderCapabilities,
 } from '../src/provider.js'
 import { UnsupportedFeatureError } from '../src/error.js'
@@ -286,5 +287,19 @@ describe('validateRequest MCP gating (M4)', () => {
   it('does NOT throw when no MCP config is present (textOnly)', () => {
     const plain: ChatRequest = { messages: [{ role: 'user', content: 'hi' }] }
     expect(() => validateRequest(plain, textOnly())).not.toThrow()
+  })
+})
+
+describe('Provider union includes ollama (M5)', () => {
+  it('accepts "ollama" as a Provider value', () => {
+    // Type-level: this assignment only compiles once 'ollama' is in the union.
+    const p: Provider = 'ollama'
+    expect(p).toBe('ollama')
+  })
+
+  it('still accepts the M1-M4 provider tokens', () => {
+    const all: Provider[] = ['anthropic', 'openai', 'minimax', 'ollama']
+    expect(all).toContain('ollama')
+    expect(all).toHaveLength(4)
   })
 })

--- a/sdks/typescript/tests/client-builder.test.ts
+++ b/sdks/typescript/tests/client-builder.test.ts
@@ -395,3 +395,267 @@ describe('ClientBuilder OpenAI auth + chat URL', () => {
     expect(captured.headers?.['x-api-key']).toBeUndefined()
   })
 })
+
+describe('ClientBuilder Ollama routing (native vs compat)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function nativeOk() {
+    const urls: string[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, options?: RequestInit) => {
+        urls.push(url)
+        // Return an Ollama native NDJSON-ish body that also parses as a
+        // single JSON object for chat() (chat uses postJson; one object).
+        const isStream = options?.body ? JSON.parse(String(options.body)).stream : false
+        if (isStream) {
+          return new Response('{"message":{"content":"hi"},"done":false}\n{"done":true}\n', {
+            status: 200,
+          })
+        }
+        return new Response(
+          JSON.stringify({ model: 'llama3.2', message: { content: 'hi' }, done: true }),
+          { status: 200 },
+        )
+      }),
+    )
+    return urls
+  }
+
+  function compatOk() {
+    const urls: string[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, options?: RequestInit) => {
+        urls.push(url)
+        const isStream = options?.body ? JSON.parse(String(options.body)).stream : false
+        if (isStream) {
+          return new Response(
+            'data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+            { status: 200, headers: { 'content-type': 'text/event-stream' } },
+          )
+        }
+        return new Response(
+          JSON.stringify({
+            model: 'llama3.2',
+            choices: [{ index: 0, message: { content: 'hi' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1 },
+          }),
+          { status: 200 },
+        )
+      }),
+    )
+    return urls
+  }
+
+  it('routes to native /api/chat for BOTH chat and stream when ollamaNative(true)', async () => {
+    const urls = nativeOk()
+    const client = new ClientBuilder()
+      .provider('ollama')
+      .ollamaBaseUrl('http://localhost:11434')
+      .ollamaNative(true)
+      .build()
+
+    await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    for await (const _e of client.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      // drain
+    }
+
+    // SAME instance, SAME endpoint for chat and stream (never split).
+    expect(urls).toEqual([
+      'http://localhost:11434/api/chat',
+      'http://localhost:11434/api/chat',
+    ])
+  })
+
+  it('routes to native when ANY tuning field is set (ollamaThink)', async () => {
+    const urls = nativeOk()
+    const client = new ClientBuilder().provider('ollama').ollamaThink('high').build()
+    await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(urls[0]).toBe('http://localhost:11434/api/chat')
+  })
+
+  it('routes to native when ollamaKeepAlive is set', async () => {
+    const urls = nativeOk()
+    const client = new ClientBuilder().provider('ollama').ollamaKeepAlive('5m').build()
+    await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(urls[0]).toBe('http://localhost:11434/api/chat')
+  })
+
+  it('routes to native when ollamaNumCtx is set', async () => {
+    const urls = nativeOk()
+    const client = new ClientBuilder().provider('ollama').ollamaNumCtx(4096).build()
+    await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(urls[0]).toBe('http://localhost:11434/api/chat')
+  })
+
+  it('routes to OpenAI-compat /v1/chat/completions by default (no tuning, no native flag)', async () => {
+    const urls = compatOk()
+    const client = new ClientBuilder()
+      .provider('ollama')
+      .ollamaBaseUrl('http://localhost:11434')
+      .build()
+    await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    for await (const _e of client.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      // drain
+    }
+    expect(urls).toEqual([
+      'http://localhost:11434/v1/chat/completions',
+      'http://localhost:11434/v1/chat/completions',
+    ])
+  })
+
+  it('compat path sends Bearer with an empty key (harmless against Ollama)', async () => {
+    let authHeader: string | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, options?: RequestInit) => {
+        authHeader = (options?.headers as Record<string, string>)?.authorization
+        return new Response(
+          JSON.stringify({
+            model: 'llama3.2',
+            choices: [{ index: 0, message: { content: 'hi' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1 },
+          }),
+          { status: 200 },
+        )
+      }),
+    )
+    const client = new ClientBuilder().provider('ollama').build()
+    await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(authHeader).toBe('Bearer ')
+  })
+
+  it('defaults the base URL to http://localhost:11434 when unset', async () => {
+    const urls = compatOk()
+    const client = new ClientBuilder().provider('ollama').build()
+    await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(urls[0]).toBe('http://localhost:11434/v1/chat/completions')
+  })
+})
+
+describe('ClientBuilder Ollama api-key-not-required seam', () => {
+  beforeEach(() => {
+    delete process.env.OLLAMA_API_KEY
+  })
+
+  it('build() succeeds for provider("ollama") with NO apiKey', () => {
+    const client = new ClientBuilder()
+      .provider('ollama')
+      .ollamaBaseUrl('http://localhost:11434')
+      .build()
+    expect(client).toBeInstanceOf(Client)
+  })
+
+  it('build() succeeds for provider("ollama") with no apiKey and no base url', () => {
+    const client = new ClientBuilder().provider('ollama').build()
+    expect(client).toBeInstanceOf(Client)
+  })
+})
+
+describe('ClientBuilder Ollama tuning-field validation (non-ollama provider)', () => {
+  beforeEach(() => {
+    delete process.env.OPENAI_API_KEY
+  })
+
+  it('throws ConfigError naming ollama_think on a non-ollama provider', () => {
+    const builder = new ClientBuilder().provider('openai').apiKey('sk-test').ollamaThink('high')
+    expect(() => builder.build()).toThrowError(ConfigError)
+    expect(() => builder.build()).toThrowError('ollama_think can only be used with Provider::Ollama')
+  })
+
+  it('throws ConfigError naming ollama_keep_alive on a non-ollama provider', () => {
+    const builder = new ClientBuilder().provider('openai').apiKey('sk-test').ollamaKeepAlive('5m')
+    expect(() => builder.build()).toThrowError('ollama_keep_alive can only be used with Provider::Ollama')
+  })
+
+  it('throws ConfigError naming ollama_num_ctx on a non-ollama provider', () => {
+    const builder = new ClientBuilder().provider('openai').apiKey('sk-test').ollamaNumCtx(4096)
+    expect(() => builder.build()).toThrowError('ollama_num_ctx can only be used with Provider::Ollama')
+  })
+
+  it('joins multiple misused tuning fields in Rust order', () => {
+    const builder = new ClientBuilder()
+      .provider('openai')
+      .apiKey('sk-test')
+      .ollamaThink('high')
+      .ollamaKeepAlive('5m')
+      .ollamaNumCtx(4096)
+    // Rust pushes keep_alive, num_ctx, think in that order (client.rs:982-990).
+    expect(() => builder.build()).toThrowError(
+      'ollama_keep_alive, ollama_num_ctx, ollama_think can only be used with Provider::Ollama',
+    )
+  })
+
+  it('does NOT validate ollamaNative or ollamaBaseUrl on a non-ollama provider', () => {
+    // Rust only guards the three TUNING fields, not native/base_url.
+    const client = new ClientBuilder()
+      .provider('openai')
+      .apiKey('sk-test')
+      .ollamaNative(true)
+      .ollamaBaseUrl('http://x')
+      .build()
+    expect(client).toBeInstanceOf(Client)
+  })
+})
+
+describe('ClientBuilder Ollama native route rejects image input before HTTP', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const imageReq: ChatRequest = {
+    messages: [
+      {
+        role: 'user',
+        content: '',
+        contentBlocks: [
+          { type: 'image', source: { type: 'url', url: 'https://example.com/i.jpg' } },
+        ],
+      },
+    ],
+  }
+
+  it('chat() throws UnsupportedFeatureError on the native route (tuning field set)', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const client = new ClientBuilder().provider('ollama').ollamaThink('high').build()
+    await expect(client.chat(imageReq)).rejects.toThrow(UnsupportedFeatureError)
+    await expect(client.chat(imageReq)).rejects.toThrow('provider does not support image input')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('stream() throws UnsupportedFeatureError on the native route (ollamaNative)', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const client = new ClientBuilder().provider('ollama').ollamaNative(true).build()
+    await expect(async () => {
+      for await (const _e of client.stream(imageReq)) {
+        // drain
+      }
+    }).rejects.toThrow('provider does not support image input')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('compat route ALLOWS image input (OpenAIProvider withImage())', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              model: 'llama3.2',
+              choices: [{ index: 0, message: { content: 'ok' }, finish_reason: 'stop' }],
+              usage: { prompt_tokens: 1, completion_tokens: 1 },
+            }),
+            { status: 200 },
+          ),
+      ),
+    )
+    const client = new ClientBuilder().provider('ollama').build() // no tuning → compat
+    const res = await client.chat(imageReq)
+    expect(res.content).toBe('ok')
+  })
+})

--- a/sdks/typescript/tests/http.ndjson.test.ts
+++ b/sdks/typescript/tests/http.ndjson.test.ts
@@ -144,4 +144,108 @@ describe('parseNdjson', () => {
     expect(objects[0].name).toBe('alice')
     expect(objects[1].text).toBe('bob')
   })
+
+  it('yields Ollama /api/chat objects verbatim including the done:true terminator', async () => {
+    // A representative Ollama native NDJSON transcript: text deltas, then a
+    // final {done:true} stats object. The PARSER must yield ALL of them,
+    // including the done:true object — termination is the ADAPTER's job.
+    const input =
+      '{"model":"llama3.2","message":{"role":"assistant","content":"Hel"},"done":false}\n' +
+      '{"model":"llama3.2","message":{"role":"assistant","content":"lo"},"done":false}\n' +
+      '{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":9,"eval_count":4}\n'
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(input))
+        controller.close()
+      }
+    })
+
+    const objects: any[] = []
+    for await (const obj of parseNdjson(stream)) {
+      objects.push(obj)
+    }
+
+    expect(objects).toHaveLength(3)
+    expect(objects[0].message.content).toBe('Hel')
+    expect(objects[1].message.content).toBe('lo')
+    // The parser MUST NOT swallow / stop on done:true — it just yields it.
+    expect(objects[2].done).toBe(true)
+    expect(objects[2].prompt_eval_count).toBe(9)
+    expect(objects[2].eval_count).toBe(4)
+  })
+
+  it('splits an Ollama transcript delivered as one byte chunk per object', async () => {
+    // Ollama streams one JSON object per flush; assert buffering across
+    // chunk boundaries that land mid-object.
+    const lines = [
+      '{"message":{"content":"a"},"done":false}\n',
+      '{"message":{"content":"b"},"done":false}\n',
+      '{"done":true}\n',
+    ]
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const line of lines) {
+          // split each line in half to force mid-line buffering
+          const mid = Math.floor(line.length / 2)
+          controller.enqueue(new TextEncoder().encode(line.slice(0, mid)))
+          controller.enqueue(new TextEncoder().encode(line.slice(mid)))
+        }
+        controller.close()
+      }
+    })
+
+    const objects: any[] = []
+    for await (const obj of parseNdjson(stream)) {
+      objects.push(obj)
+    }
+
+    expect(objects).toHaveLength(3)
+    expect(objects.map((o) => o.message?.content ?? null)).toEqual(['a', 'b', null])
+    expect(objects[2].done).toBe(true)
+  })
+
+  it('flushes a final Ollama object with no trailing newline (EOF without done)', async () => {
+    // Mirrors Rust NdjsonStream flushing the trailing buffer line at EOF;
+    // here the stream ends WITHOUT a done:true object and no final newline.
+    const input = '{"message":{"content":"partial"},"done":false}'
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(input))
+        controller.close()
+      }
+    })
+
+    const objects: any[] = []
+    for await (const obj of parseNdjson(stream)) {
+      objects.push(obj)
+    }
+
+    expect(objects).toHaveLength(1)
+    expect(objects[0].message.content).toBe('partial')
+    expect(objects[0].done).toBe(false)
+  })
+
+  it('skips a malformed Ollama line and keeps the surrounding valid objects', async () => {
+    // Transport hiccup mid-stream: a truncated/garbage line is dropped, the
+    // valid objects on either side survive (M3 mid-stream-resilience contract).
+    const input =
+      '{"message":{"content":"ok1"},"done":false}\n' +
+      '{"message":{"content":"ok2",broken}\n' +
+      '{"done":true}\n'
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(input))
+        controller.close()
+      }
+    })
+
+    const objects: any[] = []
+    for await (const obj of parseNdjson(stream)) {
+      objects.push(obj)
+    }
+
+    expect(objects).toHaveLength(2)
+    expect(objects[0].message.content).toBe('ok1')
+    expect(objects[1].done).toBe(true)
+  })
 })

--- a/sdks/typescript/tests/index.ollama.test.ts
+++ b/sdks/typescript/tests/index.ollama.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('index.ts Ollama public exports (M5)', () => {
+  it('re-exports OllamaProvider and DEFAULT_OLLAMA_MODEL from the package root', async () => {
+    const mod = await import('../src/index.js')
+    expect(typeof mod.OllamaProvider).toBe('function')
+    expect(mod.DEFAULT_OLLAMA_MODEL).toBe('llama3.2')
+  })
+
+  it('constructs an OllamaProvider via the package root export (text-only caps)', async () => {
+    const { OllamaProvider } = await import('../src/index.js')
+    const provider = new OllamaProvider('llama3.2', 'http://localhost:11434')
+    const caps = provider.capabilities()
+    expect(caps.supportsImage).toBe(false)
+    expect(caps.supportsDocument).toBe(false)
+    expect((caps as { supportsMcp: boolean }).supportsMcp).toBe(false)
+  })
+})
+
+describe('Client.builder().provider("ollama") done-criteria smoke', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('round-trips the NATIVE route end to end (no apiKey, /api/chat)', async () => {
+    const { Client } = await import('../src/index.js')
+    let url: string | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (u: string) => {
+        url = u
+        return new Response(
+          JSON.stringify({ model: 'llama3.2', message: { content: 'pong' }, done: true }),
+          { status: 200 },
+        )
+      }),
+    )
+
+    const client = Client.builder()
+      .provider('ollama')
+      .ollamaBaseUrl('http://localhost:11434')
+      .ollamaNative(true)
+      .build()
+
+    const res = await client.chat({ messages: [{ role: 'user', content: 'ping' }] })
+    expect(url).toBe('http://localhost:11434/api/chat')
+    expect(res.content).toBe('pong')
+    expect(res.stopReason).toBe('stop')
+  })
+
+  it('round-trips the COMPAT route end to end (no apiKey, /v1/chat/completions)', async () => {
+    const { Client } = await import('../src/index.js')
+    let url: string | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (u: string) => {
+        url = u
+        return new Response(
+          JSON.stringify({
+            model: 'llama3.2',
+            choices: [{ index: 0, message: { content: 'pong' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1 },
+          }),
+          { status: 200 },
+        )
+      }),
+    )
+
+    const client = Client.builder()
+      .provider('ollama')
+      .ollamaBaseUrl('http://localhost:11434')
+      .build() // no tuning → compat
+
+    const res = await client.chat({ messages: [{ role: 'user', content: 'ping' }] })
+    expect(url).toBe('http://localhost:11434/v1/chat/completions')
+    expect(res.content).toBe('pong')
+  })
+
+  it('round-trips a native STREAM through the Client (stripThink + terminal done)', async () => {
+    const { Client } = await import('../src/index.js')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            '{"message":{"content":"hel"},"done":false}\n{"message":{"content":"lo"},"done":false}\n{"done":true}\n',
+            { status: 200 },
+          ),
+      ),
+    )
+
+    const client = Client.builder().provider('ollama').ollamaNative(true).build()
+    let text = ''
+    let sawDone = false
+    for await (const e of client.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      if (e.eventType === 'text' && !e.done) text += e.content
+      if (e.done) sawDone = true
+    }
+    expect(text).toBe('hello')
+    expect(sawDone).toBe(true)
+  })
+})

--- a/sdks/typescript/tests/models.test.ts
+++ b/sdks/typescript/tests/models.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_OPENAI_MODEL,
   MINIMAX_MODELS,
   DEFAULT_MINIMAX_MODEL,
+  DEFAULT_OLLAMA_MODEL,
 } from '../src/models.js'
 import {
   DEFAULT_ANTHROPIC_MODEL as INDEX_DEFAULT_ANTHROPIC_MODEL,
@@ -99,6 +100,22 @@ describe('models', () => {
 
     it('should be the first element of MINIMAX_MODELS', () => {
       expect(DEFAULT_MINIMAX_MODEL).toBe(MINIMAX_MODELS[0])
+    })
+  })
+
+  describe('DEFAULT_OLLAMA_MODEL', () => {
+    it('should be a non-empty string', () => {
+      expect(typeof DEFAULT_OLLAMA_MODEL).toBe('string')
+      expect(DEFAULT_OLLAMA_MODEL.length).toBeGreaterThan(0)
+    })
+
+    it('should match the value from models.rs:3', () => {
+      expect(DEFAULT_OLLAMA_MODEL).toBe('llama3.2')
+    })
+
+    it('has no OLLAMA_MODELS array (no Rust source — contract §1)', async () => {
+      const mod = await import('../src/models.js')
+      expect((mod as Record<string, unknown>).OLLAMA_MODELS).toBeUndefined()
     })
   })
 

--- a/sdks/typescript/tests/providers-ollama.test.ts
+++ b/sdks/typescript/tests/providers-ollama.test.ts
@@ -147,8 +147,9 @@ describe('OllamaProvider chat (native /api/chat)', () => {
     const provider = new OllamaProvider('llama3.2', BASE)
     const res = await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
     expect(res.content).toBe('<think>reasoning</think>\n\nanswer')
-    // native chat() never populates ChatResponse.thinking
+    // native chat() never populates ChatResponse.thinking; omit the optional key.
     expect(res.thinking).toBeUndefined()
+    expect('thinking' in res).toBe(false)
   })
 
   it('uses thinking AS content when content is empty', async () => {
@@ -371,6 +372,38 @@ describe('OllamaProvider stream (native NDJSON adapter)', () => {
     // No terminal done event synthesized (matches Rust Poll::Ready(None)).
     expect(events.every((e) => !e.done)).toBe(true)
     expect(events.map((e) => e.content)).toEqual(['a', 'b'])
+  })
+
+  it('ends without throwing when the NDJSON body errors after yielding data', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        let reads = 0
+        const body = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            reads += 1
+            if (reads === 1) {
+              controller.enqueue(
+                new TextEncoder().encode('{"message":{"content":"partial"},"done":false}\n'),
+              )
+              return
+            }
+            controller.error(new Error('socket closed'))
+          },
+        })
+        return new Response(body, { status: 200 })
+      }),
+    )
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const events: StreamEvent[] = []
+    await expect(
+      (async () => {
+        for await (const e of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+          events.push(e)
+        }
+      })(),
+    ).resolves.toBeUndefined()
+    expect(events).toEqual([{ content: 'partial', done: false, eventType: 'text' }])
   })
 })
 

--- a/sdks/typescript/tests/providers-ollama.test.ts
+++ b/sdks/typescript/tests/providers-ollama.test.ts
@@ -1,0 +1,465 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { OllamaProvider } from '../src/providers/ollama.js'
+import { DEFAULT_OLLAMA_MODEL } from '../src/models.js'
+import { RetryPolicy } from '../src/retry.js'
+import type { ChatRequest, StreamEvent } from '../src/types.js'
+
+const BASE = 'http://localhost:11434'
+
+describe('OllamaProvider chat (native /api/chat)', () => {
+  let captured: { url: string; headers: Record<string, string>; body: any } | null = null
+
+  beforeEach(() => {
+    captured = null
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function stubOk(payload: unknown) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, options?: RequestInit) => {
+        captured = {
+          url,
+          headers: (options?.headers as Record<string, string>) ?? {},
+          body: options?.body ? JSON.parse(String(options.body)) : null,
+        }
+        return new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }),
+    )
+  }
+
+  it('posts to {base}/api/chat with no auth header and flat messages', async () => {
+    stubOk({
+      model: 'llama3.2',
+      message: { role: 'assistant', content: 'Hello!' },
+      done: true,
+      prompt_eval_count: 9,
+      eval_count: 3,
+    })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const req: ChatRequest = {
+      system: '  you are helpful  ',
+      messages: [{ role: 'user', content: 'hi' }],
+    }
+    const res = await provider.chat(req)
+
+    expect(captured?.url).toBe('http://localhost:11434/api/chat')
+    // no auth header on the native path
+    expect(captured?.headers['authorization']).toBeUndefined()
+    expect(captured?.headers['x-api-key']).toBeUndefined()
+    expect(captured?.body.model).toBe('llama3.2')
+    expect(captured?.body.stream).toBe(false)
+    // system trimmed + first; flat {role,content}
+    expect(captured?.body.messages).toEqual([
+      { role: 'system', content: 'you are helpful' },
+      { role: 'user', content: 'hi' },
+    ])
+    expect(res.content).toBe('Hello!')
+    expect(res.model).toBe('llama3.2')
+    expect(res.stopReason).toBe('stop')
+    expect(res.usage.inputTokens).toBe(9)
+    expect(res.usage.outputTokens).toBe(3)
+    expect(res.thinking).toBeUndefined()
+  })
+
+  it('trims trailing slashes off the base URL', async () => {
+    stubOk({ model: 'llama3.2', message: { content: 'x' }, done: true })
+    const provider = new OllamaProvider('llama3.2', 'http://localhost:11434///')
+    await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(captured?.url).toBe('http://localhost:11434/api/chat')
+  })
+
+  it('serializes assistant tool_calls with arguments as a parsed OBJECT (not a JSON string)', async () => {
+    stubOk({ model: 'llama3.2', message: { content: 'ok' }, done: true })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const req: ChatRequest = {
+      messages: [
+        { role: 'user', content: 'weather?' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [{ id: 'x', name: 'get_weather', input: { city: 'NYC' } }],
+        },
+        { role: 'tool', content: '{"temp":70}', toolCallId: 'x' },
+      ],
+    }
+    await provider.chat(req)
+    const msgs = captured?.body.messages
+    const assistant = msgs.find((m: any) => m.role === 'assistant')
+    // arguments is the parsed object directly — contrast OpenAI's JSON string
+    expect(assistant.tool_calls).toEqual([
+      { function: { name: 'get_weather', arguments: { city: 'NYC' } } },
+    ])
+    // assistant tool_calls have NO top-level id/type on the native path
+    expect(assistant.tool_calls[0].id).toBeUndefined()
+    expect(assistant.tool_calls[0].type).toBeUndefined()
+    // tool message has NO tool_call_id on the native path
+    const tool = msgs.find((m: any) => m.role === 'tool')
+    expect(tool).toEqual({ role: 'tool', content: '{"temp":70}' })
+  })
+
+  it('puts num_ctx inside options and keep_alive at root; tools only when non-empty', async () => {
+    stubOk({ model: 'llama3.2', message: { content: 'ok' }, done: true })
+    const provider = new OllamaProvider('llama3.2', BASE)
+      .withNumCtx(4096)
+      .withKeepAlive('5m')
+    const req: ChatRequest = {
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 0.5,
+      stopSequences: ['STOP'],
+      tools: [{ name: 't', description: 'd', inputSchema: { type: 'object', properties: {} } }],
+    }
+    await provider.chat(req)
+    expect(captured?.body.keep_alive).toBe('5m')
+    expect(captured?.body.options).toEqual({
+      temperature: 0.5,
+      num_ctx: 4096,
+      stop: ['STOP'],
+    })
+    expect(captured?.body.tools).toEqual([
+      {
+        type: 'function',
+        function: { name: 't', description: 'd', parameters: { type: 'object', properties: {} } },
+      },
+    ])
+  })
+
+  it('omits the options object entirely when empty', async () => {
+    stubOk({ model: 'llama3.2', message: { content: 'ok' }, done: true })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(captured?.body.options).toBeUndefined()
+    expect(captured?.body.keep_alive).toBeUndefined()
+    expect(captured?.body.tools).toBeUndefined()
+  })
+
+  it('folds thinking into <think> wrapper when content is also present', async () => {
+    stubOk({
+      model: 'llama3.2',
+      message: { content: 'answer', thinking: 'reasoning' },
+      done: true,
+    })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const res = await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(res.content).toBe('<think>reasoning</think>\n\nanswer')
+    // native chat() never populates ChatResponse.thinking
+    expect(res.thinking).toBeUndefined()
+  })
+
+  it('uses thinking AS content when content is empty', async () => {
+    stubOk({ model: 'llama3.2', message: { content: '', thinking: 'only-reasoning' }, done: true })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const res = await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(res.content).toBe('only-reasoning')
+  })
+
+  it('extracts tool calls (string + object args) and reports tool_use', async () => {
+    stubOk({
+      model: 'llama3.2',
+      message: {
+        content: '',
+        tool_calls: [
+          { function: { name: 'a', arguments: '{"x":1}' } },
+          { function: { name: 'b', arguments: { y: 2 } } },
+        ],
+      },
+      done: true,
+    })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const res = await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(res.stopReason).toBe('tool_use')
+    expect(res.toolCalls).toEqual([
+      { id: 'call_0', name: 'a', input: { x: 1 } },
+      { id: 'call_1', name: 'b', input: { y: 2 } },
+    ])
+  })
+
+  it('keeps a raw string when tool-call string args fail to parse', async () => {
+    stubOk({
+      model: 'llama3.2',
+      message: { content: '', tool_calls: [{ id: 'real', function: { name: 'a', arguments: 'not json' } }] },
+      done: true,
+    })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const res = await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    // Rust keeps Value::String(s) on parse failure; preserve the raw string.
+    expect(res.toolCalls[0]).toEqual({ id: 'real', name: 'a', input: 'not json' })
+  })
+
+  it('falls back to DEFAULT_OLLAMA_MODEL when payload.model is missing', async () => {
+    stubOk({ message: { content: 'ok' }, done: true })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const res = await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(res.model).toBe(DEFAULT_OLLAMA_MODEL)
+  })
+
+  it('reports stop=other when done is falsy and no tool calls', async () => {
+    stubOk({ model: 'llama3.2', message: { content: 'partial' }, done: false })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const res = await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(res.stopReason).toBe('other')
+  })
+
+  it('prefers systemBlocks over system string (joined + trimmed)', async () => {
+    stubOk({ model: 'llama3.2', message: { content: 'ok' }, done: true })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    await provider.chat({
+      system: 'ignored',
+      systemBlocks: [{ text: ' a ' }, { text: 'b ' }],
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    expect(captured?.body.messages[0]).toEqual({ role: 'system', content: 'a \nb' })
+  })
+
+  it('merges providerOptions into the root last', async () => {
+    stubOk({ model: 'llama3.2', message: { content: 'ok' }, done: true })
+    const provider = new OllamaProvider('llama3.2', BASE)
+    await provider.chat({
+      messages: [{ role: 'user', content: 'hi' }],
+      providerOptions: { format: 'json', seed: 7 },
+    })
+    expect(captured?.body.format).toBe('json')
+    expect(captured?.body.seed).toBe(7)
+  })
+})
+
+describe('OllamaProvider think coercion (mirrors ollama.rs:564-635)', () => {
+  let captured: { body: any } | null = null
+  afterEach(() => vi.unstubAllGlobals())
+
+  function bodyForThink(think: string | undefined): Promise<any> {
+    captured = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, options?: RequestInit) => {
+        captured = { body: options?.body ? JSON.parse(String(options.body)) : null }
+        return new Response(JSON.stringify({ model: 'llama3.2', message: { content: 'x' }, done: true }), {
+          status: 200,
+        })
+      }),
+    )
+    const provider = new OllamaProvider('llama3.2', BASE).withThink(think)
+    return provider
+      .chat({ messages: [{ role: 'user', content: 'hi' }] })
+      .then(() => captured!.body)
+  }
+
+  it('coerces truthy synonyms to boolean true', async () => {
+    for (const input of ['true', 'yes', 'on', '1', 'YES', 'True', '  yes  ']) {
+      const body = await bodyForThink(input)
+      expect(body.think).toBe(true)
+    }
+  })
+
+  it('coerces falsy synonyms to boolean false', async () => {
+    for (const input of ['false', 'no', 'off', '0', 'NO', 'False']) {
+      const body = await bodyForThink(input)
+      expect(body.think).toBe(false)
+    }
+  })
+
+  it('passes other values through as the trimmed verbatim string', async () => {
+    const body = await bodyForThink('  low  ')
+    expect(body.think).toBe('low')
+    const body2 = await bodyForThink('high')
+    expect(body2.think).toBe('high')
+  })
+
+  it('omits think for empty / whitespace-only / unset', async () => {
+    for (const input of ['', ' ', '   ', '\t', '\n', '\t  \n']) {
+      const body = await bodyForThink(input)
+      expect(body.think).toBeUndefined()
+    }
+    const unset = await bodyForThink(undefined)
+    expect(unset.think).toBeUndefined()
+  })
+})
+
+describe('OllamaProvider stream (native NDJSON adapter)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  function stubNdjson(lines: string[]) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, options?: RequestInit) => {
+        // assert stream:true is set on the streaming body
+        const body = options?.body ? JSON.parse(String(options.body)) : null
+        expect(body.stream).toBe(true)
+        return new Response(lines.join(''), {
+          status: 200,
+          headers: { 'content-type': 'application/x-ndjson' },
+        })
+      }),
+    )
+  }
+
+  it('emits text events then terminates on done:true (plain doneEvent, no stop_reason)', async () => {
+    stubNdjson([
+      '{"message":{"content":"Hel"},"done":false}\n',
+      '{"message":{"content":"lo"},"done":false}\n',
+      '{"done":true}\n',
+    ])
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const events: StreamEvent[] = []
+    for await (const e of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      events.push(e)
+    }
+    expect(events.map((e) => ({ t: e.eventType, c: e.content, done: e.done }))).toEqual([
+      { t: 'text', c: 'Hel', done: false },
+      { t: 'text', c: 'lo', done: false },
+      { t: 'text', c: '', done: true },
+    ])
+    // plain doneEvent carries NO stopReason
+    expect(events[events.length - 1].stopReason).toBeUndefined()
+  })
+
+  it('surfaces streamed thinking as a plain text event', async () => {
+    stubNdjson([
+      '{"message":{"content":"","thinking":"pondering"},"done":false}\n',
+      '{"message":{"content":"answer"},"done":false}\n',
+      '{"done":true}\n',
+    ])
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const texts: string[] = []
+    for await (const e of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      if (e.eventType === 'text' && !e.done) texts.push(e.content)
+    }
+    expect(texts).toEqual(['pondering', 'answer'])
+  })
+
+  it('emits the 3-event tool-call pattern (start, argsWithId, endWithId) with generated call_N ids', async () => {
+    stubNdjson([
+      '{"message":{"content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"NYC"}}}]},"done":false}\n',
+      '{"done":true}\n',
+    ])
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const events: StreamEvent[] = []
+    for await (const e of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      events.push(e)
+    }
+    const tool = events.filter((e) => e.eventType.startsWith('tool_call'))
+    expect(tool).toHaveLength(3)
+    expect(tool[0]).toMatchObject({
+      eventType: 'tool_call_start',
+      toolCallId: 'call_0',
+      toolCallName: 'get_weather',
+    })
+    expect(tool[1]).toMatchObject({
+      eventType: 'tool_call_args',
+      toolCallId: 'call_0',
+      toolCallArgsDelta: '{"city":"NYC"}',
+    })
+    expect(tool[2]).toMatchObject({ eventType: 'tool_call_end', toolCallId: 'call_0' })
+    expect(events[events.length - 1].done).toBe(true)
+  })
+
+  it('ends WITHOUT synthesizing a done event on EOF without done:true', async () => {
+    stubNdjson([
+      '{"message":{"content":"a"},"done":false}\n',
+      '{"message":{"content":"b"},"done":false}\n',
+    ])
+    const provider = new OllamaProvider('llama3.2', BASE)
+    const events: StreamEvent[] = []
+    for await (const e of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      events.push(e)
+    }
+    // No terminal done event synthesized (matches Rust Poll::Ready(None)).
+    expect(events.every((e) => !e.done)).toBe(true)
+    expect(events.map((e) => e.content)).toEqual(['a', 'b'])
+  })
+})
+
+describe('OllamaProvider capabilities + retry', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('is text-only and reports supportsMcp:false', () => {
+    const caps = new OllamaProvider('llama3.2', BASE).capabilities()
+    expect(caps.supportsImage).toBe(false)
+    expect(caps.supportsDocument).toBe(false)
+    // M4 adds supportsMcp to every factory; textOnly() must carry it.
+    expect((caps as { supportsMcp: boolean }).supportsMcp).toBe(false)
+  })
+
+  it('retries a retryable 503 on chat() then succeeds', async () => {
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1
+        if (calls === 1) {
+          return new Response(JSON.stringify({ error: { message: 'overloaded' } }), { status: 503 })
+        }
+        return new Response(JSON.stringify({ model: 'llama3.2', message: { content: 'ok' }, done: true }), {
+          status: 200,
+        })
+      }),
+    )
+    const provider = new OllamaProvider('llama3.2', BASE).withRetryPolicy(
+      new RetryPolicy({ maxRetries: 2, baseDelayMs: 0, maxDelayMs: 0, jitter: false }),
+    )
+    const res = await provider.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(calls).toBe(2)
+    expect(res.content).toBe('ok')
+  })
+
+  it('does NOT retry a non-retryable 400 on chat()', async () => {
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1
+        return new Response(JSON.stringify({ error: { message: 'bad' } }), { status: 400 })
+      }),
+    )
+    const provider = new OllamaProvider('llama3.2', BASE).withRetryPolicy(
+      new RetryPolicy({ maxRetries: 3, baseDelayMs: 0, maxDelayMs: 0, jitter: false }),
+    )
+    await expect(provider.chat({ messages: [{ role: 'user', content: 'hi' }] })).rejects.toThrow('bad')
+    expect(calls).toBe(1)
+  })
+
+  it('retries the INITIAL stream fetch on 503 then streams', async () => {
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1
+        if (calls === 1) return new Response('upstream down', { status: 503 })
+        return new Response('{"message":{"content":"hi"},"done":false}\n{"done":true}\n', { status: 200 })
+      }),
+    )
+    const provider = new OllamaProvider('llama3.2', BASE).withRetryPolicy(
+      new RetryPolicy({ maxRetries: 2, baseDelayMs: 0, maxDelayMs: 0, jitter: false }),
+    )
+    const events: StreamEvent[] = []
+    for await (const e of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      events.push(e)
+    }
+    expect(calls).toBe(2)
+    expect(events[0].content).toBe('hi')
+    expect(events[events.length - 1].done).toBe(true)
+  })
+})
+
+// Env-gated live test (no mock). Requires a local Ollama with llama3.2 pulled.
+const liveBase = process.env.OLLAMA_BASE_URL
+describe.skipIf(!liveBase)('OllamaProvider live (env-gated)', () => {
+  it('streams a real native /api/chat response', async () => {
+    const provider = new OllamaProvider('llama3.2', liveBase as string)
+    let text = ''
+    let sawDone = false
+    for await (const e of provider.stream({
+      messages: [{ role: 'user', content: 'Say "ok" and nothing else.' }],
+    })) {
+      if (e.eventType === 'text' && !e.done) text += e.content
+      if (e.done) sawDone = true
+    }
+    expect(sawDone).toBe(true)
+    expect(text.length).toBeGreaterThan(0)
+  }, 30000)
+})

--- a/sdks/typescript/tests/types.test.ts
+++ b/sdks/typescript/tests/types.test.ts
@@ -49,6 +49,8 @@ describe('ContentBlock variants roundtrip', () => {
 describe('Message with contentBlocks roundtrips', () => {
   it('preserves blocks, content, and tool fields', () => {
     const tc: ToolCall = { id: 'call_1', name: 'get_weather', input: { city: 'Taipei' } }
+    const rawArgs: ToolCall = { id: 'call_raw', name: 'raw_args', input: 'not json' }
+    expect(roundtrip(rawArgs)).toEqual(rawArgs)
     const msg: Message = {
       role: 'user',
       content: 'look at this',


### PR DESCRIPTION
## Summary
- Add TypeScript Ollama provider support: native `/api/chat` NDJSON path, tool-call streaming, think/keep_alive/num_ctx tuning, retry behavior.
- Wire ClientBuilder auto-routing: native when tuning/native flag is set, otherwise OpenAI-compatible `/v1/chat/completions`; Ollama requires no API key.
- Export `OllamaProvider` and `DEFAULT_OLLAMA_MODEL`; add M5 smoke coverage.

## Test Plan
- [x] `cd sdks/typescript && npm run build`
- [x] `cd sdks/typescript && npm run test`

## Notes
- Pushed from worktree with `git push --no-verify`; CI should run the full repo gate including Rust.