### PR TITLE
feat(python): per-run env injection — .env()/.envs() on CLI providers [F4/7, 0.20-parity]

### DIFF
--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -22,6 +22,13 @@ from motosan_ai.types import (
 _TIMEOUT_SECS = 300
 
 
+class _RedactedEnvs(list):
+    """list[tuple[str, str]] of (key, value) env pairs whose repr hides values."""
+
+    def __repr__(self) -> str:
+        return f"<{len(self)} redacted>"
+
+
 @dataclass
 class _ClaudeCodeConfig:
     binary_path: str = "claude"
@@ -48,6 +55,7 @@ class _ClaudeCodeConfig:
     plugin_dirs: list[str] = field(default_factory=list)
     max_budget_usd: float | None = None
     cwd: str | None = None
+    envs: _RedactedEnvs = field(default_factory=_RedactedEnvs)
 
 
 def _model_to_forward(model: str) -> str | None:
@@ -318,6 +326,32 @@ class ClaudeCodeClient:
         self._config.cwd = directory
         return self
 
+    def env(self, key: str, value: str) -> ClaudeCodeClient:
+        """Inject one environment variable into the spawned subprocess (repeatable).
+
+        The value is treated as a secret and is redacted from ``repr``.
+        """
+        self._config.envs.append((key, value))
+        return self
+
+    def envs(self, vars: dict[str, str]) -> ClaudeCodeClient:
+        """Replace the full set of injected environment variables (does not append)."""
+        self._config.envs = _RedactedEnvs(vars.items())
+        return self
+
+    def _subprocess_env(self) -> dict[str, str] | None:
+        """Child env: a copy of os.environ overlaid with injected vars.
+
+        Returns ``None`` when nothing is injected so the child inherits the
+        parent environment unchanged (and os.environ is never mutated).
+        """
+        if not self._config.envs:
+            return None
+        merged = dict(os.environ)
+        for key, value in self._config.envs:
+            merged[key] = value
+        return merged
+
     def _build_args(
         self,
         *,
@@ -441,6 +475,7 @@ class ClaudeCodeClient:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self._config.cwd,
+            env=self._subprocess_env(),
         )
 
         try:
@@ -499,6 +534,7 @@ class ClaudeCodeClient:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self._config.cwd,
+            env=self._subprocess_env(),
         )
 
         # Write prompt to stdin then close it

--- a/sdks/python/motosan_ai/providers/codex_cli.py
+++ b/sdks/python/motosan_ai/providers/codex_cli.py
@@ -34,6 +34,13 @@ class LocalProvider(StrEnum):
     ollama = "ollama"
 
 
+class _RedactedEnvs(list):
+    """list[tuple[str, str]] of (key, value) env pairs whose repr hides values."""
+
+    def __repr__(self) -> str:
+        return f"<{len(self)} redacted>"
+
+
 @dataclass
 class _CodexCliConfig:
     binary_path: str = "codex"
@@ -51,6 +58,7 @@ class _CodexCliConfig:
     disabled_features: list[str] = field(default_factory=list)
     config_overrides: list[tuple[str, str]] = field(default_factory=list)
     resume: str | None = None
+    envs: _RedactedEnvs = field(default_factory=_RedactedEnvs)
 
 
 def _model_to_forward(model: str) -> str | None:
@@ -224,6 +232,24 @@ class CodexCliClient:
         self._config.resume = thread_id
         return self
 
+    def env(self, key: str, value: str) -> CodexCliClient:
+        """Inject one env var into the spawned child (repeatable). Value is a secret."""
+        self._config.envs.append((key, value))
+        return self
+
+    def envs(self, vars: dict[str, str]) -> CodexCliClient:
+        """Replace the full set of injected env vars (does not append)."""
+        self._config.envs = _RedactedEnvs(vars.items())
+        return self
+
+    def _subprocess_env(self) -> dict[str, str] | None:
+        if not self._config.envs:
+            return None
+        merged = dict(os.environ)
+        for key, value in self._config.envs:
+            merged[key] = value
+        return merged
+
     def _build_args(self, model: str | None = None) -> list[str]:
         args: list[str] = [self._config.binary_path, "exec"]
         if self._config.resume is not None and self._config.resume.strip():
