### PR TITLE
feat(python): configurable CLI timeout — .timeout()/.no_timeout() [F6/7, 0.20-parity]

### DIFF
--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -19,8 +19,6 @@ from motosan_ai.types import (
     Usage,
 )
 
-_TIMEOUT_SECS = 300
-
 
 class _RedactedEnvs(list):
     """list[tuple[str, str]] of (key, value) env pairs whose repr hides values."""
@@ -56,6 +54,7 @@ class _ClaudeCodeConfig:
     max_budget_usd: float | None = None
     cwd: str | None = None
     envs: _RedactedEnvs = field(default_factory=_RedactedEnvs)
+    timeout_secs: float | None = 300.0
 
 
 def _model_to_forward(model: str) -> str | None:
@@ -381,6 +380,16 @@ class ClaudeCodeClient:
         self._config.envs = _RedactedEnvs(vars.items())
         return self
 
+    def timeout(self, secs: float) -> ClaudeCodeClient:
+        """Override the per-invocation timeout (``chat`` and the stream read loop)."""
+        self._config.timeout_secs = secs
+        return self
+
+    def no_timeout(self) -> ClaudeCodeClient:
+        """Disable the invocation timeout (run until the child exits)."""
+        self._config.timeout_secs = None
+        return self
+
     def _subprocess_env(self) -> dict[str, str] | None:
         """Child env: a copy of os.environ overlaid with injected vars.
 
@@ -520,15 +529,19 @@ class ClaudeCodeClient:
             env=self._subprocess_env(),
         )
 
+        timeout = self._config.timeout_secs
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(user_prompt.encode()),
-                timeout=_TIMEOUT_SECS,
-            )
+            if timeout is None:
+                stdout, stderr = await proc.communicate(user_prompt.encode())
+            else:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(user_prompt.encode()),
+                    timeout=timeout,
+                )
         except TimeoutError as exc:
             proc.kill()
             await proc.wait()
-            raise ProviderError(f"claude CLI timed out after {_TIMEOUT_SECS} seconds") from exc
+            raise ProviderError(f"claude CLI timed out after {timeout} seconds") from exc
 
         if proc.returncode != 0:
             raise ProviderError(
@@ -559,7 +572,8 @@ class ClaudeCodeClient:
         """Stream via ``claude --print --output-format stream-json``, yielding NDJSON events.
 
         Raises :class:`~motosan_ai.error.ProviderError` if no output is received
