### PR TITLE
feat(python): session continuity — session_id + resume [F3/7, 0.20-parity]

### DIFF
--- a/sdks/python/motosan_ai/_stream_collect.py
+++ b/sdks/python/motosan_ai/_stream_collect.py
@@ -27,8 +27,13 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
     current_tc_id = ""
     current_tc_name = ""
     current_tc_args = ""
+    session_id: str | None = None
 
     async for event in events:
+        # last-wins on session_id (HTTP providers never set it, so usually None);
+        # CLI readback uses the provider chat()/stream() first-wins path, not this.
+        if event.session_id is not None:
+            session_id = event.session_id
         if event.event_type == "text" and event.content:
             content += event.content
         elif event.event_type == "thinking" and event.content:
@@ -76,4 +81,5 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
         usage=usage,
         stop_reason=stop_reason,
         thinking=thinking or None,
+        session_id=session_id,
     )

--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -88,8 +88,8 @@ def _messages_to_prompt(messages: list[Message]) -> tuple[str | None, str]:
     return system, prompt
 
 
-def _parse_agent_json(raw: str) -> tuple[str, Usage]:
-    """Parse JSON output from agent mode, extracting ``result`` and ``usage``."""
+def _parse_agent_json(raw: str) -> tuple[str, Usage, str | None]:
+    """Parse JSON output from agent mode: ``result``, ``usage``, ``session_id``."""
     try:
         v = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -97,9 +97,15 @@ def _parse_agent_json(raw: str) -> tuple[str, Usage]:
 
     text = v.get("result", "")
     u = v.get("usage", {})
-    return text, Usage(
-        input_tokens=int(u.get("input_tokens", 0)),
-        output_tokens=int(u.get("output_tokens", 0)),
+    sid = v.get("session_id")
+    session_id = sid if isinstance(sid, str) and sid else None
+    return (
+        text,
+        Usage(
+            input_tokens=int(u.get("input_tokens", 0)),
+            output_tokens=int(u.get("output_tokens", 0)),
+        ),
+        session_id,
     )
 
 
@@ -131,10 +137,13 @@ def _parse_ndjson_line(line: str) -> list[StreamEvent]:
         return [StreamEvent(content=text, done=False)]
 
     if event_type == "result":
-        events: list[StreamEvent] = []
+        events_out: list[StreamEvent] = []
+        sid = event.get("session_id")
+        if isinstance(sid, str) and sid:
+            events_out.append(StreamEvent(content="", done=False, session_id=sid))
         usage_obj = event.get("usage")
         if isinstance(usage_obj, dict):
-            events.append(
+            events_out.append(
                 StreamEvent(
                     content="",
                     done=False,
@@ -145,8 +154,8 @@ def _parse_ndjson_line(line: str) -> list[StreamEvent]:
                     ),
                 )
             )
-        events.append(StreamEvent(content="", done=True))
-        return events
+        events_out.append(StreamEvent(content="", done=True))
+        return events_out
 
     return []
 
@@ -452,10 +461,11 @@ class ClaudeCodeClient:
         raw = stdout.decode()
 
         if self._agent_mode:
-            text, usage = _parse_agent_json(raw)
+            text, usage, session_id = _parse_agent_json(raw)
         else:
             text = raw.strip()
             usage = Usage(input_tokens=0, output_tokens=0)
+            session_id = None
 
         effective_model = request.model or self._config.model or ""
 
@@ -465,6 +475,7 @@ class ClaudeCodeClient:
             model=effective_model,
             usage=usage,
             stop_reason=StopReason.end_turn,
+            session_id=session_id,
         )
 
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:

--- a/sdks/python/motosan_ai/providers/codex_cli.py
+++ b/sdks/python/motosan_ai/providers/codex_cli.py
@@ -50,6 +50,7 @@ class _CodexCliConfig:
     enabled_features: list[str] = field(default_factory=list)
     disabled_features: list[str] = field(default_factory=list)
     config_overrides: list[tuple[str, str]] = field(default_factory=list)
+    resume: str | None = None
 
 
 def _model_to_forward(model: str) -> str | None:
@@ -143,6 +144,12 @@ def _parse_jsonl_line(line: str) -> list[StreamEvent]:
         msg = event.get("message") or "codex error"
         raise ProviderError(f"codex error: {msg}")
 
+    if event_type == "thread.started":
+        thread_id = event.get("thread_id")
+        if thread_id:
+            return [StreamEvent(content="", done=False, session_id=thread_id)]
+        return []
+
     return []
 
 
