### PR TITLE
feat(python): CLI tool-call stream events [F5/7, 0.20-parity]

### DIFF
--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -133,16 +133,58 @@ def _parse_ndjson_line(line: str) -> list[StreamEvent]:
     if event_type == "assistant":
         message = event.get("message", {})
         content_blocks = message.get("content", [])
-        parts: list[str] = []
+        events: list[StreamEvent] = []
+        text_parts: list[str] = []
+
+        def _flush_text() -> None:
+            joined = "".join(text_parts)
+            if joined:
+                events.append(StreamEvent(content=joined, done=False))
+            text_parts.clear()
+
         for block in content_blocks:
-            if isinstance(block, dict) and block.get("type") == "text":
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
                 t = block.get("text", "")
                 if t:
-                    parts.append(t)
-        text = "".join(parts)
-        if not text:
-            return []
-        return [StreamEvent(content=text, done=False)]
+                    text_parts.append(t)
+            elif btype == "tool_use":
+                _flush_text()
+                tool_id = block.get("id", "")
+                tool_name = block.get("name", "")
+                tool_input = block.get("input", {})
+                args = json.dumps(tool_input, separators=(",", ":"))
+                events.append(
+                    StreamEvent(
+                        content="",
+                        done=False,
+                        event_type="tool_call_start",
+                        tool_call_id=tool_id,
+                        tool_call_name=tool_name,
+                    )
+                )
+                events.append(
+                    StreamEvent(
+                        content="",
+                        done=False,
+                        event_type="tool_call_args",
+                        tool_call_id=tool_id,
+                        tool_call_args_delta=args,
+                    )
+                )
+                events.append(
+                    StreamEvent(
+                        content="",
+                        done=False,
+                        event_type="tool_call_end",
+                        tool_call_id=tool_id,
+                    )
+                )
+            # thinking / other blocks ignored
+        _flush_text()
+        return events
 
     if event_type == "result":
         events_out: list[StreamEvent] = []
@@ -545,13 +587,14 @@ class ClaudeCodeClient:
         await proc.stdin.wait_closed()
 
         assert proc.stdout is not None
+        saw_tool_call = False
         try:
             while True:
                 try:
                     raw_line = await asyncio.wait_for(proc.stdout.readline(), timeout=_TIMEOUT_SECS)
                 except TimeoutError as exc:
                     raise ProviderError(
-                        f"claude CLI stream timed out after {_TIMEOUT_SECS} seconds"
+                        f"claude CLI stream read timed out after {_TIMEOUT_SECS}s"
                     ) from exc
                 if not raw_line:
                     break
@@ -559,6 +602,16 @@ class ClaudeCodeClient:
                 if not line:
                     continue
                 for event in _parse_ndjson_line(line):
+                    if event.event_type in (
+                        "tool_call_start",
+                        "tool_call_args",
+                        "tool_call_end",
+                    ):
+                        saw_tool_call = True
+                    if event.done:
+                        event.stop_reason = (
+                            StopReason.tool_use if saw_tool_call else StopReason.end_turn
+                        )
                     yield event
                     if event.done:
                         return

--- a/sdks/python/motosan_ai/providers/codex_cli.py
+++ b/sdks/python/motosan_ai/providers/codex_cli.py
@@ -98,6 +98,47 @@ def _compose_prompt(system: str | None, user: str) -> str:
     return user
 
 
+def _tool_call_events(item: dict) -> list[StreamEvent]:
+    """Expand a command_execution / mcp_tool_call item into start/args/end events."""
+    call_id = item.get("id") or ""
+    server = item.get("server")
+    tool = item.get("tool")
+    if server and tool:
+        name = f"{server}/{tool}"
+    elif tool:
+        name = tool
+    else:
+        name = item.get("type") or ""
+
+    arguments = item.get("arguments")
+    # Compact separators (finding 8) — matches Rust's serde_json::to_string and
+    # the claude/gemini CLI providers: {"command":"ls -la"}, no spaces.
+    if arguments is not None:
+        args_json = json.dumps(arguments, separators=(",", ":"))
+    elif item.get("command") is not None:
+        args_json = json.dumps({"command": item["command"]}, separators=(",", ":"))
+    else:
+        args_json = "{}"
+
+    return [
+        StreamEvent(
+            content="",
+            done=False,
+            tool_call_id=call_id,
+            tool_call_name=name,
+            event_type="tool_call_start",
+        ),
+        StreamEvent(
+            content="",
+            done=False,
+            tool_call_id=call_id,
+            tool_call_args_delta=args_json,
+            event_type="tool_call_args",
+        ),
+        StreamEvent(content="", done=False, tool_call_id=call_id, event_type="tool_call_end"),
+    ]
+
+
 def _parse_jsonl_line(line: str) -> list[StreamEvent]:
     """Parse one JSONL line from ``codex exec --json`` into stream events."""
     if not line:
