### PR TITLE
feat(python): fallible stream — stream() raises StreamError mid-stream [F1/7, 0.20-parity]

### DIFF
--- a/sdks/python/motosan_ai/_stream_collect.py
+++ b/sdks/python/motosan_ai/_stream_collect.py
@@ -14,7 +14,9 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
 
     Handles text, thinking, tool-call start/args/end, usage, and terminal
     stop_reason events. Malformed streamed tool arguments are treated as an
-    empty object to match provider collector behavior.
+    empty object to match provider collector behavior. A mid-stream provider
+    error (StreamError / NetworkError / ProviderError) raised by ``events``
+    propagates out of this function uncollected.
     """
     content = ""
     thinking = ""

--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -333,18 +333,22 @@ class Client:
         last_error: RateLimitError | None = None
         max_attempts = self._max_retries + 1 if self._max_retries > 0 else 1
         for attempt in range(max_attempts):
+            yielded = False
             try:
                 stripper = ThinkStripper()
                 async for event in self._provider.stream(request):
                     if event.event_type == "text" and event.content:
                         clean = stripper.feed(event.content)
                         if clean:
+                            yielded = True
                             yield StreamEvent(content=clean, done=False)
                     else:
                         if event.done:
                             remaining = stripper.flush()
                             if remaining:
+                                yielded = True
                                 yield StreamEvent(content=remaining, done=False)
+                        yielded = True
                         yield event
                 return
             except (RateLimitError, NetworkError, ProviderError) as e:
@@ -355,7 +359,11 @@ class Client:
                     _parse_retry_after,
                 )
 
-                if not _is_retryable(e):
+                # F1: once the stream has emitted any event, a mid-stream error
+                # must propagate verbatim — retrying would replay a partially
+                # consumed request and double-emit. Only connection-time
+                # (pre-first-yield) failures are retried.
+                if yielded or not _is_retryable(e):
                     raise
                 last_error = e
                 if attempt >= self._max_retries:

--- a/sdks/python/motosan_ai/providers/anthropic.py
+++ b/sdks/python/motosan_ai/providers/anthropic.py
@@ -7,7 +7,7 @@ from typing import Any
 import httpx
 
 from motosan_ai._stream_collect import collect_stream
-from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError
+from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
 from motosan_ai.types import (
     ChatRequest,
@@ -390,101 +390,114 @@ class AnthropicProvider(BaseProvider):
         except httpx.HTTPError as exc:
             raise NetworkError(str(exc)) from exc
 
-        if not resp.is_success:
-            error_body = await resp.aread()
-            message = self._response_error_message(
-                resp.status_code, resp.headers, error_body.decode()
-            )
-            raise self._map_http_error(resp.status_code, message)
-
         current_tool_id: str | None = None
         current_stop_reason: StopReason | None = None
 
-        async for line in resp.aiter_lines():
-            if not line.startswith("data: "):
-                continue
-            data = line[6:]
-            if data == "[DONE]":
-                yield StreamEvent(content="", done=True, stop_reason=current_stop_reason)
-                return
+        try:
+            if not resp.is_success:
+                error_body = await resp.aread()
+                message = self._response_error_message(
+                    resp.status_code, resp.headers, error_body.decode()
+                )
+                raise self._map_http_error(resp.status_code, message)
 
-            try:
-                payload = json.loads(data)
-            except json.JSONDecodeError:
-                continue
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:].strip()
+                if not data or data == "[DONE]":
+                    if data == "[DONE]":
+                        yield StreamEvent(content="", done=True, stop_reason=current_stop_reason)
+                        return
+                    continue
 
-            event_type = payload.get("type")
+                try:
+                    payload = json.loads(data)
+                except json.JSONDecodeError as exc:
+                    raise StreamError(f"malformed SSE chunk: {exc}") from exc
 
-            if event_type == "message_start":
-                usage = (payload.get("message") or {}).get("usage")
-                if usage:
-                    yield StreamEvent(
-                        content="",
-                        done=False,
-                        event_type="usage",
-                        usage=_usage_from_dict(usage),
-                    )
-                continue
+                event_type = payload.get("type")
 
-            if event_type == "message_delta":
-                delta = payload.get("delta") or {}
-                reason = delta.get("stop_reason")
-                if reason:
-                    current_stop_reason = _STOP_REASON_MAP.get(reason, StopReason.other)
-                usage = payload.get("usage")
-                if usage:
-                    yield StreamEvent(
-                        content="",
-                        done=False,
-                        event_type="usage",
-                        usage=_usage_from_dict(usage),
-                    )
-                continue
+                if event_type == "message_start":
+                    usage = (payload.get("message") or {}).get("usage")
+                    if usage:
+                        yield StreamEvent(
+                            content="",
+                            done=False,
+                            event_type="usage",
+                            usage=_usage_from_dict(usage),
+                        )
+                    continue
 
-            if event_type == "content_block_start":
-                block = payload.get("content_block") or {}
-                if block.get("type") == "tool_use":
-                    current_tool_id = block.get("id", "")
-                    yield StreamEvent(
-                        content="",
-                        done=False,
-                        tool_call_id=current_tool_id,
-                        tool_call_name=block.get("name", ""),
-                        event_type="tool_call_start",
-                    )
+                if event_type == "message_delta":
+                    delta = payload.get("delta") or {}
+                    reason = delta.get("stop_reason")
+                    if reason:
+                        current_stop_reason = _STOP_REASON_MAP.get(reason, StopReason.other)
+                    usage = payload.get("usage")
+                    if usage:
+                        yield StreamEvent(
+                            content="",
+                            done=False,
+                            event_type="usage",
+                            usage=_usage_from_dict(usage),
+                        )
+                    continue
 
-            elif event_type == "content_block_delta":
-                delta = payload.get("delta") or {}
-                delta_type = delta.get("type")
-                if delta_type == "text_delta":
-                    text = delta.get("text", "")
-                    if text:
-                        yield StreamEvent(content=text, done=False)
-                elif delta_type == "thinking_delta":
-                    thinking_text = delta.get("thinking", "")
-                    if thinking_text:
-                        yield StreamEvent(content=thinking_text, done=False, event_type="thinking")
-                elif delta_type == "input_json_delta":
-                    partial = delta.get("partial_json", "")
-                    if partial:
+                if event_type == "content_block_start":
+                    block = payload.get("content_block") or {}
+                    if block.get("type") == "tool_use":
+                        current_tool_id = block.get("id", "")
                         yield StreamEvent(
                             content="",
                             done=False,
                             tool_call_id=current_tool_id,
-                            tool_call_args_delta=partial,
-                            event_type="tool_call_args",
+                            tool_call_name=block.get("name", ""),
+                            event_type="tool_call_start",
                         )
 
-            elif event_type == "content_block_stop":
-                if current_tool_id is not None:
-                    yield StreamEvent(
-                        content="",
-                        done=False,
-                        tool_call_id=current_tool_id,
-                        event_type="tool_call_end",
-                    )
-                    current_tool_id = None
+                elif event_type == "content_block_delta":
+                    delta = payload.get("delta") or {}
+                    delta_type = delta.get("type")
+                    if delta_type == "text_delta":
+                        text = delta.get("text", "")
+                        if text:
+                            yield StreamEvent(content=text, done=False)
+                    elif delta_type == "thinking_delta":
+                        thinking_text = delta.get("thinking", "")
+                        if thinking_text:
+                            yield StreamEvent(
+                                content=thinking_text, done=False, event_type="thinking"
+                            )
+                    elif delta_type == "input_json_delta":
+                        partial = delta.get("partial_json", "")
+                        if partial:
+                            yield StreamEvent(
+                                content="",
+                                done=False,
+                                tool_call_id=current_tool_id,
+                                tool_call_args_delta=partial,
+                                event_type="tool_call_args",
+                            )
 
-            elif event_type == "message_stop":
-                yield StreamEvent(content="", done=True, stop_reason=current_stop_reason)
-                return
+                elif event_type == "content_block_stop":
+                    if current_tool_id is not None:
+                        yield StreamEvent(
+                            content="",
+                            done=False,
+                            tool_call_id=current_tool_id,
+                            event_type="tool_call_end",
+                        )
+                        current_tool_id = None
+
+                elif event_type == "message_stop":
+                    yield StreamEvent(content="", done=True, stop_reason=current_stop_reason)
+                    return
+        except StreamError:
+            raise
+        except (AuthError, RateLimitError, ProviderError, NetworkError):
+            raise
+        except httpx.HTTPError as exc:
+            raise StreamError(f"stream transport error: {exc}") from exc
+        finally:
+            await resp.aclose()

--- a/sdks/python/motosan_ai/providers/gemini.py
+++ b/sdks/python/motosan_ai/providers/gemini.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import httpx
 
-from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError
+from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
 from motosan_ai.types import (
     ChatRequest,
@@ -272,66 +272,75 @@ class GeminiProvider(BaseProvider):
             )
             raise self._map_http_error(resp.status_code, message)
 
-        async for line in resp.aiter_lines():
-            if not line.startswith("data: "):
-                continue
-            data = line[len("data: ") :].strip()
-            if not data or data == "[DONE]":
-                continue
-            try:
-                payload = json.loads(data)
-            except json.JSONDecodeError:
-                continue
+        try:
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[len("data: ") :].strip()
+                if not data or data == "[DONE]":
+                    continue
+                try:
+                    payload = json.loads(data)
+                except json.JSONDecodeError as exc:
+                    raise StreamError(f"malformed SSE chunk: {exc}") from exc
 
-            candidates = payload.get("candidates") or []
-            if not candidates:
-                continue
-            candidate = candidates[0]
-            parts = (candidate.get("content") or {}).get("parts") or []
-            finish_reason = candidate.get("finishReason")
-            has_tool_calls = False
+                candidates = payload.get("candidates") or []
+                if not candidates:
+                    continue
+                candidate = candidates[0]
+                parts = (candidate.get("content") or {}).get("parts") or []
+                finish_reason = candidate.get("finishReason")
+                has_tool_calls = False
 
-            for part in parts:
-                text = part.get("text")
-                if text:
-                    yield StreamEvent(content=text, done=False)
-                function_call = part.get("functionCall")
-                if function_call:
-                    has_tool_calls = True
-                    call_id = _gen_tool_call_id()
-                    name = function_call.get("name", "")
-                    args = function_call.get("args") or {}
+                for part in parts:
+                    text = part.get("text")
+                    if text:
+                        yield StreamEvent(content=text, done=False)
+                    function_call = part.get("functionCall")
+                    if function_call:
+                        has_tool_calls = True
+                        call_id = _gen_tool_call_id()
+                        name = function_call.get("name", "")
+                        args = function_call.get("args") or {}
+                        yield StreamEvent(
+                            content="",
+                            done=False,
+                            tool_call_id=call_id,
+                            tool_call_name=name,
+                            event_type="tool_call_start",
+                        )
+                        yield StreamEvent(
+                            content="",
+                            done=False,
+                            tool_call_id=call_id,
+                            tool_call_args_delta=json.dumps(args),
+                            event_type="tool_call_args",
+                        )
+                        yield StreamEvent(
+                            content="", done=False, tool_call_id=call_id, event_type="tool_call_end"
+                        )
+
+                usage_meta = payload.get("usageMetadata")
+                if usage_meta:
                     yield StreamEvent(
                         content="",
                         done=False,
-                        tool_call_id=call_id,
-                        tool_call_name=name,
-                        event_type="tool_call_start",
+                        event_type="usage",
+                        usage=_usage_from_metadata(usage_meta),
                     )
+
+                if finish_reason:
                     yield StreamEvent(
                         content="",
-                        done=False,
-                        tool_call_id=call_id,
-                        tool_call_args_delta=json.dumps(args),
-                        event_type="tool_call_args",
+                        done=True,
+                        stop_reason=_stop_reason_for(finish_reason, has_tool_calls),
                     )
-                    yield StreamEvent(
-                        content="", done=False, tool_call_id=call_id, event_type="tool_call_end"
-                    )
-
-            usage_meta = payload.get("usageMetadata")
-            if usage_meta:
-                yield StreamEvent(
-                    content="",
-                    done=False,
-                    event_type="usage",
-                    usage=_usage_from_metadata(usage_meta),
-                )
-
-            if finish_reason:
-                yield StreamEvent(
-                    content="",
-                    done=True,
-                    stop_reason=_stop_reason_for(finish_reason, has_tool_calls),
-                )
-                return
+                    return
+        except StreamError:
+            raise
+        except (AuthError, RateLimitError, ProviderError, NetworkError):
+            raise
+        except httpx.HTTPError as exc:
+            raise StreamError(f"stream transport error: {exc}") from exc
+        finally:
+            await resp.aclose()

--- a/sdks/python/motosan_ai/providers/gemini_code_assist.py
+++ b/sdks/python/motosan_ai/providers/gemini_code_assist.py
@@ -10,7 +10,7 @@ from typing import Any
 import httpx
 
 from motosan_ai._stream_collect import collect_stream
-from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError
+from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
 from motosan_ai.providers.gemini import build_gemini_body
 from motosan_ai.types import ChatRequest, ChatResponse, StopReason, StreamEvent, Usage
@@ -50,8 +50,8 @@ def _parse_sse_event(data: str, state: _CodeAssistAdapterState) -> list[StreamEv
         return []
     try:
         chunk = json.loads(s)
-    except json.JSONDecodeError:
-        return []
+    except json.JSONDecodeError as exc:
+        raise StreamError(f"malformed SSE chunk: {exc}") from exc
 
     response_data = chunk.get("response")
     if not isinstance(response_data, dict):
@@ -212,14 +212,19 @@ class GeminiCodeAssistProvider(BaseProvider):
                 raise self._map_http_error(resp.status_code, error_body.decode())
 
             state = _CodeAssistAdapterState()
-            async for line in resp.aiter_lines():
-                if not line.startswith("data: "):
-                    continue
-                data = line[len("data: ") :]
-                for event in _parse_sse_event(data, state):
-                    yield event
-                    if event.done:
-                        return
+            try:
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    data = line[len("data: ") :]
+                    for event in _parse_sse_event(data, state):
+                        yield event
+                        if event.done:
+                            return
+            except (StreamError, AuthError, RateLimitError, ProviderError, NetworkError):
+                raise
+            except httpx.HTTPError as exc:
+                raise StreamError(f"stream transport error: {exc}") from exc
         finally:
             await resp.aclose()
 

--- a/sdks/python/motosan_ai/providers/minimax.py
+++ b/sdks/python/motosan_ai/providers/minimax.py
@@ -12,6 +12,7 @@ from motosan_ai.error import (
     NetworkError,
     ProviderError,
     RateLimitError,
+    StreamError,
 )
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.types import (
@@ -200,6 +201,10 @@ class MinimaxProvider:
         if request.provider_options:
             body.update(request.provider_options)
 
+        # Q2: an httpx fault BEFORE the first yield is a connection-time fault
+        # (NetworkError, retryable). The SAME fault AFTER the first yield, or a
+        # malformed frame, is mid-stream -> StreamError (non-retryable).
+        yielded = False
         try:
             async with self._client.stream(
                 "POST",
@@ -216,17 +221,21 @@ class MinimaxProvider:
                     if not line.startswith("data:"):
                         continue
                     data = line[5:].strip()
-                    if data == "[DONE]":
-                        yield StreamEvent(content="", done=True)
-                        return
+                    if not data or data == "[DONE]":
+                        if data == "[DONE]":
+                            yielded = True
+                            yield StreamEvent(content="", done=True)
+                            return
+                        continue
                     try:
                         payload = json.loads(data)
-                    except json.JSONDecodeError:
-                        continue
+                    except json.JSONDecodeError as exc:
+                        raise StreamError(f"malformed SSE chunk: {exc}") from exc
                     choice = (payload.get("choices") or [{}])[0]
                     delta = choice.get("delta") or {}
                     text = delta.get("content") or ""
                     if text:
+                        yielded = True
                         yield StreamEvent(content=text, done=False)
 
                     for tc in delta.get("tool_calls") or []:
@@ -235,6 +244,7 @@ class MinimaxProvider:
                         tc_name = fn.get("name")
                         tc_args = fn.get("arguments")
                         if tc_id and tc_name:
+                            yielded = True
                             yield StreamEvent(
                                 content="",
                                 done=False,
@@ -243,6 +253,7 @@ class MinimaxProvider:
                                 event_type="tool_call_start",
                             )
                         if tc_args:
+                            yielded = True
                             yield StreamEvent(
                                 content="",
                                 done=False,
@@ -252,8 +263,11 @@ class MinimaxProvider:
 
                     finish_reason = choice.get("finish_reason")
                     if finish_reason == "tool_calls":
+                        yielded = True
                         yield StreamEvent(content="", done=False, event_type="tool_call_end")
-        except Exception as exc:
-            if isinstance(exc, AuthError | RateLimitError | InvalidRequestError | ProviderError):
-                raise
+        except (AuthError, RateLimitError, InvalidRequestError, ProviderError, StreamError):
+            raise
+        except httpx.HTTPError as exc:
+            if yielded:
+                raise StreamError(f"stream transport error: {exc}") from exc
             raise NetworkError(str(exc)) from exc

--- a/sdks/python/motosan_ai/providers/ollama.py
+++ b/sdks/python/motosan_ai/providers/ollama.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import httpx
 
-from motosan_ai.error import NetworkError, ProviderError
+from motosan_ai.error import NetworkError, ProviderError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.types import (
     ChatRequest,
@@ -150,6 +150,10 @@ class OllamaProvider:
 
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:
         body = self._build_body(request, stream=True)
+        # Q2: an httpx fault BEFORE the first yield is connection-time
+        # (NetworkError, retryable); after the first yield it is mid-stream
+        # (StreamError, non-retryable). A malformed NDJSON line -> StreamError.
+        yielded = False
         try:
             async with self._http.stream("POST", f"{self.base_url}/api/chat", json=body) as resp:
                 if resp.status_code >= 400:
@@ -163,9 +167,10 @@ class OllamaProvider:
                         continue
                     try:
                         chunk = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
+                    except json.JSONDecodeError as exc:
+                        raise StreamError(f"malformed NDJSON chunk: {exc}") from exc
                     if chunk.get("done"):
+                        yielded = True
                         yield StreamEvent(content="", done=True)
                         return
                     msg = chunk.get("message", {})
@@ -173,6 +178,7 @@ class OllamaProvider:
                     thinking = msg.get("thinking", "")
                     text = content or thinking
                     if text:
+                        yielded = True
                         yield StreamEvent(content=text, done=False)
 
                     for tc in msg.get("tool_calls") or []:
@@ -183,6 +189,7 @@ class OllamaProvider:
                         else:
                             args_str = json.dumps(raw_args, ensure_ascii=False)
                         tc_id = str(uuid.uuid4())
+                        yielded = True
                         yield StreamEvent(
                             content="",
                             done=False,
@@ -203,7 +210,9 @@ class OllamaProvider:
                             tool_call_id=tc_id,
                             event_type="tool_call_end",
                         )
-        except Exception as exc:
-            if isinstance(exc, ProviderError):
-                raise
+        except (ProviderError, StreamError):
+            raise
+        except httpx.HTTPError as exc:
+            if yielded:
+                raise StreamError(f"stream transport error: {exc}") from exc
             raise NetworkError(str(exc)) from exc

--- a/sdks/python/motosan_ai/providers/openai.py
+++ b/sdks/python/motosan_ai/providers/openai.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import httpx
 
-from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError
+from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.types import (
     ChatRequest,
@@ -209,52 +209,62 @@ class OpenAIProvider:
         except httpx.HTTPError as exc:
             raise NetworkError(str(exc)) from exc
 
-        if not resp.is_success:
-            error_body = await resp.aread()
-            raise self._map_http_error(resp.status_code, error_body.decode())
+        try:
+            if not resp.is_success:
+                error_body = await resp.aread()
+                raise self._map_http_error(resp.status_code, error_body.decode())
 
-        async for line in resp.aiter_lines():
-            if not line.startswith("data: "):
-                continue
-            data = line[6:]
-            if data == "[DONE]":
-                yield StreamEvent(content="", done=True)
-                return
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:].strip()
+                if not data or data == "[DONE]":
+                    if data == "[DONE]":
+                        yield StreamEvent(content="", done=True)
+                        return
+                    continue
+                try:
+                    payload = json.loads(data)
+                except json.JSONDecodeError as exc:
+                    raise StreamError(f"malformed SSE chunk: {exc}") from exc
 
-            try:
-                payload = json.loads(data)
-            except json.JSONDecodeError:
-                continue
+                for choice in payload.get("choices") or []:
+                    delta = choice.get("delta") or {}
+                    text = delta.get("content") or ""
+                    if text:
+                        yield StreamEvent(content=text, done=False)
 
-            for choice in payload.get("choices") or []:
-                delta = choice.get("delta") or {}
-                text = delta.get("content") or ""
-                if text:
-                    yield StreamEvent(content=text, done=False)
+                    for tc in delta.get("tool_calls") or []:
+                        fn = tc.get("function") or {}
+                        tc_id = tc.get("id")
+                        tc_name = fn.get("name")
+                        tc_args = fn.get("arguments")
+                        if tc_id and tc_name:
+                            yield StreamEvent(
+                                content="",
+                                done=False,
+                                tool_call_id=tc_id,
+                                tool_call_name=tc_name,
+                                event_type="tool_call_start",
+                            )
+                        if tc_args:
+                            yield StreamEvent(
+                                content="",
+                                done=False,
+                                tool_call_args_delta=tc_args,
+                                event_type="tool_call_args",
+                            )
 
-                for tc in delta.get("tool_calls") or []:
-                    fn = tc.get("function") or {}
-                    tc_id = tc.get("id")
-                    tc_name = fn.get("name")
-                    tc_args = fn.get("arguments")
-                    if tc_id and tc_name:
-                        yield StreamEvent(
-                            content="",
-                            done=False,
-                            tool_call_id=tc_id,
-                            tool_call_name=tc_name,
-                            event_type="tool_call_start",
-                        )
-                    if tc_args:
-                        yield StreamEvent(
-                            content="",
-                            done=False,
-                            tool_call_args_delta=tc_args,
-                            event_type="tool_call_args",
-                        )
-
-                if choice.get("finish_reason"):
-                    if choice.get("finish_reason") == "tool_calls":
-                        yield StreamEvent(content="", done=False, event_type="tool_call_end")
-                    yield StreamEvent(content="", done=True)
-                    return
+                    if choice.get("finish_reason"):
+                        if choice.get("finish_reason") == "tool_calls":
+                            yield StreamEvent(content="", done=False, event_type="tool_call_end")
+                        yield StreamEvent(content="", done=True)
+                        return
+        except StreamError:
+            raise
+        except (AuthError, RateLimitError, ProviderError, NetworkError):
+            raise
+        except httpx.HTTPError as exc:
+            raise StreamError(f"stream transport error: {exc}") from exc
+        finally:
+            await resp.aclose()

--- a/sdks/python/tests/test_anthropic_stream_usage.py
+++ b/sdks/python/tests/test_anthropic_stream_usage.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 import respx
 
+from motosan_ai.error import StreamError
 from motosan_ai.providers.anthropic import AnthropicProvider
 from motosan_ai.types import ChatRequest, Message, StopReason
 
@@ -99,3 +100,27 @@ async def test_stream_done_without_delta_has_no_stop_reason(provider):
     events = [e async for e in provider.stream(ChatRequest(messages=[Message.user("hi")]))]
     done = next(e for e in events if e.done)
     assert done.stop_reason is None
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_raises_on_malformed_chunk(provider):
+    # one good text delta (via the file's _sse helper), then a non-empty malformed data: frame
+    sse = (
+        _sse(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "hi"},
+            }
+        )
+        + "data: {not valid json\n"
+    )
+    respx.post("https://mock.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, text=sse, headers={"content-type": "text/event-stream"})
+    )
+    seen = []
+    with pytest.raises(StreamError, match="malformed SSE chunk"):
+        async for ev in provider.stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(ev)
+    assert any(e.content == "hi" for e in seen)  # the good delta was yielded first

--- a/sdks/python/tests/test_client_stream_collect.py
+++ b/sdks/python/tests/test_client_stream_collect.py
@@ -8,6 +8,7 @@ import respx
 
 from motosan_ai import Client, Provider
 from motosan_ai._stream_collect import collect_stream
+from motosan_ai.error import StreamError
 from motosan_ai.types import ChatRequest, Message, StopReason, StreamEvent, Usage
 
 
@@ -225,3 +226,13 @@ def test_collect_stream_exported_from_top_level():
     import motosan_ai
 
     assert callable(motosan_ai.collect_stream)
+
+
+@pytest.mark.asyncio
+async def test_collect_stream_propagates_mid_stream_raise():
+    async def _raising_stream():
+        yield StreamEvent(content="partial", done=False)
+        raise StreamError("boom")
+
+    with pytest.raises(StreamError, match="boom"):
+        await collect_stream(_raising_stream())

--- a/sdks/python/tests/test_client_stream_with.py
+++ b/sdks/python/tests/test_client_stream_with.py
@@ -7,7 +7,8 @@ import pytest
 import respx
 
 from motosan_ai import Client, Provider
-from motosan_ai.types import ChatRequest, Message
+from motosan_ai.error import ProviderError, StreamError
+from motosan_ai.types import ChatRequest, Message, StreamEvent
 
 
 def _sse_lines(*events: dict) -> str:
@@ -68,3 +69,57 @@ async def test_stream_kwargs_path_unchanged_regression(monkeypatch):
     assert any(event.content == "hi" for event in events)
     body = json.loads(route.calls[0].request.content)
     assert body["system"] == "terse"
+
+
+class _CountingProvider:
+    """Provider stub that records how many times stream() was invoked."""
+
+    def __init__(self, make_gen):
+        self._make_gen = make_gen
+        self.stream_calls = 0
+
+    async def stream(self, request):
+        self.stream_calls += 1
+        async for event in self._make_gen():
+            yield event
+
+
+@pytest.mark.asyncio
+async def test_stream_with_does_not_retry_stream_error(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    async def gen():
+        # Long enough to clear ThinkStripper's tail-hold so it flushes mid-stream
+        # (short deltas stay buffered until a done event, which never arrives here).
+        yield StreamEvent(content="hello world", done=False)
+        raise StreamError("boom")
+
+    client = Client(provider=Provider.anthropic, max_retries=3)
+    provider = _CountingProvider(gen)
+    client._provider = provider  # documented injection seam
+    req = ChatRequest(messages=[Message.user("hi")])
+    seen = []
+    with pytest.raises(StreamError, match="boom"):
+        async for ev in client.stream_with(req):
+            seen.append(ev)
+    assert provider.stream_calls == 1  # never retried
+    # the pre-raise delta was emitted once (ThinkStripper holds a 6-char tail)
+    assert "".join(e.content for e in seen) == "hello"
+
+
+@pytest.mark.asyncio
+async def test_stream_with_does_not_retry_provider_error_after_yield(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    async def gen():
+        yield StreamEvent(content="partial", done=False)
+        raise ProviderError("503 server error")  # retryable BY CLASS, but mid-stream
+
+    client = Client(provider=Provider.anthropic, max_retries=3)
+    provider = _CountingProvider(gen)
+    client._provider = provider  # documented injection seam
+    req = ChatRequest(messages=[Message.user("hi")])
+    with pytest.raises(ProviderError):
+        async for _ in client.stream_with(req):
+            pass
+    assert provider.stream_calls == 1  # mid-stream retryable error is NOT replayed

--- a/sdks/python/tests/test_code_assist_stream.py
+++ b/sdks/python/tests/test_code_assist_stream.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 import respx
 
+from motosan_ai.error import StreamError
 from motosan_ai.providers.gemini_code_assist import (
     GeminiCodeAssistProvider,
     _CodeAssistAdapterState,
@@ -198,8 +199,9 @@ def test_chunk_without_response_wrapper_skipped():
     assert _parse_sse_event(payload, state) == []
 
 
-def test_malformed_json_skipped():
-    assert _parse_sse_event("not json {", _CodeAssistAdapterState()) == []
+def test_malformed_json_raises_stream_error():
+    with pytest.raises(StreamError, match="malformed SSE chunk"):
+        _parse_sse_event("not json {", _CodeAssistAdapterState())
 
 
 @respx.mock
@@ -292,3 +294,21 @@ async def test_stream_sends_envelope_in_body():
     assert captured["body"]["project"] == "myproj"
     assert captured["body"]["userAgent"] == "motosan-ai"
     assert "contents" in captured["body"]["request"]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_raises_on_malformed_chunk():
+    sse = (
+        _sse_text({"response": {"candidates": [{"content": {"parts": [{"text": "hi"}]}}]}})
+        + "data: {not valid json\n"
+    )
+    respx.post("https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse").mock(
+        return_value=httpx.Response(200, text=sse, headers={"content-type": "text/event-stream"})
+    )
+    p = GeminiCodeAssistProvider("ya29.fake", "myproj")
+    seen = []
+    with pytest.raises(StreamError, match="malformed SSE chunk"):
+        async for ev in p.stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(ev)
+    assert any(e.content == "hi" for e in seen)

--- a/sdks/python/tests/test_gemini_stream.py
+++ b/sdks/python/tests/test_gemini_stream.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 import respx
 
+from motosan_ai.error import StreamError
 from motosan_ai.providers.gemini import GeminiProvider
 from motosan_ai.types import ChatRequest, Message, StopReason
 
@@ -107,3 +108,19 @@ async def test_stream_ignores_empty_data_and_done_marker(provider):
     )
     events = [e async for e in provider.stream(ChatRequest(messages=[Message.user("hi")]))]
     assert [e.content for e in events if e.event_type == "text" and not e.done] == ["ok"]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_raises_on_malformed_chunk(provider):
+    sse = (
+        _sse({"candidates": [{"content": {"parts": [{"text": "hi"}]}}]}) + "data: {not valid json\n"
+    )
+    respx.post(_stream_url()).mock(
+        return_value=httpx.Response(200, text=sse, headers={"content-type": "text/event-stream"})
+    )
+    seen = []
+    with pytest.raises(StreamError, match="malformed SSE chunk"):
+        async for ev in provider.stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(ev)
+    assert any(e.content == "hi" for e in seen)

--- a/sdks/python/tests/test_minimax.py
+++ b/sdks/python/tests/test_minimax.py
@@ -2,6 +2,7 @@ import pytest
 import respx
 from httpx import Response
 
+from motosan_ai.error import StreamError
 from motosan_ai.providers.minimax import MinimaxProvider
 from motosan_ai.types import ChatRequest, Message, StopReason
 
@@ -60,3 +61,18 @@ async def test_minimax_stream():
     assert route.called
     assert [e.content for e in events if not e.done] == ["hel", "lo"]
     assert events[-1].done is True
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_raises_stream_error_not_network_error():
+    sse = 'data: {"choices":[{"delta":{"content":"hi"}}]}\ndata: {not valid json\n'
+    respx.post("https://api.minimax.chat/v1/text/chatcompletion_v2").mock(
+        return_value=Response(200, text=sse, headers={"content-type": "text/event-stream"})
+    )
+    provider = MinimaxProvider("test-key")
+    seen = []
+    with pytest.raises(StreamError, match="malformed SSE chunk"):
+        async for ev in provider.stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(ev)
+    assert any(e.content == "hi" for e in seen)

--- a/sdks/python/tests/test_ollama_native.py
+++ b/sdks/python/tests/test_ollama_native.py
@@ -5,6 +5,7 @@ import pytest
 import respx
 
 from motosan_ai import Client, Provider
+from motosan_ai.error import StreamError
 from motosan_ai.providers.ollama import OllamaProvider
 from motosan_ai.types import ChatRequest, Message, StopReason, Tool, ToolCall
 
@@ -356,3 +357,15 @@ async def test_chat_error_response(provider):
     respx.post(CHAT_URL).mock(return_value=httpx.Response(500, text="internal error"))
     with pytest.raises(Exception, match="Ollama error 500"):
         await provider.chat(ChatRequest(messages=[Message.user("hi")]))
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_raises_stream_error_on_malformed_ndjson(provider):
+    ndjson = '{"message":{"content":"hi"},"done":false}\n{not valid json\n'
+    respx.post(CHAT_URL).mock(return_value=httpx.Response(200, text=ndjson))
+    seen = []
+    with pytest.raises(StreamError, match="malformed NDJSON chunk"):
+        async for ev in provider.stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(ev)
+    assert any(e.content == "hi" for e in seen)

--- a/sdks/python/tests/test_openai.py
+++ b/sdks/python/tests/test_openai.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 import respx
 
+from motosan_ai.error import StreamError
 from motosan_ai.providers.openai import OpenAIProvider
 from motosan_ai.types import ChatRequest, Message, StopReason, Tool
 
@@ -204,3 +205,17 @@ async def test_openai_401_raises_auth_error(provider):
 
     with pytest.raises(AuthError):
         await provider.chat(ChatRequest(messages=[Message.user("hi")]))
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_raises_on_malformed_chunk(provider):
+    body = 'data: {"choices":[{"delta":{"content":"hi"}}]}\ndata: {not valid json\n'
+    respx.post("https://mock.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+    )
+    seen = []
+    with pytest.raises(StreamError, match="malformed SSE chunk"):
+        async for ev in provider.stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(ev)
+    assert any(e.content == "hi" for e in seen)


### PR DESCRIPTION
**Milestone F1 (foundation)** of the Python SDK → Rust 0.20.0 parity effort (target release **0.13.0**). Plan: `docs/superpowers/plans/2026-06-23-python-0.20-cli-runtime-alignment.md`.

## What changes (BREAKING)
Provider `stream()` async generators now **raise `motosan_ai.error.StreamError`** mid-stream on a malformed frame or transport fault, instead of silently swallowing them and ending the stream. `collect_stream` propagates the raise. Migration: an `async for ev in client.stream(...)` (or `collect_stream`) may now raise `StreamError` mid-iteration — wrap it or let it propagate.

## Tasks (9 commits, TDD red→green→ruff-format→commit each)
- **F1.1** `client.stream_with` gains a `yielded` guard — a mid-stream raise is **not** retried (would otherwise re-emit already-yielded deltas); only pre-first-yield connection errors retry. Q3 regression test confirms `StreamError` is non-retryable.
- **F1.2** characterization test: `collect_stream` propagates a mid-stream raise.
- **F1.3–F1.8** the six HTTP providers (anthropic / openai / gemini / gemini_code_assist / minimax / ollama) raise `StreamError` on a non-empty malformed frame, with:
  - **Q1** empty/`[DONE]` pre-filter before `json.loads` (added to anthropic+openai),
  - re-raise-ordering guard so pre-loop 4xx/5xx typed errors aren't re-wrapped,
  - **Q4** `try/finally: await resp.aclose()` on anthropic/openai/gemini,
  - **Q2** `yielded` flag on minimax/ollama: pre-first-yield `httpx` fault → `NetworkError` (retryable), post-yield → `StreamError`.
- **F1.9** `collect_stream` docstring note.

## Design decisions
Python raises (no `Result` wrapper) — idiomatic; `StreamError` stays out of `retry.py::_is_retryable` and the `stream_with` except tuple. See the plan's "Global Constraints → Design Decisions" (Q1–Q4).

## Verification
- `uv run pytest -q` → **563 passed, 30 skipped, 0 failed** (skips = opt-in live tests).
- CI lint scope `ruff check motosan_ai/` → clean; `ruff format --check` → clean.
- Independent adversarial verify (incl. a mutation check: reverting a `raise`→`continue` makes the malformed-frame test fail) → **ship**.

Scope: `sdks/python/` only (6 providers + client.py + _stream_collect.py + 8 test files). No version bump here — that lands in the final **F-release** milestone. Foundation for F2–F6 (CLI cwd / session / env / tool-call events / timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)