@@ -212,13 +219,16 @@ class CodexCliClient:
         self._config.config_overrides.append((key, value))
         return self
 
+    def resume(self, thread_id: str) -> CodexCliClient:
+        """Resume a previous Codex thread (`codex exec resume <id>`)."""
+        self._config.resume = thread_id
+        return self
+
     def _build_args(self, model: str | None = None) -> list[str]:
-        args: list[str] = [
-            self._config.binary_path,
-            "exec",
-            "--json",
-            "--skip-git-repo-check",
-        ]
+        args: list[str] = [self._config.binary_path, "exec"]
+        if self._config.resume is not None and self._config.resume.strip():
+            args.extend(["resume", self._config.resume.strip()])
+        args.extend(["--json", "--skip-git-repo-check"])
         if self._config.agent_mode:
             args.append("--full-auto")
         if self._config.dangerously_bypass_approvals_and_sandbox:
@@ -280,9 +290,12 @@ class CodexCliClient:
 
         content_parts: list[str] = []
         usage = Usage(0, 0)
+        session_id: str | None = None
         for raw in stdout.decode().splitlines():
             for event in _parse_jsonl_line(raw):
-                if event.event_type == "text" and event.content:
+                if event.session_id is not None and session_id is None:
+                    session_id = event.session_id
+                elif event.event_type == "text" and event.content:
                     content_parts.append(event.content)
                 elif event.event_type == "usage" and event.usage is not None:
                     usage = event.usage
@@ -294,6 +307,7 @@ class CodexCliClient:
             model=request.model or self._config.model or "",
             usage=usage,
             stop_reason=StopReason.end_turn,
+            session_id=session_id,
         )
 
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:

--- a/sdks/python/motosan_ai/providers/gemini_cli.py
+++ b/sdks/python/motosan_ai/providers/gemini_cli.py
@@ -91,6 +91,12 @@ def _parse_jsonl_line(line: str) -> list[StreamEvent]:
 
     event_type = event.get("type")
 
+    if event_type == "init":
+        session_id = event.get("session_id")
+        if isinstance(session_id, str) and session_id:
+            return [StreamEvent(content="", done=False, session_id=session_id)]
+        return []
+
     if event_type == "message":
         role = event.get("role")
         delta = event.get("delta", False)
@@ -180,6 +186,11 @@ class GeminiCliClient:
         return self
 
     def resume(self, session: str) -> GeminiCliClient:
+        """Resume a prior Gemini session (`--resume <id>`).
+
+        Resuming an arbitrary externally supplied id is validated only by the
+        skip-guarded live test; the captured-id round-trip is the supported path.
+        """
         self._config.resume = session
         return self
 
@@ -246,9 +257,12 @@ class GeminiCliClient:
 
         content_parts: list[str] = []
         usage = Usage(0, 0)
+        session_id: str | None = None
         for raw in stdout.decode().splitlines():
             for event in _parse_jsonl_line(raw):
-                if event.event_type == "text" and event.content:
+                if event.session_id and session_id is None:
+                    session_id = event.session_id
+                elif event.event_type == "text" and event.content:
                     content_parts.append(event.content)
                 elif event.event_type == "usage" and event.usage is not None:
                     usage = event.usage
@@ -259,6 +273,7 @@ class GeminiCliClient:
             model=request.model or self._config.model or "",
             usage=usage,
             stop_reason=StopReason.end_turn,
+            session_id=session_id,
         )
 
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:

--- a/sdks/python/motosan_ai/types.py
+++ b/sdks/python/motosan_ai/types.py
@@ -344,6 +344,7 @@ class ChatResponse:
     usage: Usage = field(default_factory=lambda: Usage(0, 0))
     stop_reason: StopReason = StopReason.end_turn
     thinking: str | None = None
+    session_id: str | None = None
 
 
 @dataclass
@@ -356,6 +357,7 @@ class StreamEvent:
     event_type: str = "text"
     usage: Usage | None = None
     stop_reason: StopReason | None = None
+    session_id: str | None = None
 
 
 class ChatRequestBuilder:

--- a/sdks/python/tests/test_claude_code.py
+++ b/sdks/python/tests/test_claude_code.py
@@ -90,14 +90,14 @@ class TestParseAgentJson:
                 "usage": {"input_tokens": 10, "output_tokens": 5},
             }
         )
-        text, usage = _parse_agent_json(raw)
+        text, usage, _sid = _parse_agent_json(raw)
         assert text == "hello world"
         assert usage.input_tokens == 10
         assert usage.output_tokens == 5
 
     def test_without_usage(self):
         raw = json.dumps({"result": "hello"})