-        within ``_TIMEOUT_SECS`` seconds.
+        within the configured ``timeout_secs`` (default 300s; disabled by
+        :meth:`no_timeout`).
         """
         msg_system, user_prompt = _messages_to_prompt(request.messages)
         system_prompt = request.system or msg_system
@@ -587,15 +601,19 @@ class ClaudeCodeClient:
         await proc.stdin.wait_closed()
 
         assert proc.stdout is not None
+        timeout = self._config.timeout_secs
         saw_tool_call = False
         try:
             while True:
-                try:
-                    raw_line = await asyncio.wait_for(proc.stdout.readline(), timeout=_TIMEOUT_SECS)
-                except TimeoutError as exc:
-                    raise ProviderError(
-                        f"claude CLI stream read timed out after {_TIMEOUT_SECS}s"
-                    ) from exc
+                if timeout is None:
+                    raw_line = await proc.stdout.readline()
+                else:
+                    try:
+                        raw_line = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+                    except TimeoutError as exc:
+                        raise ProviderError(
+                            f"claude CLI stream read timed out after {timeout}s"
+                        ) from exc
                 if not raw_line:
                     break
                 line = raw_line.decode().strip()

--- a/sdks/python/motosan_ai/providers/codex_cli.py
+++ b/sdks/python/motosan_ai/providers/codex_cli.py
@@ -20,7 +20,7 @@ from motosan_ai.types import (
     Usage,
 )
 
-_TIMEOUT_SECS = 600
+_DEFAULT_TIMEOUT_SECS = 600.0
 
 
 class SandboxMode(StrEnum):
@@ -59,6 +59,7 @@ class _CodexCliConfig:
     config_overrides: list[tuple[str, str]] = field(default_factory=list)
     resume: str | None = None
     envs: _RedactedEnvs = field(default_factory=_RedactedEnvs)
+    timeout_secs: float | None = _DEFAULT_TIMEOUT_SECS
 
 
 def _model_to_forward(model: str) -> str | None:
@@ -288,6 +289,16 @@ class CodexCliClient:
         self._config.envs = _RedactedEnvs(vars.items())
         return self
 
+    def timeout(self, secs: float) -> CodexCliClient:
+        """Override the per-invocation timeout (chat + per-read stream deadline)."""
+        self._config.timeout_secs = secs
+        return self
+
+    def no_timeout(self) -> CodexCliClient:
+        """Disable the invocation timeout (run until the child exits)."""
+        self._config.timeout_secs = None
+        return self
+
     def _subprocess_env(self) -> dict[str, str] | None:
         if not self._config.envs:
             return None
@@ -347,14 +358,18 @@ class CodexCliClient:
             stderr=asyncio.subprocess.PIPE,
             env=self._subprocess_env(),
         )
+        timeout = self._config.timeout_secs
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(prompt.encode()), timeout=_TIMEOUT_SECS
-            )
+            if timeout is None:
+                stdout, stderr = await proc.communicate(prompt.encode())
+            else:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(prompt.encode()), timeout=timeout
+                )
         except TimeoutError as exc:
             proc.kill()
             await proc.wait()
-            raise ProviderError(f"codex CLI timed out after {_TIMEOUT_SECS}s") from exc
+            raise ProviderError(f"codex CLI timed out after {timeout}s") from exc
 
         if proc.returncode != 0:
             raise ProviderError(
@@ -406,8 +421,17 @@ class CodexCliClient:
             with contextlib.suppress(BrokenPipeError, ConnectionResetError, AttributeError):
                 await proc.stdin.wait_closed()
 
+            timeout = self._config.timeout_secs
             while True:
-                raw = await proc.stdout.readline()
+                if timeout is None:
+                    raw = await proc.stdout.readline()
+                else:
+                    try:
+                        raw = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+                    except TimeoutError as exc:
+                        raise ProviderError(
+                            f"codex CLI stream read timed out after {timeout}s"
+                        ) from exc
                 if not raw:
                     break
                 line = raw.decode().rstrip("\n")

--- a/sdks/python/motosan_ai/providers/gemini_cli.py
+++ b/sdks/python/motosan_ai/providers/gemini_cli.py
@@ -20,7 +20,7 @@ from motosan_ai.types import (
     Usage,
 )
 
-_TIMEOUT_SECS = 600
+_DEFAULT_TIMEOUT_SECS = 600.0
 
 
 class ApprovalMode(StrEnum):
@@ -65,6 +65,7 @@ class _GeminiCliConfig:
     resume: str | None = None
     cwd: str | None = None
     envs: _RedactedEnvs = field(default_factory=_RedactedEnvs)
+    timeout_secs: float | None = _DEFAULT_TIMEOUT_SECS
 
 
 def _model_to_forward(model: str) -> str | None:
@@ -263,6 +264,16 @@ class GeminiCliClient:
         self._config.envs.replace_from(vars)
         return self
 
+    def timeout(self, seconds: float) -> GeminiCliClient:
+        """Override the per-invocation timeout (chat + per-read stream deadline)."""
+        self._config.timeout_secs = seconds
+        return self
+
+    def no_timeout(self) -> GeminiCliClient:
+        """Disable the invocation timeout (run until the child exits)."""
+        self._config.timeout_secs = None
+        return self
+
     def _child_env(self) -> dict[str, str] | None:
         if len(self._config.envs) == 0:
             return None
@@ -314,13 +325,17 @@ class GeminiCliClient:
             env=self._child_env(),
         )
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(stdin_payload.encode()), timeout=_TIMEOUT_SECS
-            )
+            if self._config.timeout_secs is None:
+                stdout, stderr = await proc.communicate(stdin_payload.encode())
+            else:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(stdin_payload.encode()),
+                    timeout=self._config.timeout_secs,
+                )
         except TimeoutError as exc:
             proc.kill()
             await proc.wait()
-            raise ProviderError(f"gemini CLI timed out after {_TIMEOUT_SECS}s") from exc
+            raise ProviderError(f"gemini CLI timed out after {self._config.timeout_secs}s") from exc
 
         if proc.returncode != 0:
             raise ProviderError(
@@ -373,8 +388,17 @@ class GeminiCliClient:
             with contextlib.suppress(BrokenPipeError, ConnectionResetError, AttributeError):
                 await proc.stdin.wait_closed()
 
+            timeout = self._config.timeout_secs
             while True:
-                raw = await proc.stdout.readline()
+                if timeout is None:
+                    raw = await proc.stdout.readline()
+                else:
+                    try:
+                        raw = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+                    except TimeoutError as exc:
+                        raise ProviderError(
+                            f"gemini CLI stream read timed out after {timeout}s"
+                        ) from exc
                 if not raw:
                     break
                 line = raw.decode().rstrip("\n")

--- a/sdks/python/tests/test_claude_code.py
+++ b/sdks/python/tests/test_claude_code.py
@@ -314,6 +314,15 @@ class TestClaudeCodeClientConstruction:
         assert "sk-secret" not in r
         assert "<1 redacted>" in r
 
+    def test_default_timeout_is_300(self):
+        assert ClaudeCodeClient()._config.timeout_secs == 300.0
+
+    def test_timeout_override(self):
+        assert ClaudeCodeClient().timeout(5)._config.timeout_secs == 5
+
+    def test_no_timeout_sets_none(self):
+        assert ClaudeCodeClient().no_timeout()._config.timeout_secs is None
+
 
 # ---------------------------------------------------------------------------
 # _build_args

--- a/sdks/python/tests/test_claude_code_runtime.py
+++ b/sdks/python/tests/test_claude_code_runtime.py
@@ -81,3 +81,19 @@ async def test_stream_tool_use_sets_terminal_stop_reason(monkeypatch):
     ]
     done = [e for e in events if e.done][-1]
     assert done.stop_reason == StopReason.tool_use
+
+
+@pytest.mark.asyncio
+async def test_chat_no_timeout_skips_wait_for(monkeypatch):
+    proc = _make_proc()
+    monkeypatch.setattr(
+        "motosan_ai.providers.claude_code.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=proc),
+    )
+
+    def _boom(*a, **k):
+        raise AssertionError("wait_for must not be called under no_timeout")
+
+    monkeypatch.setattr("motosan_ai.providers.claude_code.asyncio.wait_for", _boom)
+    client = ClaudeCodeClient().no_timeout()
+    await client.chat(ChatRequest(messages=[Message(role=Role.user, content="hi")]))

--- a/sdks/python/tests/test_codex_cli_flags.py
+++ b/sdks/python/tests/test_codex_cli_flags.py
@@ -232,3 +232,12 @@ def test_env_repr_redacts_secret():
 def test_env_not_in_argv():
     args = CodexCliClient(binary_path="codex").env("OPENAI_API_KEY", "sk-secret")._build_args()
     assert all("sk-secret" not in a for a in args)
+
+
+def test_default_timeout_is_600():
+    assert CodexCliClient(binary_path="codex")._config.timeout_secs == 600.0
+
+
+def test_timeout_override_and_no_timeout():
+    assert CodexCliClient(binary_path="codex").timeout(5)._config.timeout_secs == 5
+    assert CodexCliClient(binary_path="codex").no_timeout()._config.timeout_secs is None

--- a/sdks/python/tests/test_codex_cli_stream.py
+++ b/sdks/python/tests/test_codex_cli_stream.py
@@ -355,3 +355,26 @@ async def test_stream_tool_call_sets_tool_use_stop_reason(monkeypatch):
     ]
     done = [e for e in events if e.done][-1]
     assert done.stop_reason == StopReason.tool_use
+
+
+@pytest.mark.asyncio
+async def test_stream_read_stall_raises(monkeypatch):
+    class _StallStdout:
+        async def readline(self):
+            await asyncio.Event().wait()  # never returns
+            return b""
+
+    proc = AsyncMock()
+    proc.stdin = AsyncMock()
+    proc.stdin.write = lambda b: None
+    proc.stdin.close = lambda: None
+    proc.stdout = _StallStdout()
+    proc.returncode = None
+    proc.kill = lambda: None
+    proc.wait = AsyncMock(return_value=0)
+    monkeypatch.setattr(asyncio.subprocess, "PIPE", -1, raising=False)
+    monkeypatch.setattr("asyncio.create_subprocess_exec", AsyncMock(return_value=proc))
+    client = CodexCliClient(binary_path="codex").timeout(0.05)
+    with pytest.raises(ProviderError, match="timed out"):
+        async for _ in client.stream(ChatRequest(messages=[Message.user("hi")])):
+            pass

--- a/sdks/python/tests/test_gemini_cli_dispatch.py
+++ b/sdks/python/tests/test_gemini_cli_dispatch.py
@@ -53,3 +53,12 @@ def test_env_repr_redacts():
     client = GeminiCliClient().env("GEMINI_API_KEY", "sk-x")
     r = repr(client._config)
     assert "<1 redacted>" in r and "sk-x" not in r
+
+
+def test_default_timeout_is_600():
+    assert GeminiCliClient()._config.timeout_secs == 600.0
+
+
+def test_timeout_override_and_no_timeout():
+    assert GeminiCliClient().timeout(5)._config.timeout_secs == 5
+    assert GeminiCliClient().no_timeout()._config.timeout_secs is None

--- a/sdks/python/tests/test_gemini_cli_stream.py
+++ b/sdks/python/tests/test_gemini_cli_stream.py
@@ -354,3 +354,26 @@ async def test_stream_tool_call_terminal_is_tool_use(monkeypatch):
     ]
     done = [e for e in events if e.done][-1]
     assert done.stop_reason == StopReason.tool_use
+
+
+@pytest.mark.asyncio
+async def test_stream_stall_raises(monkeypatch):
+    class _StallStdout:
+        async def readline(self):
+            await asyncio.Event().wait()
+            return b""
+
+    proc = AsyncMock()
+    proc.stdin = AsyncMock()
+    proc.stdin.write = lambda b: None
+    proc.stdin.close = lambda: None
+    proc.stdout = _StallStdout()
+    proc.returncode = None
+    proc.kill = lambda: None
+    proc.wait = AsyncMock(return_value=0)
+    monkeypatch.setattr(asyncio.subprocess, "PIPE", -1, raising=False)
+    monkeypatch.setattr("asyncio.create_subprocess_exec", AsyncMock(return_value=proc))
+    client = GeminiCliClient(binary_path="gemini").timeout(0.05)
+    with pytest.raises(ProviderError, match="timed out"):
+        async for _ in client.stream(ChatRequest(messages=[Message.user("hi")])):
+            pass


### PR DESCRIPTION
**Milestone F6** (final feature milestone) of the Python SDK → Rust 0.20.0 parity effort (→ 0.13.0). Plan: `docs/superpowers/plans/2026-06-23-python-0.20-cli-runtime-alignment.md`.

## What changes
A configurable timeout on the 3 CLI providers (claude_code / codex_cli / gemini_cli):
- `.timeout(secs)` / `.no_timeout()` builders + a `timeout_secs: float | None` field. Defaults (float): **Claude 300.0, Codex 600.0, Gemini 600.0**.
- Applies to **both** chat() (`wait_for` around `communicate`) and the stream() per-read deadline (`wait_for` around `readline` — built on F5's while/readline loops). `.no_timeout()` (None) skips the wrapper.
- A per-read stall raises `ProviderError` with the standardized message `"<provider> CLI stream read timed out after {n}s"` (Rust's typed `StreamReadTimeout` intentionally collapsed to `ProviderError`).

## Verification
- `ruff check motosan_ai/` (CI scope) → clean; `ruff format --check .` → clean.
- `uv run pytest -q` → **621 passed, 30 skipped**; `-k "timeout or stall or no_timeout"` → 10 passed.
- Independent verify (incl. stall mutation check: bare readline hangs, wrapped raises) → **ship, zero issues**.

Scope: `sdks/python/` only (3 providers + 6 test files). No version bump (lands next in **F-release** → 0.13.0). Built on F1–F5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)