### PR TITLE
feat(python): CLI cwd setters — claude/gemini .cwd() [F2/7, 0.20-parity]

### DIFF
--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -47,6 +47,7 @@ class _ClaudeCodeConfig:
     no_session_persistence: bool = False
     plugin_dirs: list[str] = field(default_factory=list)
     max_budget_usd: float | None = None
+    cwd: str | None = None
 
 
 def _model_to_forward(model: str) -> str | None:
@@ -303,6 +304,11 @@ class ClaudeCodeClient:
         self._config.max_budget_usd = amount
         return self
 
+    def cwd(self, directory: str) -> ClaudeCodeClient:
+        """Set the working directory for the spawned ``claude`` subprocess."""
+        self._config.cwd = directory
+        return self
+
     def _build_args(
         self,
         *,
@@ -425,6 +431,7 @@ class ClaudeCodeClient:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=self._config.cwd,
         )
 
         try:
@@ -480,6 +487,7 @@ class ClaudeCodeClient:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=self._config.cwd,
         )
 
         # Write prompt to stdin then close it

--- a/sdks/python/motosan_ai/providers/gemini_cli.py
+++ b/sdks/python/motosan_ai/providers/gemini_cli.py
@@ -41,6 +41,7 @@ class _GeminiCliConfig:
     extensions: list[str] = field(default_factory=list)
     allowed_mcp_servers: list[str] = field(default_factory=list)
     resume: str | None = None
+    cwd: str | None = None
 
 
 def _model_to_forward(model: str) -> str | None:
@@ -182,6 +183,11 @@ class GeminiCliClient:
         self._config.resume = session
         return self
 
+    def cwd(self, directory: str) -> GeminiCliClient:
+        """Run the spawned ``gemini`` process in ``directory`` (subprocess cwd)."""
+        self._config.cwd = directory
+        return self
+
     def _build_args(self, model: str | None = None) -> list[str]:
         args: list[str] = [self._config.binary_path, "-p", "", "-o", "stream-json"]
 
@@ -222,6 +228,7 @@ class GeminiCliClient:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=self._config.cwd,
         )
         try:
             stdout, stderr = await asyncio.wait_for(
@@ -266,6 +273,7 @@ class GeminiCliClient:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=self._config.cwd,
         )
         try:
             assert proc.stdin is not None and proc.stdout is not None

--- a/sdks/python/tests/test_claude_code.py
+++ b/sdks/python/tests/test_claude_code.py
@@ -254,6 +254,13 @@ class TestClaudeCodeClientConstruction:
         assert client._model == "opus"
         assert client._agent_mode is True
 
+    def test_cwd_setter(self):
+        client = ClaudeCodeClient().cwd("/work")
+        assert client._config.cwd == "/work"
+
+    def test_cwd_default_none(self):
+        assert ClaudeCodeClient()._config.cwd is None
+
 
 # ---------------------------------------------------------------------------
 # _build_args

--- a/sdks/python/tests/test_claude_code_runtime.py
+++ b/sdks/python/tests/test_claude_code_runtime.py
@@ -1,0 +1,37 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from motosan_ai.providers.claude_code import ClaudeCodeClient
+from motosan_ai.types import ChatRequest, Message, Role
+
+
+def _make_proc(stdout: bytes = b'{"type":"result","result":"hi","is_error":false}\n'):
+    """AsyncMock claude proc. `stdout` feeds BOTH proc.communicate() (chat)
+    and proc.stdout.readline() (stream): readline pops one `\n`-terminated
+    line per call, then b''."""
+    proc = AsyncMock()
+    proc.communicate = AsyncMock(return_value=(stdout, b""))
+    lines = stdout.splitlines(keepends=True)
+    proc.stdout = AsyncMock()
+    proc.stdout.readline = AsyncMock(side_effect=[*lines, b""])
+    proc.stdin = AsyncMock()
+    proc.stdin.write = lambda b: None
+    proc.stdin.close = lambda: None
+    proc.returncode = 0
+    proc.kill = lambda: None
+    proc.wait = AsyncMock(return_value=0)
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_chat_passes_cwd_to_subprocess():
+    proc = _make_proc()
+    with patch(
+        "motosan_ai.providers.claude_code.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=proc),
+    ) as spawn:
+        client = ClaudeCodeClient().agent_mode(True).cwd("/work")
+        req = ChatRequest(messages=[Message(role=Role.user, content="hi")])
+        await client.chat(req)
+        assert spawn.call_args.kwargs["cwd"] == "/work"