@@ -111,12 +152,17 @@ def _parse_jsonl_line(line: str) -> list[StreamEvent]:
 
     if event_type == "item.completed":
         item = event.get("item") or {}
-        if not isinstance(item, dict) or item.get("type") != "agent_message":
+        if not isinstance(item, dict):
             return []
-        text = item.get("text") or ""
-        if not text:
-            return []
-        return [StreamEvent(content=text, done=False)]
+        item_type = item.get("type")
+        if item_type == "agent_message":
+            text = item.get("text") or ""
+            if not text:
+                return []
+            return [StreamEvent(content=text, done=False)]
+        if item_type in ("command_execution", "mcp_tool_call"):
+            return _tool_call_events(item)
+        return []
 
     if event_type == "turn.completed":
         out: list[StreamEvent] = []
@@ -350,6 +396,7 @@ class CodexCliClient:
             env=self._subprocess_env(),
         )
 
+        saw_tool_call = False
         try:
             assert proc.stdin is not None and proc.stdout is not None
             proc.stdin.write(prompt.encode())
@@ -359,9 +406,20 @@ class CodexCliClient:
             with contextlib.suppress(BrokenPipeError, ConnectionResetError, AttributeError):
                 await proc.stdin.wait_closed()
 
-            async for raw in proc.stdout:
+            while True:
+                raw = await proc.stdout.readline()
+                if not raw:
+                    break
                 line = raw.decode().rstrip("\n")
                 for event in _parse_jsonl_line(line):
+                    if event.event_type in (
+                        "tool_call_start",
+                        "tool_call_args",
+                        "tool_call_end",
+                    ):
+                        saw_tool_call = True
+                    if event.done and saw_tool_call:
+                        event.stop_reason = StopReason.tool_use
                     yield event
                     if event.done:
                         return

--- a/sdks/python/motosan_ai/providers/gemini_cli.py
+++ b/sdks/python/motosan_ai/providers/gemini_cli.py
@@ -120,6 +120,37 @@ def _parse_jsonl_line(line: str) -> list[StreamEvent]:
             return [StreamEvent(content="", done=False, session_id=session_id)]
         return []
 
+    if event_type == "tool_use":
+        tool_id = event.get("tool_id") or ""
+        tool_name = event.get("tool_name") or "tool_use"
+        parameters = event.get("parameters")
+        # Compact separators (finding 8) — matches Rust + claude/codex CLI providers.
+        args_json = (
+            json.dumps(parameters, separators=(",", ":")) if isinstance(parameters, dict) else "{}"
+        )
+        return [
+            StreamEvent(
+                content="",
+                done=False,
+                event_type="tool_call_start",
+                tool_call_id=tool_id,
+                tool_call_name=tool_name,
+            ),
+            StreamEvent(
+                content="",
+                done=False,
+                event_type="tool_call_args",
+                tool_call_id=tool_id,
+                tool_call_args_delta=args_json,
+            ),
+            StreamEvent(
+                content="",
+                done=False,
+                event_type="tool_call_end",
+                tool_call_id=tool_id,
+            ),
+        ]
+
     if event_type == "message":
         role = event.get("role")
         delta = event.get("delta", False)
@@ -332,6 +363,7 @@ class GeminiCliClient:
             cwd=self._config.cwd,
             env=self._child_env(),
         )
+        saw_tool_call = False
         try:
             assert proc.stdin is not None and proc.stdout is not None
             proc.stdin.write(stdin_payload.encode())
@@ -341,9 +373,18 @@ class GeminiCliClient:
             with contextlib.suppress(BrokenPipeError, ConnectionResetError, AttributeError):
                 await proc.stdin.wait_closed()
 
-            async for raw in proc.stdout:
+            while True:
+                raw = await proc.stdout.readline()
+                if not raw:
+                    break
                 line = raw.decode().rstrip("\n")
                 for event in _parse_jsonl_line(line):
+                    if event.event_type == "tool_call_start":
+                        saw_tool_call = True
+                    if event.done:
+                        event.stop_reason = (
+                            StopReason.tool_use if saw_tool_call else StopReason.end_turn
+                        )
                     yield event
                     if event.done:
                         return