@@ -273,6 +299,7 @@ class CodexCliClient:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=self._subprocess_env(),
         )
         try:
             stdout, stderr = await asyncio.wait_for(
@@ -320,6 +347,7 @@ class CodexCliClient:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=self._subprocess_env(),
         )
 
         try:

--- a/sdks/python/motosan_ai/providers/gemini_cli.py
+++ b/sdks/python/motosan_ai/providers/gemini_cli.py
@@ -30,6 +30,28 @@ class ApprovalMode(StrEnum):
     plan = "plan"
 
 
+class _RedactedEnvs:
+    """Ordered env-var pairs whose ``repr`` never prints values (secrets)."""
+
+    def __init__(self, pairs: list[tuple[str, str]] | None = None) -> None:
+        self._pairs: list[tuple[str, str]] = list(pairs) if pairs else []
+
+    def push(self, key: str, value: str) -> None:
+        self._pairs.append((key, value))
+
+    def replace_from(self, vars: dict[str, str]) -> None:
+        self._pairs = [(str(k), str(v)) for k, v in vars.items()]
+
+    def as_dict(self) -> dict[str, str]:
+        return dict(self._pairs)
+
+    def __len__(self) -> int:
+        return len(self._pairs)
+
+    def __repr__(self) -> str:
+        return f"<{len(self._pairs)} redacted>"
+
+
 @dataclass
 class _GeminiCliConfig:
     binary_path: str = "gemini"
@@ -42,6 +64,7 @@ class _GeminiCliConfig:
     allowed_mcp_servers: list[str] = field(default_factory=list)
     resume: str | None = None
     cwd: str | None = None
+    envs: _RedactedEnvs = field(default_factory=_RedactedEnvs)
 
 
 def _model_to_forward(model: str) -> str | None:
@@ -199,6 +222,23 @@ class GeminiCliClient:
         self._config.cwd = directory
         return self
 
+    def env(self, key: str, value: str) -> GeminiCliClient:
+        """Inject one environment variable into the child (repeatable; value is a secret)."""
+        self._config.envs.push(key, value)
+        return self
+
+    def envs(self, vars: dict[str, str]) -> GeminiCliClient:
+        """Replace the full set of injected environment variables (does not append)."""
+        self._config.envs.replace_from(vars)
+        return self
+
+    def _child_env(self) -> dict[str, str] | None:
+        if len(self._config.envs) == 0:
+            return None
+        merged = dict(os.environ)
+        merged.update(self._config.envs.as_dict())
+        return merged
+
     def _build_args(self, model: str | None = None) -> list[str]:
         args: list[str] = [self._config.binary_path, "-p", "", "-o", "stream-json"]
 
@@ -240,6 +280,7 @@ class GeminiCliClient:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self._config.cwd,
+            env=self._child_env(),
         )
         try:
             stdout, stderr = await asyncio.wait_for(
@@ -289,6 +330,7 @@ class GeminiCliClient:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self._config.cwd,
+            env=self._child_env(),
         )
         try:
             assert proc.stdin is not None and proc.stdout is not None

--- a/sdks/python/tests/test_claude_code.py
+++ b/sdks/python/tests/test_claude_code.py
@@ -270,6 +270,20 @@ class TestClaudeCodeClientConstruction:
     def test_cwd_default_none(self):
         assert ClaudeCodeClient()._config.cwd is None
 
+    def test_env_appends(self):
+        client = ClaudeCodeClient().env("A", "1").env("B", "2")
+        assert list(client._config.envs) == [("A", "1"), ("B", "2")]
+
+    def test_envs_replaces(self):
+        client = ClaudeCodeClient().env("X", "0").envs({"A": "1"})
+        assert list(client._config.envs) == [("A", "1")]
+
+    def test_repr_redacts_env_values(self):
+        client = ClaudeCodeClient().env("ANTHROPIC_API_KEY", "sk-secret")
+        r = repr(client._config)
+        assert "sk-secret" not in r
+        assert "<1 redacted>" in r
+
 
 # ---------------------------------------------------------------------------
 # _build_args

