### PR TITLE
fix(oauth): omit state for random PKCE token exchange

### DIFF
--- a/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
+++ b/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `motosan-ai-oauth` are documented in this file.
 
-## [Unreleased]
+## [0.2.1] - 2026-06-13
 
 ### Fixed
 - `exchange_code` now sends `state` to the token endpoint only for

--- a/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
+++ b/sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `motosan-ai-oauth` are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- `exchange_code` now sends `state` to the token endpoint only for
+  `StateStrategy::EqualsVerifier` (Anthropic). `StateStrategy::Random`
+  providers omit it to avoid token endpoints that reject unexpected fields.
+
 ## [0.2.0] - 2026-05-18
 
 ### Added

--- a/sdks/rust/crates/motosan-ai-oauth/Cargo.toml
+++ b/sdks/rust/crates/motosan-ai-oauth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai-oauth"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/crates/motosan-ai-oauth/src/exchange.rs
+++ b/sdks/rust/crates/motosan-ai-oauth/src/exchange.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::{error::Error, unix_now, OAuthConfig, Token};
+use crate::{error::Error, unix_now, OAuthConfig, StateStrategy, Token};
 
 #[derive(Deserialize)]
 struct RawTokenResponse {
@@ -70,19 +70,20 @@ pub async fn exchange_code(
     verifier: &str,
     redirect_uri: &str,
 ) -> Result<Token, Error> {
-    // We include `state` in the token POST body to match pi-ai's reference
-    // implementation against Anthropic. Standard OAuth (RFC 6749 §4.1.3)
-    // does not require `state` on the token endpoint — most servers ignore
-    // extra fields — but Anthropic appears to validate it. Codex/Gemini
-    // tolerate the extra field.
+    // Standard OAuth (RFC 6749 §4.1.3) does not require `state` on the
+    // token endpoint, and some servers reject extra fields. Anthropic's
+    // endpoint empirically validates it, so only echo `state` for the
+    // Anthropic-style strategy where state equals the PKCE verifier.
     let mut params = vec![
         ("grant_type", "authorization_code"),
         ("code", code),
-        ("state", state),
         ("redirect_uri", redirect_uri),
         ("code_verifier", verifier),
         ("client_id", config.client_id),
     ];
+    if matches!(config.state_strategy, StateStrategy::EqualsVerifier) {
+        params.push(("state", state));
+    }
     if let Some(secret) = config.client_secret {
         params.push(("client_secret", secret));
     }
@@ -114,7 +115,7 @@ mod tests {
     use mockito::Matcher;
 
     #[tokio::test]
-    async fn exchange_code_sends_form_body_when_format_is_form() {
+    async fn exchange_code_omits_state_for_random_strategy_form_body() {
         let mut server = mockito::Server::new_async().await;
         let token_url: &'static str = Box::leak(format!("{}/token", server.url()).into_boxed_str());
 
@@ -124,12 +125,10 @@ mod tests {
                 "content-type",
                 Matcher::Regex("application/x-www-form-urlencoded".into()),
             )
-            .match_body(Matcher::AllOf(vec![
-                Matcher::UrlEncoded("grant_type".into(), "authorization_code".into()),
-                Matcher::UrlEncoded("code".into(), "AUTHCODE".into()),
-                Matcher::UrlEncoded("state".into(), "STATE".into()),
-                Matcher::UrlEncoded("client_id".into(), "test-client".into()),
-            ]))
+            .match_body(Matcher::Exact(
+                "grant_type=authorization_code&code=AUTHCODE&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcb&code_verifier=VERIFIER&client_id=test-client"
+                    .into(),
+            ))
             .with_status(200)
             .with_body(r#"{"access_token":"AT","refresh_token":"RT","expires_in":3600}"#)
             .create_async()
@@ -156,7 +155,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exchange_code_sends_json_body_when_format_is_json() {
+    async fn exchange_code_omits_state_for_random_strategy_json_body() {
         let mut server = mockito::Server::new_async().await;
         let token_url: &'static str = Box::leak(format!("{}/token", server.url()).into_boxed_str());
 
@@ -165,6 +164,43 @@ mod tests {
             .match_header("content-type", Matcher::Regex("application/json".into()))
             // Matcher::JsonString compares parsed JSON, so key order in the
             // serialized HashMap does not matter.
+            .match_body(Matcher::JsonString(
+                r#"{"grant_type":"authorization_code","code":"AUTHCODE","redirect_uri":"http://127.0.0.1/cb","code_verifier":"VERIFIER","client_id":"test-client"}"#
+                .into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"access_token":"AT","refresh_token":"RT","expires_in":3600}"#)
+            .create_async()
+            .await;
+
+        let cfg = crate::OAuthConfig {
+            client_id: "test-client",
+            client_secret: None,
+            auth_url: "https://unused/",
+            token_url,
+            scopes: &[],
+            redirect_port: None,
+            callback_path: "/auth/callback",
+            redirect_uri_host: "127.0.0.1",
+            token_body: TokenBodyFormat::Json,
+            extra_auth_params: &[],
+            state_strategy: crate::StateStrategy::Random,
+        };
+        let token = exchange_code(&cfg, "AUTHCODE", "STATE", "VERIFIER", "http://127.0.0.1/cb")
+            .await
+            .expect("ok");
+        assert_eq!(token.access_token, "AT");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn exchange_code_sends_state_for_equals_verifier_strategy_json_body() {
+        let mut server = mockito::Server::new_async().await;
+        let token_url: &'static str = Box::leak(format!("{}/token", server.url()).into_boxed_str());
+
+        let mock = server
+            .mock("POST", "/token")
+            .match_header("content-type", Matcher::Regex("application/json".into()))
             .match_body(Matcher::JsonString(
                 r#"{"grant_type":"authorization_code","code":"AUTHCODE","state":"STATE","redirect_uri":"http://127.0.0.1/cb","code_verifier":"VERIFIER","client_id":"test-client"}"#
                 .into(),
@@ -185,7 +221,7 @@ mod tests {
             redirect_uri_host: "127.0.0.1",
             token_body: TokenBodyFormat::Json,
             extra_auth_params: &[],
-            state_strategy: crate::StateStrategy::Random,
+            state_strategy: crate::StateStrategy::EqualsVerifier,
         };
         let token = exchange_code(&cfg, "AUTHCODE", "STATE", "VERIFIER", "http://127.0.0.1/cb")
             .await


### PR DESCRIPTION
## Summary
- sends `state` to the token endpoint only for `StateStrategy::EqualsVerifier`
- releases `motosan-ai-oauth v0.2.1` in Cargo.toml/CHANGELOG

## Verification
- `cargo test -p motosan-ai-oauth`
- `cargo publish -p motosan-ai-oauth --dry-run`
- pre-push gate: Python unit tests, Rust unit tests, Python live Anthropic tests, Rust live Anthropic tests

## Release
Published `motosan-ai-oauth v0.2.1` to crates.io.