-        text, usage = _parse_agent_json(raw)
+        text, usage, _sid = _parse_agent_json(raw)
         assert text == "hello"
         assert usage.input_tokens == 0
         assert usage.output_tokens == 0
@@ -107,6 +107,15 @@ class TestParseAgentJson:
 
         with pytest.raises(ProviderError, match="failed to parse"):
             _parse_agent_json("not json")
+
+    def test_returns_session_id(self):
+        text, usage, sid = _parse_agent_json('{"result":"hi","session_id":"s1"}')
+        assert text == "hi"
+        assert sid == "s1"
+
+    def test_session_id_none_when_absent(self):
+        text, usage, sid = _parse_agent_json('{"result":"hi"}')
+        assert sid is None
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/tests/test_claude_code_stream_usage.py
+++ b/sdks/python/tests/test_claude_code_stream_usage.py
@@ -30,3 +30,15 @@ def test_text_event_unchanged():
     assert len(events) == 1
     assert events[0].content == "hi"
     assert events[0].done is False
+
+
+def test_result_surfaces_session_id():
+    events = _parse_ndjson_line('{"type":"result","result":"done","session_id":"sess_99"}')
+    assert events[0].session_id == "sess_99"
+    assert events[0].done is False
+    assert events[-1].done is True  # session event precedes the terminal done
+
+
+def test_result_empty_session_id_omitted():
+    events = _parse_ndjson_line('{"type":"result","result":"done","session_id":""}')
+    assert all(e.session_id is None for e in events)

--- a/sdks/python/tests/test_client_stream_collect.py
+++ b/sdks/python/tests/test_client_stream_collect.py
@@ -236,3 +236,25 @@ async def test_collect_stream_propagates_mid_stream_raise():
 
     with pytest.raises(StreamError, match="boom"):
         await collect_stream(_raising_stream())
+
+
+@pytest.mark.asyncio
+async def test_collect_stream_captures_session_id():
+    async def gen():
+        yield StreamEvent(content="", done=False, session_id="sid-1")
+        yield StreamEvent(content="hi", done=False)
+        yield StreamEvent(content="", done=True)
+
+    resp = await collect_stream(gen())
+    assert resp.session_id == "sid-1"
+    assert resp.content == "hi"
+
+
+@pytest.mark.asyncio
+async def test_collect_stream_session_id_none_when_absent():
+    async def gen():
+        yield StreamEvent(content="hi", done=False)
+        yield StreamEvent(content="", done=True)
+
+    resp = await collect_stream(gen())
+    assert resp.session_id is None

--- a/sdks/python/tests/test_codex_cli_flags.py
+++ b/sdks/python/tests/test_codex_cli_flags.py
@@ -203,3 +203,14 @@ def test_codex_has_no_os_cwd_setter():
     # Codex's working-directory mechanism is the --cd argv flag (cd()),
     # not asyncio create_subprocess_exec(cwd=). Confirm no cwd() builder.
     assert not hasattr(CodexCliClient(binary_path="codex"), "cwd")
+
+
+def test_resume_inserts_exec_resume_subcommand():
+    args = CodexCliClient(binary_path="codex").resume("th_abc")._build_args()
+    assert args[:4] == ["codex", "exec", "resume", "th_abc"]
+    assert "--json" in args
+
+
+def test_resume_blank_skipped():
+    args = CodexCliClient(binary_path="codex").resume("   ")._build_args()
+    assert "resume" not in args

--- a/sdks/python/tests/test_codex_cli_stream.py
+++ b/sdks/python/tests/test_codex_cli_stream.py
@@ -71,7 +71,20 @@ def test_top_level_error_raises_provider_error():
 
 
 def test_unknown_event_dropped():
-    assert _parse_jsonl_line('{"type": "thread.started", "thread_id": "t1"}') == []
+    # thread.started now parses (F3); use a still-unmodeled event type.
+    assert _parse_jsonl_line('{"type":"item.started","item_id":"abc"}') == []
+
+
+def test_thread_started_captures_session_id():
+    events = _parse_jsonl_line('{"type":"thread.started","thread_id":"th_abc"}')
+    assert len(events) == 1
+    assert events[0].session_id == "th_abc"
+    assert events[0].done is False
+    assert events[0].content == ""
+
+
+def test_thread_started_without_id_dropped():
+    assert _parse_jsonl_line('{"type":"thread.started"}') == []
 
 
 def test_malformed_json_returns_empty():