--- a/sdks/python/tests/test_claude_code_runtime.py
+++ b/sdks/python/tests/test_claude_code_runtime.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -35,3 +36,26 @@ async def test_chat_passes_cwd_to_subprocess():
         req = ChatRequest(messages=[Message(role=Role.user, content="hi")])
         await client.chat(req)
         assert spawn.call_args.kwargs["cwd"] == "/work"
+
+
+@pytest.mark.asyncio
+async def test_chat_merges_env_over_os_environ(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    proc = _make_proc()
+    spawn = AsyncMock(return_value=proc)
+    monkeypatch.setattr("motosan_ai.providers.claude_code.asyncio.create_subprocess_exec", spawn)
+    client = ClaudeCodeClient().env("K", "v")  # agent_mode if needed for parse
+    await client.chat(ChatRequest(messages=[Message(role=Role.user, content="hi")]))
+    env = spawn.call_args.kwargs["env"]
+    assert env["K"] == "v"
+    assert env["PATH"] == "/usr/bin"  # inherited (merge, not replace)
+    assert "K" not in os.environ  # parent unmutated
+
+
+@pytest.mark.asyncio
+async def test_chat_env_none_when_empty(monkeypatch):
+    proc = _make_proc()
+    spawn = AsyncMock(return_value=proc)
+    monkeypatch.setattr("motosan_ai.providers.claude_code.asyncio.create_subprocess_exec", spawn)
+    await ClaudeCodeClient().chat(ChatRequest(messages=[Message(role=Role.user, content="hi")]))
+    assert spawn.call_args.kwargs["env"] is None

--- a/sdks/python/tests/test_codex_cli_flags.py
+++ b/sdks/python/tests/test_codex_cli_flags.py
@@ -214,3 +214,21 @@ def test_resume_inserts_exec_resume_subcommand():
 def test_resume_blank_skipped():
     args = CodexCliClient(binary_path="codex").resume("   ")._build_args()
     assert "resume" not in args
+
+
+def test_env_appends_and_envs_replaces():
+    client = CodexCliClient(binary_path="codex").env("A", "1").env("B", "2")
+    assert list(client._config.envs) == [("A", "1"), ("B", "2")]
+    client.envs({"C": "3"})
+    assert list(client._config.envs) == [("C", "3")]
+
+
+def test_env_repr_redacts_secret():
+    client = CodexCliClient(binary_path="codex").env("OPENAI_API_KEY", "sk-secret")
+    r = repr(client._config)
+    assert "<1 redacted>" in r and "sk-secret" not in r
+
+
+def test_env_not_in_argv():
+    args = CodexCliClient(binary_path="codex").env("OPENAI_API_KEY", "sk-secret")._build_args()
+    assert all("sk-secret" not in a for a in args)

--- a/sdks/python/tests/test_codex_cli_stream.py
+++ b/sdks/python/tests/test_codex_cli_stream.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import AsyncMock
 
 import pytest
@@ -264,3 +265,23 @@ async def test_stream_yields_events_in_order(monkeypatch):
     assert len(done_events) == 1
     assert events.index(text_events[0]) < events.index(usage_events[0])
     assert events.index(usage_events[0]) < events.index(done_events[0])
+
+
+@pytest.mark.asyncio
+async def test_chat_passes_env_to_subprocess(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setattr(asyncio.subprocess, "PIPE", -1, raising=False)
+    fake = _FakeProc(
+        '{"type": "item.completed", "item": {"type": "agent_message", "text": "hi"}}\n'
+        '{"type": "turn.completed"}\n'
+    )
+    spawn = AsyncMock(return_value=fake)
+    monkeypatch.setattr("asyncio.create_subprocess_exec", spawn)
+    await (
+        CodexCliClient(binary_path="codex")
+        .env("K", "v")
+        .chat(ChatRequest(messages=[Message.user("hi")]))
+    )
+    env = spawn.call_args.kwargs["env"]
+    assert env["K"] == "v" and env["PATH"] == "/usr/bin"
+    assert "K" not in os.environ

--- a/sdks/python/tests/test_gemini_cli_dispatch.py
+++ b/sdks/python/tests/test_gemini_cli_dispatch.py
@@ -39,3 +39,17 @@ def test_cwd_setter():
 
 def test_cwd_default_none():
     assert GeminiCliClient()._config.cwd is None
+
+
+def test_env_appends_and_envs_replaces():
+    client = GeminiCliClient().env("A", "1").env("B", "2")
+    assert client._child_env()["A"] == "1" and client._child_env()["B"] == "2"
+    client.envs({"C": "3"})
+    child = client._child_env()
+    assert child["C"] == "3" and "A" not in child
+
+
+def test_env_repr_redacts():
+    client = GeminiCliClient().env("GEMINI_API_KEY", "sk-x")
+    r = repr(client._config)
+    assert "<1 redacted>" in r and "sk-x" not in r

--- a/sdks/python/tests/test_gemini_cli_stream.py
+++ b/sdks/python/tests/test_gemini_cli_stream.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import AsyncMock
 
 import pytest
@@ -269,3 +270,23 @@ async def test_chat_passes_cwd_to_subprocess(monkeypatch):
     client = GeminiCliClient().cwd("/work/dir")
     await client.chat(ChatRequest(messages=[Message.user("hi")]))
     assert spawn.call_args.kwargs["cwd"] == "/work/dir"
+
+
+@pytest.mark.asyncio
+async def test_chat_merges_env(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setattr(asyncio.subprocess, "PIPE", -1, raising=False)
+    fake = _FakeProc(
+        '{"type": "message", "role": "assistant", "content": "hi", "delta": true}\n'
+        '{"type": "result", "status": "success"}\n'
+    )
+    spawn = AsyncMock(return_value=fake)
+    monkeypatch.setattr("asyncio.create_subprocess_exec", spawn)
+    await (
+        GeminiCliClient(binary_path="gemini")
+        .env("K", "v")
+        .chat(ChatRequest(messages=[Message.user("hi")]))
+    )
+    env = spawn.call_args.kwargs["env"]
+    assert env["K"] == "v" and env["PATH"] == "/usr/bin"
+    assert "K" not in os.environ


### PR DESCRIPTION
**Milestone F4** of the Python SDK → Rust 0.20.0 parity effort (→ 0.13.0). Plan: `docs/superpowers/plans/2026-06-23-python-0.20-cli-runtime-alignment.md`.

## What changes
Per-run environment injection on the 3 CLI providers (claude_code / codex_cli / gemini_cli):
- `.env(key, value)` / `.envs(mapping)` builders (return self) + an `envs` config field.
- `env=` passed into `asyncio.create_subprocess_exec` at **both** spawn sites: a **copy** of `os.environ` overlaid with the per-run pairs — the parent `os.environ` is never mutated.
- Secrets redacted in `repr` (`<N redacted>`, never the value). The three `_RedactedEnvs` keep deliberately distinct shapes (list subclass for claude/codex, wrapper for gemini).

## Verification
- `ruff check motosan_ai/` (CI scope) → clean; `ruff format --check .` → clean.
- `uv run pytest -q` → **598 passed, 30 skipped**; `-k "env or redact"` → 30 passed.
- Independent verify (incl. mutation checks: stripping `env=` fails a test; leaking repr fails a redaction test) → **ship, zero issues**.

Scope: `sdks/python/` only (3 providers + 6 test files). No version bump (F-release). Built on F1–F3 (#202/#203/#204).

🤖 Generated with [Claude Code](https://claude.com/claude-code)