--- a/sdks/python/tests/test_claude_code.py
+++ b/sdks/python/tests/test_claude_code.py
@@ -201,6 +201,36 @@ class TestParseNdjsonLine:
         assert _parse_ndjson_line("{") == []
         assert _parse_ndjson_line("") == []
 
+    def test_tool_use_block_yields_triplet(self):
+        line = (
+            '{"type":"assistant","message":{"content":['
+            '{"type":"tool_use","id":"toolu_01","name":"Read","input":{"path":"/tmp/x"}}]}}'
+        )
+        events = _parse_ndjson_line(line)
+        assert [e.event_type for e in events] == [
+            "tool_call_start",
+            "tool_call_args",
+            "tool_call_end",
+        ]
+        assert events[0].tool_call_id == "toolu_01"
+        assert events[0].tool_call_name == "Read"
+        assert events[1].tool_call_args_delta == '{"path":"/tmp/x"}'
+        assert events[2].tool_call_id == "toolu_01"
+
+    def test_assistant_text_and_tool_use_preserves_text(self):
+        line = (
+            '{"type":"assistant","message":{"content":['
+            '{"type":"text","text":"let me read it"},'
+            '{"type":"tool_use","id":"toolu_01","name":"Read","input":{}}]}}'
+        )
+        events = _parse_ndjson_line(line)
+        assert events[0].content == "let me read it"
+        assert [e.event_type for e in events[1:]] == [
+            "tool_call_start",
+            "tool_call_args",
+            "tool_call_end",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # ClaudeCodeClient construction

--- a/sdks/python/tests/test_claude_code_runtime.py
+++ b/sdks/python/tests/test_claude_code_runtime.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from motosan_ai.providers.claude_code import ClaudeCodeClient
-from motosan_ai.types import ChatRequest, Message, Role
+from motosan_ai.types import ChatRequest, Message, Role, StopReason
 
 
 def _make_proc(stdout: bytes = b'{"type":"result","result":"hi","is_error":false}\n'):
@@ -59,3 +59,25 @@ async def test_chat_env_none_when_empty(monkeypatch):
     monkeypatch.setattr("motosan_ai.providers.claude_code.asyncio.create_subprocess_exec", spawn)
     await ClaudeCodeClient().chat(ChatRequest(messages=[Message(role=Role.user, content="hi")]))
     assert spawn.call_args.kwargs["env"] is None
+
+
+@pytest.mark.asyncio
+async def test_stream_tool_use_sets_terminal_stop_reason(monkeypatch):
+    stdout = (
+        b'{"type":"assistant","message":{"content":['
+        b'{"type":"tool_use","id":"toolu_01","name":"Read","input":{}}]}}\n'
+        b'{"type":"result","result":"done"}\n'
+    )
+    proc = _make_proc(stdout=stdout)
+    monkeypatch.setattr(
+        "motosan_ai.providers.claude_code.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=proc),
+    )
+    events = [
+        ev
+        async for ev in ClaudeCodeClient().stream(
+            ChatRequest(messages=[Message(role=Role.user, content="hi")])
+        )
+    ]
+    done = [e for e in events if e.done][-1]
+    assert done.stop_reason == StopReason.tool_use

--- a/sdks/python/tests/test_codex_cli_stream.py
+++ b/sdks/python/tests/test_codex_cli_stream.py
@@ -13,7 +13,7 @@ from motosan_ai.providers.codex_cli import (
     _messages_to_prompt,
     _parse_jsonl_line,
 )
-from motosan_ai.types import ChatRequest, Message
+from motosan_ai.types import ChatRequest, Message, StopReason
 
 
 def test_agent_message_emits_text_event():
@@ -93,6 +93,37 @@ def test_malformed_json_returns_empty():
     assert _parse_jsonl_line("") == []
 
 
+def test_command_execution_yields_tool_call_events():
+    line = (
+        '{"type":"item.completed","item":{"id":"item_0",'
+        '"type":"command_execution","command":"ls -la"}}'
+    )
+    events = _parse_jsonl_line(line)
+    assert [e.event_type for e in events] == [
+        "tool_call_start",
+        "tool_call_args",
+        "tool_call_end",
+    ]
+    assert events[0].tool_call_id == "item_0"
+    assert events[0].tool_call_name == "command_execution"
+    assert events[1].tool_call_args_delta == '{"command":"ls -la"}'
+
+
+def test_mcp_tool_call_uses_server_qualified_name():
+    line = (
+        '{"type":"item.completed","item":{"id":"i1","type":"mcp_tool_call",'
+        '"server":"node_repl","tool":"js","arguments":{"code":"x"}}}'
+    )
+    events = _parse_jsonl_line(line)
+    assert events[0].tool_call_name == "node_repl/js"
+    assert "code" in events[1].tool_call_args_delta
+
+
+def test_tool_call_only_tool_name_when_no_server():
+    line = '{"type":"item.completed","item":{"id":"i2","type":"mcp_tool_call","tool":"js"}}'
+    assert _parse_jsonl_line(line)[0].tool_call_name == "js"
+
+
 def test_messages_to_prompt_extracts_system_and_user_prompt():
     system, prompt = _messages_to_prompt([Message.system("be terse"), Message.user("hello")])
     assert system == "be terse"
@@ -137,6 +168,11 @@ class _FakeStdin:
 class _FakeStdout:
     def __init__(self, text: str) -> None:
         self._lines = [line.encode() for line in text.splitlines(True)]
+
+    async def readline(self) -> bytes:
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
 
     def __aiter__(self):
         self._iter = iter(self._lines)
@@ -285,3 +321,21 @@ async def test_chat_passes_env_to_subprocess(monkeypatch):
     env = spawn.call_args.kwargs["env"]
     assert env["K"] == "v" and env["PATH"] == "/usr/bin"
     assert "K" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_stream_tool_call_sets_tool_use_stop_reason(monkeypatch):
+    jsonl = (
+        '{"type": "item.completed", "item": {"id": "i0", "type": "command_execution", '
+        '"command": "ls"}}\n'
+        '{"type": "turn.completed"}\n'
+    )
+    _stub_subprocess(monkeypatch, _FakeProc(jsonl, returncode=None))
+    events = [
+        ev
+        async for ev in CodexCliClient(binary_path="codex").stream(
+            ChatRequest(messages=[Message.user("hi")])
+        )
+    ]
+    done = [e for e in events if e.done][-1]
+    assert done.stop_reason == StopReason.tool_use

--- a/sdks/python/tests/test_codex_cli_stream.py
+++ b/sdks/python/tests/test_codex_cli_stream.py
@@ -324,6 +324,22 @@ async def test_chat_passes_env_to_subprocess(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_chat_does_not_surface_tool_calls(monkeypatch):
+    jsonl = (
+        '{"type": "item.completed", "item": {"id": "i0", "type": "command_execution", '
+        '"command": "ls"}}\n'
+        '{"type": "item.completed", "item": {"type": "agent_message", "text": "done"}}\n'
+        '{"type": "turn.completed"}\n'
+    )
+    _stub_subprocess(monkeypatch, _FakeProc(jsonl))
+    resp = await CodexCliClient(binary_path="codex").chat(
+        ChatRequest(messages=[Message.user("hi")])
+    )
+    assert resp.tool_calls == []
+    assert "done" in resp.content
+
+
+@pytest.mark.asyncio
 async def test_stream_tool_call_sets_tool_use_stop_reason(monkeypatch):
     jsonl = (
         '{"type": "item.completed", "item": {"id": "i0", "type": "command_execution", '

--- a/sdks/python/tests/test_gemini_cli_stream.py
+++ b/sdks/python/tests/test_gemini_cli_stream.py
@@ -13,7 +13,7 @@ from motosan_ai.providers.gemini_cli import (
     _messages_to_prompt,
     _parse_jsonl_line,
 )
-from motosan_ai.types import ChatRequest, Message
+from motosan_ai.types import ChatRequest, Message, StopReason
 
 
 def test_init_event_without_session_id_dropped():
@@ -95,6 +95,33 @@ def test_malformed_json_returns_empty():
     assert _parse_jsonl_line("") == []
 
 
+def test_tool_use_yields_triplet():
+    line = (
+        '{"type":"tool_use","tool_id":"read_file_1","tool_name":"read_file",'
+        '"parameters":{"file_path":"Cargo.toml"}}'
+    )
+    events = _parse_jsonl_line(line)
+    assert [e.event_type for e in events] == [
+        "tool_call_start",
+        "tool_call_args",
+        "tool_call_end",
+    ]
+    assert events[0].tool_call_id == "read_file_1"
+    assert events[0].tool_call_name == "read_file"
+    assert events[1].tool_call_args_delta == '{"file_path":"Cargo.toml"}'
+
+
+def test_tool_use_defaults():
+    events = _parse_jsonl_line('{"type":"tool_use"}')
+    assert events[0].tool_call_id == ""
+    assert events[0].tool_call_name == "tool_use"
+    assert events[1].tool_call_args_delta == "{}"
+
+
+def test_tool_result_dropped():
+    assert _parse_jsonl_line('{"type":"tool_result","tool_id":"x"}') == []
+
+
 def test_messages_to_prompt_single_user_returns_just_content():
     assert _messages_to_prompt([Message.user("hello")]) == (None, "hello")
 
@@ -141,6 +168,11 @@ class _FakeStdin:
 class _FakeStdout:
     def __init__(self, text: str) -> None:
         self._lines = [line.encode() for line in text.splitlines(True)]
+
+    async def readline(self) -> bytes:
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
 
     def __aiter__(self):
         self._iter = iter(self._lines)
@@ -290,3 +322,20 @@ async def test_chat_merges_env(monkeypatch):
     env = spawn.call_args.kwargs["env"]
     assert env["K"] == "v" and env["PATH"] == "/usr/bin"
     assert "K" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_stream_tool_call_terminal_is_tool_use(monkeypatch):
+    jsonl = (
+        '{"type": "tool_use", "tool_id": "t1", "tool_name": "read_file", "parameters": {}}\n'
+        '{"type": "result", "status": "success"}\n'
+    )
+    _stub_subprocess(monkeypatch, _FakeProc(jsonl, returncode=None))
+    events = [
+        ev
+        async for ev in GeminiCliClient(binary_path="gemini").stream(
+            ChatRequest(messages=[Message.user("hi")])
+        )
+    ]
+    done = [e for e in events if e.done][-1]
+    assert done.stop_reason == StopReason.tool_use

--- a/sdks/python/tests/test_gemini_cli_stream.py
+++ b/sdks/python/tests/test_gemini_cli_stream.py
@@ -325,6 +325,21 @@ async def test_chat_merges_env(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_blocking_chat_tool_calls_empty(monkeypatch):
+    jsonl = (
+        '{"type": "tool_use", "tool_id": "t1", "tool_name": "read_file", "parameters": {}}\n'
+        '{"type": "message", "role": "assistant", "content": "hi", "delta": true}\n'
+        '{"type": "result", "status": "success"}\n'
+    )
+    _stub_subprocess(monkeypatch, _FakeProc(jsonl))
+    resp = await GeminiCliClient(binary_path="gemini").chat(
+        ChatRequest(messages=[Message.user("hi")])
+    )
+    assert resp.tool_calls == []
+    assert "hi" in resp.content
+
+
+@pytest.mark.asyncio
 async def test_stream_tool_call_terminal_is_tool_use(monkeypatch):
     jsonl = (
         '{"type": "tool_use", "tool_id": "t1", "tool_name": "read_file", "parameters": {}}\n'


### PR DESCRIPTION
**Milestone F5** of the Python SDK → Rust 0.20.0 parity effort (→ 0.13.0). Plan: `docs/superpowers/plans/2026-06-23-python-0.20-cli-runtime-alignment.md`.

## What changes
Each CLI provider's `stream()` now surfaces tool calls as `ToolCallStart → ToolCallArgs → ToolCallEnd`; blocking `chat().tool_calls` stays empty.
- **F5.1 ClaudeCode** — `tool_use` blocks in `assistant message.content[]` → triplet; loop-level `saw_tool_call` → terminal `done.stop_reason = tool_use` (the parity gap — now matches codex/gemini).
- **F5.2 Codex** — `command_execution` + `mcp_tool_call` (MCP tool name = `server/tool`); `stream()` → `while/readline` loop + `saw_tool_call`.
- **F5.3 / F5.5** — codex & gemini `chat().tool_calls` stay `[]` (guards).
- **F5.4 Gemini** — `tool_use` → triplet + `saw_tool_call`.
- Tool-call args serialized **compact** `json.dumps(separators=(",",":"))` on all three (Rust parity).

## Verification
- `ruff check motosan_ai/` (CI scope) → clean; `ruff format --check .` → clean.
- `uv run pytest -q` → **611 passed, 30 skipped**; tool subset → 33 passed/4 skip (live).
- Independent verify (incl. Rust event-name parity + mutation check) → **ship**.

Scope: `sdks/python/` only (3 providers + 4 test files). No version bump (F-release). Built on F1–F4. (The `while/readline` stream loops are also groundwork for F6's per-read timeout.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)