@@ -234,10 +247,16 @@ async def test_stream_yields_events_in_order(monkeypatch):
     client = CodexCliClient(binary_path="codex")
     events = [e async for e in client.stream(ChatRequest(messages=[Message.user("hi")]))]
 
-    text_events = [e for e in events if e.event_type == "text" and not e.done]
+    # thread.started now emits a session event (F3); exclude it from text events.
+    session_events = [e for e in events if e.session_id is not None]
+    text_events = [
+        e for e in events if e.event_type == "text" and not e.done and e.session_id is None
+    ]
     usage_events = [e for e in events if e.event_type == "usage"]
     done_events = [e for e in events if e.done]
 
+    assert len(session_events) == 1
+    assert session_events[0].session_id == "t1"
     assert [e.content for e in text_events] == ["hi"]
     assert len(usage_events) == 1
     assert usage_events[0].usage is not None

--- a/sdks/python/tests/test_gemini_cli_stream.py
+++ b/sdks/python/tests/test_gemini_cli_stream.py
@@ -15,8 +15,15 @@ from motosan_ai.providers.gemini_cli import (
 from motosan_ai.types import ChatRequest, Message
 
 
-def test_init_event_dropped():
-    assert _parse_jsonl_line('{"type": "init", "session_id": "s1"}') == []
+def test_init_event_without_session_id_dropped():
+    assert _parse_jsonl_line('{"type":"init"}') == []
+
+
+def test_init_event_yields_session_id():
+    events = _parse_jsonl_line('{"type":"init","session_id":"s1"}')
+    assert len(events) == 1
+    assert events[0].session_id == "s1"
+    assert events[0].done is False
 
 
 def test_user_message_dropped():
@@ -191,6 +198,20 @@ async def test_chat_returns_concatenated_text(monkeypatch):
     assert resp.content == "Hello world."
     assert resp.usage.input_tokens == 10
     assert resp.usage.output_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_chat_captures_session_id(monkeypatch):
+    jsonl = (
+        '{"type": "init", "session_id": "s1"}\n'
+        '{"type": "message", "role": "assistant", "content": "hi", "delta": true}\n'
+        '{"type": "result", "status": "success"}\n'
+    )
+    _stub_subprocess(monkeypatch, _FakeProc(jsonl))
+    resp = await GeminiCliClient(binary_path="gemini").chat(
+        ChatRequest(messages=[Message.user("hi")])
+    )
+    assert resp.session_id == "s1"
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -145,3 +145,19 @@ def test_public_api_exports_new_types():
     assert m.McpToolConfigDenied is not None
     assert m.ProviderCapabilities is not None
     assert m.StreamEventType is not None
+
+
+def test_stream_event_session_id_defaults_none():
+    assert StreamEvent(content="hi", done=False).session_id is None
+
+
+def test_stream_event_session_id_settable():
+    assert StreamEvent(content="", done=False, session_id="s").session_id == "s"
+
+
+def test_chat_response_session_id_defaults_none():
+    assert ChatResponse(content="hi").session_id is None
+
+
+def test_chat_response_session_id_settable():
+    assert ChatResponse(content="hi", session_id="s").session_id == "s"


### PR DESCRIPTION
**Milestone F3** of the Python SDK → Rust 0.20.0 parity effort (→ 0.13.0). Plan: `docs/superpowers/plans/2026-06-23-python-0.20-cli-runtime-alignment.md`.

## What changes
Surface the provider's session id and enable resume:
- **F3.1** additive `session_id: str | None = None` on `StreamEvent` **and** `ChatResponse` (default None — non-breaking).
- **F3.2** `collect_stream` captures `session_id` (last-wins).
- **F3.3 ClaudeCode** — `_parse_agent_json` → 3-tuple `(text, usage, session_id)`; surfaces `result.session_id` on stream + ChatResponse. (Existing 2-tuple unpack tests updated in the same step.)
- **F3.4 Codex** — `thread.started` → `session_id`; new `resume(id)` → `codex exec resume <id>`.
- **F3.5 Gemini** — `init.session_id` → `session_id`; existing `resume()` verified.

## Verification
- `ruff check motosan_ai/` (CI scope) → clean; `ruff format --check .` → clean.
- `uv run pytest -q` → **586 passed, 30 skipped**; F3 subset → 22 passed/1 skip (live).
- Independent verify (incl. mutation check) → **ship**.

Scope: `sdks/python/` only (types.py + _stream_collect.py + 3 CLI providers + 7 test files). No version bump (F-release). Built on F1 (#202) + F2 (#203).

🤖 Generated with [Claude Code](https://claude.com/claude-code)