--- a/sdks/python/tests/test_codex_cli_flags.py
+++ b/sdks/python/tests/test_codex_cli_flags.py
@@ -197,3 +197,9 @@ def test_full_config_argv_order_matches_rust_common_args():
         "approval_policy=never",
         "-",
     ]
+
+
+def test_codex_has_no_os_cwd_setter():
+    # Codex's working-directory mechanism is the --cd argv flag (cd()),
+    # not asyncio create_subprocess_exec(cwd=). Confirm no cwd() builder.
+    assert not hasattr(CodexCliClient(binary_path="codex"), "cwd")

--- a/sdks/python/tests/test_gemini_cli_dispatch.py
+++ b/sdks/python/tests/test_gemini_cli_dispatch.py
@@ -30,3 +30,12 @@ def test_gemini_cli_does_not_require_api_key(monkeypatch):
         monkeypatch.delenv(env, raising=False)
     client = Client(provider=Provider.gemini_cli)
     assert isinstance(client._provider, GeminiCliClient)
+
+
+def test_cwd_setter():
+    client = GeminiCliClient().cwd("/work/dir")
+    assert client._config.cwd == "/work/dir"
+
+
+def test_cwd_default_none():
+    assert GeminiCliClient()._config.cwd is None

--- a/sdks/python/tests/test_gemini_cli_stream.py
+++ b/sdks/python/tests/test_gemini_cli_stream.py
@@ -234,3 +234,17 @@ async def test_stream_yields_events_in_order(monkeypatch):
     assert len(done_events) == 1
     assert events.index(text_events[0]) < events.index(usage_events[0])
     assert events.index(usage_events[0]) < events.index(done_events[0])
+
+
+@pytest.mark.asyncio
+async def test_chat_passes_cwd_to_subprocess(monkeypatch):
+    monkeypatch.setattr(asyncio.subprocess, "PIPE", -1, raising=False)
+    fake = _FakeProc(
+        '{"type": "message", "role": "assistant", "content": "hi", "delta": true}\n'
+        '{"type": "result", "status": "success"}\n'
+    )
+    spawn = AsyncMock(return_value=fake)
+    monkeypatch.setattr("asyncio.create_subprocess_exec", spawn)
+    client = GeminiCliClient().cwd("/work/dir")
+    await client.chat(ChatRequest(messages=[Message.user("hi")]))
+    assert spawn.call_args.kwargs["cwd"] == "/work/dir"


### PR DESCRIPTION
**Milestone F2** of the Python SDK → Rust 0.20.0 parity effort (→ 0.13.0). Plan: `docs/superpowers/plans/2026-06-23-python-0.20-cli-runtime-alignment.md`.

## What changes
A working-directory setter on the CLI providers so the spawned child runs in a chosen dir:
- **F2.1 ClaudeCode** — new `cwd` config field + `.cwd(dir)` builder; `cwd=` passed into `asyncio.create_subprocess_exec` at **both** spawn sites (chat + stream). Distinct from the binary-path setter.
- **F2.2 Gemini CLI** — same `cwd` field + `.cwd(dir)` builder at both spawn sites.
- **F2.3 Codex** — verified its existing `.cd()`/`--cd` already sets the working dir (matches Rust); no code change, guard test added.

## Verification
- `ruff check motosan_ai/` (CI scope) → clean; `ruff format --check .` → clean.
- `uv run pytest -q` → **570 passed, 30 skipped**; `pytest -k cwd` → 7 passed.
- Independent verify (incl. mutation check: removing `cwd=` makes the test fail) → **ship**.

Scope: `sdks/python/` only (2 providers + 4 test files). No version bump (lands in F-release). Foundation: F1 (#202) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)