### PR TITLE
feat/cli cwd setters

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -37,14 +37,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.82.0
-      - name: Pin indexmap for MSRV
+      - name: Pin transitive deps for MSRV
         # indexmap >=2.14 requires hashbrown >=0.17, which itself requires
         # the unstable `edition2024` Cargo feature — unavailable on 1.82.
-        # Cargo.lock is gitignored (library crate), so without this pin
-        # CI resolves transitively to the latest indexmap on every run.
+        # uuid >=1.23 pulls getrandom 0.4, which also requires edition2024.
+        # Cargo.lock is gitignored (library crate), so without these pins
+        # CI resolves transitively to the latest compatible-looking versions
+        # on every run.
         run: |
           cargo generate-lockfile
           cargo update -p indexmap --precise 2.13.1
+          cargo update -p uuid --precise 1.18.1
       - name: Cargo build (no features)
         run: cargo build
       - name: Cargo test (no features)

--- a/docs/cli-runtime-integration-requirements.md
+++ b/docs/cli-runtime-integration-requirements.md
@@ -1,0 +1,180 @@
+# CliRuntime (§6.2) — motosan-ai Integration Requirements
+
+> **Status:** planning record for the **deferred** v1.x `CliRuntime`. Not implemented in v1.
+> **Basis:** verified source audit of **motosan-ai 0.19.0** (`../motosan-ai/sdks/rust`), 2026-06-09.
+> **Purpose:** capture exactly what `motosan-ai`'s CLI providers must add before `CliRuntime` is viable, so the work can be scheduled / handed to the motosan-ai maintainers. CliRuntime's feasibility is **gated on these provider capabilities** — that is the concrete reason v1 shipped `LoopRuntime` first and pushed CliRuntime to v1.x.
+
+## 1. What CliRuntime is, and why it depends on motosan-ai
+
+`CliRuntime` is the §6.2 `AgentRuntime` adapter that — unlike v1's in-process `LoopRuntime` (Anthropic/OpenAI HTTP API via loop's `Engine`) — **spawns an external coding-agent CLI as a subprocess** (Claude Code / Codex CLI / Gemini CLI). This is Paperclip's model: the agent *is* the CLI, inheriting its full tool set; the org just orchestrates the black box.
+
+The §6 `AgentRuntime` contract has two load-bearing requirements that LoopRuntime gets for free but CliRuntime must obtain from each CLI provider:
+
+1. **`cwd` is the cross-run state boundary** — the spawned process MUST run with actual working directory `== ctx.cwd`.
+2. **Same-issue runs reuse the same session** — conversation continuity across heartbeats (recorded in `HeartbeatRun.session_ref`).
+
+Both depend entirely on what each provider's flags expose. The three providers' capabilities are **inconsistent**, and (per the audit) **no single provider currently satisfies both `cwd` and `session` through the SDK**.
+
+## 2. Verified capability matrix (motosan-ai 0.19.0)
+
+| Capability | **ClaudeCode** (`claude-code`) | **CodexCli** (`codex-cli`) | **GeminiCli** (`gemini-cli`) |
+|---|---|---|---|
+| Set `cwd` | ✅ `.cwd()` → `Command::current_dir` (`--add-dir` only adds *extra* roots) | ✅ `.cd()` → `--cd` (Codex workspace-root flag, not OS cwd) | ✅ `.cwd()` → `Command::current_dir` (`--include-directories` only adds roots) |
+| Session continuity | ⚠️ can **set** `--session-id <uuid>` / `--resume`, but the created id is **never read back** | ❌ none (`codex exec` only; `--ephemeral` is the opposite; `thread.started` id dropped) | ⚠️ `--resume latest\|index` only; **no `session_id`**, and the `init` event's id is dropped |
+| Per-call budget cap | ✅ `--max-budget-usd` | ❌ none | ❌ none |
+| Permission mode | ✅ `--permission-mode` (6 modes) + `--dangerously-skip-permissions` | ⚠️ coarse only (`--full-auto` / `--sandbox` / bypass); **no interactive approval channel** | ✅ `--approval-mode` (default/auto_edit/yolo/plan) + `--yolo`/`--sandbox` |
+| Text stream events | ✅ | ✅ | ✅ |
+| Usage stream event (**tokens only — no $ cost field**) | ✅ (`result.usage`) | ✅ (`turn.completed`) | ✅ (`result.stats`) |
+| ToolCall / ToolResult events | ❌ dropped (`tool_use` → Other) | ❌ dropped (command/mcp/file-change → Other) | ❌ never parsed |
+| Thinking events | ❌ dropped | ❌ dropped | n/a (headless emits none) |
+| `started` synthetic event | ❌ (none in SDK) | ❌ | ❌ |
+| Stream error surfacing | (use blocking path) | ❌ swallowed → silent `done` | ❌ silent stream break (no error variant) |
+| Stop reason | plain `done()` (no reason) | none on stream | hardcoded `EndTurn` (chat) |
+
+**Cross-cutting facts (all three providers):**
+- Every agent-shaping knob (`cwd`, session, budget, permission, sandbox) is a **provider-builder field, not a `ChatRequest` field** — **except `model`**, which IS honored per-request via `ChatRequest::model` (all three providers call `build_spawn_config(request.model)`). Varying `cwd`/session **per run** means **rebuilding the provider each call** (providers are `Clone`, so cheap, but it is structural friction — and `model` shows the per-request override path already exists; see P2.4 + the §4 design note).
+- **No `env`/`envs()` injection anywhere** — the child inherits the parent process env (including auth). There is no SDK path to inject a per-run secret into the subprocess.
+- Cancellation is **`kill_on_drop` only** — no clean cancel handle.
+- Timeouts are **hardcoded** (Claude 300s, Codex/Gemini 600s) and apply mostly to the **blocking path only**; several stream paths have **no timeout**.
+
+## 3. Three findings that change the design (vs spec §6.2)
+
+**Finding 1 — the spec's "process-layer `cwd` workaround" does not exist.**
+§6.2 says when a provider lacks a cwd setter (ClaudeCode/Gemini), `CliRuntime` should "set the working directory at the process layer via `Command::current_dir(ctx.cwd)`, bypassing the provider builder." **That assumes the runtime owns the spawn.** It does not — the motosan-ai **provider** owns `Command::new(...).spawn()` (`claude_code/mod.rs:418`, `claude_code/spawn.rs:364`; `gemini_cli/mod.rs:208`, `gemini_cli/spawn.rs:180`). The runtime cannot inject `current_dir`, and there is no env passthrough to smuggle it either. `std::env::set_current_dir` is process-global — it mutates the whole process's cwd, so concurrent runs race on it — and therefore not an option. **Consequence:** `cwd` correctness for ClaudeCode/Gemini **requires an SDK change** (or bypassing motosan-ai's spawn entirely). This promotes "add a `current_dir` setter" from *nice-to-have* to **mandatory** (→ P0).
+
+**Finding 2 — ClaudeCode session is "set-only", but mintable, so continuity is achievable today.**
+The provider accepts `--session-id <uuid>` (you supply the id) and `--resume <id>`, but its stream/result parser reads only `result` + `usage` and **discards the session id the CLI mints**. So you cannot *learn* a fresh id — **but you don't need to**: the runtime can **generate its own deterministic UUID** (the CliRuntime analog of `session_key`), pass it as `--session-id` on run 1, then `--resume <same-uuid>` on subsequent runs. ClaudeCode session continuity is therefore solvable **without an SDK change**. Codex and Gemini have **no** such escape hatch.
+
+**Finding 3 — provider-level config + no env injection breaks the per-run secret model.**
+v1's security model is `SecretResolver → ctx.secrets` (per-run key, never persisted). With CLI providers, all knobs are provider-level and **there is no `env()` injection**, so a per-run secret cannot reach the child through the SDK. CliRuntime would have to rely on ambient env (weaker) until motosan-ai exposes env injection (→ P2).
+
+## 4. Required motosan-ai changes (prioritized)
+
+### P0 — makes the `cwd` contract satisfiable (without this, even the flagship is non-compliant)
+- **P0.1 — `ClaudeCodeProvider`: `cwd` / `current_dir` setter landed.** `--add-dir` remains an extra-roots mechanism, not a substitute.
+- **P0.2 — `GeminiCliProvider`: `cwd` / `current_dir` setter landed.** `--include-directories` remains an extra-roots mechanism, not a substitute.
+- CodexCli already has `.cd()` → `--cd` — nothing needed; CliRuntime just calls `.cd(ctx.cwd)`.
+
+### P1 — makes "same-issue session continuity" satisfiable
+- **P1.1 — `CodexCliProvider`: add session resume.** Capture the dropped `thread.started` `thread_id` and support `codex exec resume <thread_id>`. (Biggest Codex gap; `codex_cli/mod.rs:48-49`, `stream_json.rs:54-56`.)
+- **P1.2 — surface created session ids on all three** (ClaudeCode `result`, Codex `thread.started`, Gemini `init` all parse the id away). Needed for deterministic cross-run resume. (ClaudeCode has the mint-your-own workaround; Codex/Gemini do not.)
+- **P1.3 — `GeminiCliProvider`: expose a readable `session_id`** so a *specific* conversation can be resumed (today only `--resume latest|index`).
+
+### P2 — agent-backend quality
+- **P2.1 — `env`/`envs()` injection** on all providers, so a per-run `SecretBundle` can reach the child (aligns with the org's `SecretResolver` model).
+- **P2.2 — ToolCall / ToolResult stream events** (currently all dropped) so a runtime can observe/gate tool use.
+- **P2.3 — surface stream errors + a real `stop_reason`** (Codex/Gemini currently end silently on error); **configurable timeout** (now hardcoded, blocking-path only); a **cancel handle** (now `kill_on_drop` only).
+- **P2.4 — (structural) allow per-`ChatRequest` overrides** for `cwd`/session/budget, to avoid rebuilding the provider every run.
+
+> **Design note — where `cwd`/session should live (fork for the motosan-ai maintainers).**
+> The §5 patches add `cwd` as a **provider-builder field**. But `model` already rides on `ChatRequest` and is honored per-request (`build_spawn_config(request.model)` in all three providers) — that is exactly the per-request-override pattern P2.4 asks for, *already shipped for one knob*. So there are two routes:
+> - **(a) builder field** — the §5 patches as written. Smallest diff; keeps the "rebuild the provider to vary `cwd`/session per run" friction this doc flags.
+> - **(b) `ChatRequest` / `provider_options`** — put `cwd`/session alongside `model`. More consistent, removes the per-run rebuild, and **folds P2.4 into P0** instead of deferring it.
+>
+> The §5 drafts take route (a) because it is the minimal change that unblocks the `cwd` contract. If motosan-ai would rather not entrench the builder-field pattern, route (b) is the place to start — decide this before applying §5.
+
+## 5. P0 patch drafts (ready to apply — motosan-ai 0.19.0)
+
+Both providers spawn at **two** sites (a blocking path and an inline streaming path); the `current_dir` call must be added at **both**, fed by a new `SpawnConfig.cwd` threaded from a new provider field. Anchors are 0.19.0 line numbers.
+
+### 5.1 `ClaudeCodeProvider` — add `cwd`
+
+**`src/providers/claude_code/mod.rs`**
+```rust
+// (1) struct field — after `max_budget_usd` (~line 128):
+    /// Working directory for the spawned `claude` process. When set, the child
+    /// runs with this cwd instead of inheriting the parent's.
+    pub cwd: Option<PathBuf>,
+
+// (2) ClaudeCodeProvider::new() — after `max_budget_usd: None,` (~line 161):
+            cwd: None,
+
+// (3) builder — next to `max_budget_usd(...)` (`pub fn` at line 347):
+    /// Set the working directory for the spawned process (`Command::current_dir`).
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
+// (4) build_spawn_config — after `max_budget_usd: self.max_budget_usd,` (line 381):
+            cwd: self.cwd.clone(),
+
+// (5) stream() — right after `let mut cmd = Command::new(&config.binary_path);` (line 418):
+        if let Some(dir) = &config.cwd {
+            cmd.current_dir(dir);
+        }
+```
+
+**`src/providers/claude_code/spawn.rs`**
+```rust
+// (6) SpawnConfig field — after `binary_path` (~line 93):
+    /// Working directory for the spawned process; `None` inherits the parent's.
+    pub cwd: Option<PathBuf>,
+
+// (7) invoke_cli — right after `let mut cmd = Command::new(&config.binary_path);` (line 364):
+    if let Some(dir) = &config.cwd {
+        cmd.current_dir(dir);
+    }
+```
+(`PathBuf` is already imported in both files.)
+
+### 5.2 `GeminiCliProvider` — add `cwd`
+
+**`src/providers/gemini_cli/mod.rs`**
+```rust
+// (1) struct field — after `resume` (line 60):
+    /// Working directory for the spawned `gemini` process. When set, the child
+    /// runs with this cwd instead of inheriting the parent's.
+    pub cwd: Option<PathBuf>,
+
+// (2) GeminiCliProvider::new() — after `resume: None,` (~line 80):
+            cwd: None,
+
+// (3) builder — alongside the other setters:
+    /// Set the working directory for the spawned process (`Command::current_dir`).
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
+// (4) build_spawn_config — after `resume: self.resume.clone(),` (line 171):
+            cwd: self.cwd.clone(),
+
+// (5) stream() — right after `let mut cmd = Command::new(&config.binary_path);` (line 208):
+        if let Some(dir) = &config.cwd {
+            cmd.current_dir(dir);
+        }
+```
+
+**`src/providers/gemini_cli/spawn.rs`**
+```rust
+// (6) SpawnConfig field — after `binary_path` (~line 64):
+    /// Working directory for the spawned process; `None` inherits the parent's.
+    pub cwd: Option<PathBuf>,
+
+// (7) build_command — right after `let mut cmd = Command::new(&config.binary_path);` (line 180):
+    if let Some(dir) = &config.cwd {
+        cmd.current_dir(dir);
+    }
+```
+
+> **Tests:** add a `common_args`/spawn test asserting the child's `current_dir` is set when `cwd` is `Some` (mirror the existing `common_args_*` argv tests). Note `cwd` is **not** an argv flag, so it won't appear in `common_args` output — assert on the built `Command` instead, or expose a small `cwd()` accessor on `SpawnConfig` for the test.
+
+## 6. Viable paths today (with the degradations)
+
+- **ClaudeCode** — cwd ✅ (`.cwd(ctx.cwd)` landed), session ✅ (self-minted UUID via `--session-id`/`--resume`), budget ✅, permission ✅, tool events ❌ (synthesize `Started`/`Finished`). This is the intended flagship path; P0 is landed.
+- **CodexCli** — cwd ✅ (`.cd(ctx.cwd)` → `--cd`, not OS `current_dir`), **session ❌** → continuity degrades to "stateless-per-run, context carried by persistent files inside `cwd`"; budget/permission weak. Usable today *if* you accept stateless heartbeats.
+- **GeminiCli** — cwd ✅ (`.cwd(ctx.cwd)` landed) and session ⚠️ → still needs P1.3; lowest priority.
+
+→ The two CLI paths each miss a complementary piece, and **both missing pieces live in motosan-ai**. That is the hard gate behind the v1.x deferral.
+
+## 7. What CliRuntime (org side) does once P0/P1 land
+
+For reference, the org-side adapter is a thin `AgentRuntime` over a `motosan_ai::Client` configured for `Provider::ClaudeCode`/`CodexCli`/`GeminiCli` (feature `cli-runtime`):
+- Resolve provider + flags from `AdapterRef.config`; set `cwd` via the new setter (`.cwd(ctx.cwd)` / `.cd(ctx.cwd)`).
+- Session: mint/derive a deterministic id (the `session_key` analog), set it on run 1, resume it thereafter; record in `HeartbeatRun.session_ref`.
+- Events: synthesize `Started`/`Finished` (the SDK has neither), map `Text` + `usage` → `RunEvent::Text` + one `CostDelta`. **Note:** the SDK's usage events carry **token counts only — there is no $ cost field** (`ClaudeStreamUsage`/`CodexUsage`/`GeminiStats` are all tokens), so the `CostDelta` must be **computed from tokens × model price**, not read off the stream. Tool events absent until P2.2.
+- Conclusion: parse the §8 JSON block from the CLI's final output (same mechanism as LoopRuntime); parse failure → `Progress`.
+- Budget: map `ctx.budget_remaining_minor` → `--max-budget-usd` where available (ClaudeCode only) as double-insurance; orchestrator stage-2b hard-stop is the real gate elsewhere.
+
+With P0 landed, v1 still recommends **LoopRuntime** until P1.1 lands; the two already-validated CLI fallbacks are **CodexCli** (cwd via `--cd`, no session → stateless) and **ClaudeCode** (cwd + session).

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = "1"
 base64 = "0.22"
 thiserror = "2"
 
-motosan-agent-primitives = { path = "../../../motosan-agent-primitives", version = "0.4.0" }
+motosan-agent-primitives = "0.4.0"
 bytes = { version = "1", optional = true }
 reqwest = { version = "0.12", optional = true, features = [
   "json",

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -27,13 +27,7 @@ openai = [
   "dep:tokio",
 ]
 minimax = ["anthropic"]
-ollama = [
-  "openai",
-  "dep:reqwest",
-  "dep:tokio",
-  "dep:tokio-stream",
-  "dep:bytes",
-]
+ollama = ["openai", "dep:reqwest", "dep:tokio", "dep:tokio-stream", "dep:bytes"]
 # Retained as an alias for backwards compatibility. The `ollama_native(true)`
 # runtime flag still controls explicit routing — see ClientBuilder::ollama_native.
 # As of 0.15.0 the OllamaProvider (/api/chat) is also auto-selected whenever

--- a/sdks/rust/crates/anthropic-oauth/Cargo.toml
+++ b/sdks/rust/crates/anthropic-oauth/Cargo.toml
@@ -12,7 +12,9 @@ keywords = ["anthropic", "claude", "oauth", "authentication"]
 categories = ["authentication", "api-bindings"]
 
 [dependencies]
-motosan-ai-oauth = { version = "0.2", path = "../motosan-ai-oauth", features = ["anthropic"] }
+motosan-ai-oauth = { version = "0.2", path = "../motosan-ai-oauth", features = [
+  "anthropic",
+] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/sdks/rust/crates/codex-oauth/Cargo.toml
+++ b/sdks/rust/crates/codex-oauth/Cargo.toml
@@ -12,7 +12,9 @@ keywords = ["openai", "codex", "oauth", "authentication"]
 categories = ["authentication", "api-bindings"]
 
 [dependencies]
-motosan-ai-oauth = { version = "0.2", path = "../motosan-ai-oauth", features = ["codex"] }
+motosan-ai-oauth = { version = "0.2", path = "../motosan-ai-oauth", features = [
+  "codex",
+] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1137,7 +1137,9 @@ mod tests {
 
             let msgs = body["messages"].as_array().expect("messages array");
             let last = msgs.last().expect("a message");
-            let blocks = last["content"].as_array().expect("content must be a block array");
+            let blocks = last["content"]
+                .as_array()
+                .expect("content must be a block array");
             let cc = &blocks.last().expect("a content block")["cache_control"]["type"];
             assert_eq!(cc, "ephemeral", "oauth={oauth}");
         }
@@ -1164,9 +1166,7 @@ mod tests {
                 AnthropicRequestBuilder::new(req, "claude-opus-4-8".to_string(), oauth).build();
 
             let msgs = body["messages"].as_array().expect("messages array");
-            let blocks = msgs
-                .last()
-                .expect("a message")["content"]
+            let blocks = msgs.last().expect("a message")["content"]
                 .as_array()
                 .expect("content blocks");
             let cc = &blocks.last().expect("a content block")["cache_control"]["type"];

--- a/sdks/rust/src/providers/claude_code/mod.rs
+++ b/sdks/rust/src/providers/claude_code/mod.rs
@@ -126,6 +126,10 @@ pub struct ClaudeCodeProvider {
     pub no_session_persistence: bool,
     /// `--max-budget-usd <amount>`.
     pub max_budget_usd: Option<f64>,
+    /// Working directory for the spawned `claude` process. When set, the child
+    /// runs with this cwd (`Command::current_dir`) instead of inheriting the
+    /// parent's. The §6.2 `CliRuntime` cwd contract requires this.
+    pub cwd: Option<PathBuf>,
 }
 
 impl ClaudeCodeProvider {
@@ -159,6 +163,7 @@ impl ClaudeCodeProvider {
             agent: None,
             no_session_persistence: false,
             max_budget_usd: None,
+            cwd: None,
         }
     }
 
@@ -349,6 +354,12 @@ impl ClaudeCodeProvider {
         self
     }
 
+    /// Set the working directory for the spawned process (`Command::current_dir`).
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
     fn build_spawn_config(
         &self,
         request_model: Option<String>,
@@ -379,6 +390,7 @@ impl ClaudeCodeProvider {
             agent: self.agent.clone(),
             no_session_persistence: self.no_session_persistence,
             max_budget_usd: self.max_budget_usd,
+            cwd: self.cwd.clone(),
         }
     }
 
@@ -416,6 +428,9 @@ impl ClaudeCodeProvider {
         let config = self.build_spawn_config(request.model, append_system_prompt);
 
         let mut cmd = Command::new(&config.binary_path);
+        if let Some(dir) = &config.cwd {
+            cmd.current_dir(dir);
+        }
         // `--verbose` is required by `claude` ≥ 2.1.x when combining `--print`
         // with `--output-format=stream-json`. Without it the CLI exits with
         // "Error: When using --print, --output-format=stream-json requires
@@ -522,6 +537,13 @@ mod tests {
     fn claude_code_client_implements_provider_impl() {
         use crate::providers::ProviderImpl;
         let _client: Box<dyn ProviderImpl> = Box::new(ClaudeCodeProvider::new());
+    }
+
+    #[test]
+    fn cwd_builder_threads_into_spawn_config() {
+        let provider = ClaudeCodeProvider::new().cwd("/work/dir");
+        let cfg = provider.build_spawn_config(None, None);
+        assert_eq!(cfg.cwd.as_deref(), Some(std::path::Path::new("/work/dir")));
     }
 
     #[test]

--- a/sdks/rust/src/providers/claude_code/spawn.rs
+++ b/sdks/rust/src/providers/claude_code/spawn.rs
@@ -356,29 +356,30 @@ pub(crate) fn common_args(config: &SpawnConfig) -> Vec<OsString> {
     args
 }
 
+/// Build the blocking `claude --print ...` Command (everything except spawn).
+/// Shared construction point so working-directory / env wiring is applied and
+/// unit-testable in one place.
+fn build_command(config: &SpawnConfig) -> Command {
+    let mut cmd = Command::new(&config.binary_path);
+    cmd.arg("--print");
+    if config.agent_mode {
+        cmd.arg("--output-format").arg("json");
+    }
+    cmd.args(common_args(config));
+    cmd.arg("-"); // read prompt from stdin
+    cmd.kill_on_drop(true);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd
+}
+
 /// Invoke the `claude` CLI with `--print` and return `(text, usage)`.
 pub async fn invoke_cli(
     config: &SpawnConfig,
     prompt: &str,
 ) -> Result<(String, Usage), MotosanError> {
-    let mut cmd = Command::new(&config.binary_path);
-    cmd.arg("--print");
-
-    if config.agent_mode {
-        // Agent mode requires structured output so we can extract token
-        // usage from the `usage` field.
-        cmd.arg("--output-format").arg("json");
-    }
-
-    cmd.args(common_args(config));
-
-    // Read prompt from stdin.
-    cmd.arg("-");
-
-    cmd.kill_on_drop(true);
-    cmd.stdin(std::process::Stdio::piped());
-    cmd.stdout(std::process::Stdio::piped());
-    cmd.stderr(std::process::Stdio::piped());
+    let mut cmd = build_command(config);
 
     let mut child = cmd
         .spawn()
@@ -499,6 +500,18 @@ mod tests {
         args.iter()
             .map(|a| a.to_string_lossy().into_owned())
             .collect()
+    }
+
+    #[test]
+    fn build_command_uses_binary_and_print_args() {
+        let cmd = build_command(&empty_config());
+        let std_cmd = cmd.as_std();
+        let argv: Vec<String> = std_cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert!(argv.contains(&"--print".to_string()));
+        assert_eq!(argv.last().map(String::as_str), Some("-"));
     }
 
     #[test]

--- a/sdks/rust/src/providers/claude_code/spawn.rs
+++ b/sdks/rust/src/providers/claude_code/spawn.rs
@@ -159,6 +159,8 @@ pub struct SpawnConfig {
     /// `--max-budget-usd <amount>` — dollar cap for API calls during
     /// this session. Only meaningful under `--print`.
     pub max_budget_usd: Option<f64>,
+    /// Working directory for the spawned process; `None` inherits the parent's.
+    pub cwd: Option<PathBuf>,
 }
 
 const TIMEOUT_SECS: u64 = 300;
@@ -361,6 +363,9 @@ pub(crate) fn common_args(config: &SpawnConfig) -> Vec<OsString> {
 /// unit-testable in one place.
 fn build_command(config: &SpawnConfig) -> Command {
     let mut cmd = Command::new(&config.binary_path);
+    if let Some(dir) = &config.cwd {
+        cmd.current_dir(dir);
+    }
     cmd.arg("--print");
     if config.agent_mode {
         cmd.arg("--output-format").arg("json");
@@ -493,6 +498,7 @@ mod tests {
             agent: None,
             no_session_persistence: false,
             max_budget_usd: None,
+            cwd: None,
         }
     }
 
@@ -512,6 +518,23 @@ mod tests {
             .collect();
         assert!(argv.contains(&"--print".to_string()));
         assert_eq!(argv.last().map(String::as_str), Some("-"));
+    }
+
+    #[test]
+    fn build_command_sets_current_dir_when_cwd_present() {
+        let cfg = SpawnConfig {
+            cwd: Some(PathBuf::from("/work/dir")),
+            ..empty_config()
+        };
+        let cmd = build_command(&cfg);
+        assert_eq!(
+            cmd.as_std().get_current_dir(),
+            Some(std::path::Path::new("/work/dir"))
+        );
+        assert_eq!(
+            build_command(&empty_config()).as_std().get_current_dir(),
+            None
+        );
     }
 
     #[test]
@@ -886,6 +909,7 @@ mod tests {
             agent: Some("reviewer".to_string()),
             no_session_persistence: true,
             max_budget_usd: Some(3.0),
+            cwd: None,
         };
         assert_eq!(
             args_as_strings(&common_args(&cfg)),

--- a/sdks/rust/src/providers/gemini_cli/mod.rs
+++ b/sdks/rust/src/providers/gemini_cli/mod.rs
@@ -58,6 +58,9 @@ pub struct GeminiCliProvider {
     /// Session to resume, forwarded as `--resume <value>` (accepts
     /// `"latest"` or a numeric index).
     pub resume: Option<String>,
+    /// Working directory for the spawned `gemini` process. When set, the child
+    /// runs with this cwd (`Command::current_dir`) instead of inheriting the parent's.
+    pub cwd: Option<PathBuf>,
 }
 
 impl GeminiCliProvider {
@@ -78,6 +81,7 @@ impl GeminiCliProvider {
             extensions: Vec::new(),
             allowed_mcp_servers: Vec::new(),
             resume: None,
+            cwd: None,
         }
     }
 
@@ -158,6 +162,12 @@ impl GeminiCliProvider {
         self
     }
 
+    /// Set the working directory for the spawned process (`Command::current_dir`).
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
     fn build_spawn_config(&self, request_model: Option<String>) -> spawn::SpawnConfig {
         spawn::SpawnConfig {
             binary_path: self.binary_path.clone(),
@@ -169,6 +179,7 @@ impl GeminiCliProvider {
             extensions: self.extensions.clone(),
             allowed_mcp_servers: self.allowed_mcp_servers.clone(),
             resume: self.resume.clone(),
+            cwd: self.cwd.clone(),
         }
     }
 
@@ -206,6 +217,9 @@ impl GeminiCliProvider {
         let config = self.build_spawn_config(request.model);
 
         let mut cmd = Command::new(&config.binary_path);
+        if let Some(dir) = &config.cwd {
+            cmd.current_dir(dir);
+        }
         cmd.args(spawn::common_args(&config));
         cmd.kill_on_drop(true);
         cmd.stdin(std::process::Stdio::piped());
@@ -313,6 +327,14 @@ mod tests {
     fn gemini_cli_client_implements_provider_impl() {
         use crate::providers::ProviderImpl;
         let _client: Box<dyn ProviderImpl> = Box::new(GeminiCliProvider::new());
+    }
+
+    #[test]
+    fn cwd_builder_threads_into_spawn_config() {
+        let cfg = GeminiCliProvider::new()
+            .cwd("/work/dir")
+            .build_spawn_config(None);
+        assert_eq!(cfg.cwd.as_deref(), Some(std::path::Path::new("/work/dir")));
     }
 
     #[test]

--- a/sdks/rust/src/providers/gemini_cli/spawn.rs
+++ b/sdks/rust/src/providers/gemini_cli/spawn.rs
@@ -89,6 +89,8 @@ pub struct SpawnConfig {
     /// `"latest"` or a numeric index matching `gemini --list-sessions`.
     /// Blank strings are skipped.
     pub resume: Option<String>,
+    /// Working directory for the spawned process; `None` inherits the parent's.
+    pub cwd: Option<PathBuf>,
 }
 
 /// Hard timeout for a single `gemini -p` invocation.
@@ -178,6 +180,9 @@ pub(crate) fn common_args(config: &SpawnConfig) -> Vec<OsString> {
 /// Assemble a ready-to-spawn [`Command`] for a blocking `gemini` call.
 fn build_command(config: &SpawnConfig) -> Command {
     let mut cmd = Command::new(&config.binary_path);
+    if let Some(dir) = &config.cwd {
+        cmd.current_dir(dir);
+    }
     cmd.args(common_args(config));
 
     cmd.kill_on_drop(true);
@@ -292,6 +297,7 @@ mod tests {
             extensions: Vec::new(),
             allowed_mcp_servers: Vec::new(),
             resume: None,
+            cwd: None,
         }
     }
 
@@ -299,6 +305,22 @@ mod tests {
         args.iter()
             .map(|a| a.to_string_lossy().into_owned())
             .collect()
+    }
+
+    #[test]
+    fn build_command_sets_current_dir_when_cwd_present() {
+        let cfg = SpawnConfig {
+            cwd: Some(PathBuf::from("/work/dir")),
+            ..empty_config()
+        };
+        assert_eq!(
+            build_command(&cfg).as_std().get_current_dir(),
+            Some(std::path::Path::new("/work/dir"))
+        );
+        assert_eq!(
+            build_command(&empty_config()).as_std().get_current_dir(),
+            None
+        );
     }
 
     #[test]
@@ -504,6 +526,7 @@ mod tests {
             extensions: vec!["fast".to_string()],
             allowed_mcp_servers: vec!["fs".to_string()],
             resume: Some("latest".to_string()),
+            cwd: None,
         };
         assert_eq!(
             args_as_strings(&common_args(&cfg)),


### PR DESCRIPTION
- **refactor(claude_code): extract build_command helper for testable spawn**
- **feat(claude_code): add cwd setter (Command::current_dir) for CliRuntime**
- **feat(gemini_cli): add cwd setter (Command::current_dir) for CliRuntime**
- **docs: cwd setters landed for ClaudeCode + Gemini (P0 done)**
- **style(rust): apply rustfmt to anthropic tests**
- **style(toml): apply treefmt formatting**
