### PR TITLE
fix(retry): decide retryability before parsing chat response bodies

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -491,13 +491,12 @@ impl ProviderImpl for AnthropicProvider {
 
             let status = response.status();
             let retry_after = parse_retry_after(response.headers());
-            let current_payload: Value = response
-                .json()
-                .await
-                .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
 
             if status.is_success() {
-                payload = current_payload;
+                payload = response
+                    .json()
+                    .await
+                    .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
                 break;
             }
 
@@ -507,7 +506,8 @@ impl ProviderImpl for AnthropicProvider {
                 continue;
             }
 
-            let message = extract_error_message(&current_payload, "anthropic request failed");
+            let error_payload: Value = response.json().await.unwrap_or(json!({}));
+            let message = extract_error_message(&error_payload, "anthropic request failed");
             let message = Self::with_auth_hint(
                 status.as_u16(),
                 message,

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -265,24 +265,23 @@ impl ProviderImpl for OllamaProvider {
 
             let status = response.status();
             let retry_after = parse_retry_after(response.headers());
-            let current_payload: Value = response
+
+            if !status.is_success() {
+                if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
+                    attempt += 1;
+                    sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
+                    continue;
+                }
+                let error_payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
+                let message = extract_error_message(&error_payload, "ollama request failed");
+                return Err(map_http_error(status.as_u16(), message));
+            }
+
+            payload = response
                 .json()
                 .await
                 .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
-
-            if status.is_success() {
-                payload = current_payload;
-                break;
-            }
-
-            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
-                attempt += 1;
-                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                continue;
-            }
-
-            let message = extract_error_message(&current_payload, "ollama request failed");
-            return Err(map_http_error(status.as_u16(), message));
+            break;
         }
 
         let message = payload.get("message");

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -505,13 +505,11 @@ impl ProviderImpl for OpenAIProvider {
                 return self.chat_via_responses(&fallback_request).await;
             }
 
-            let current_payload: Value = response
-                .json()
-                .await
-                .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
-
             if status.is_success() {
-                payload = current_payload;
+                payload = response
+                    .json()
+                    .await
+                    .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
                 break;
             }
 
@@ -521,7 +519,8 @@ impl ProviderImpl for OpenAIProvider {
                 continue;
             }
 
-            let message = extract_error_message(&current_payload, "openai request failed");
+            let error_payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
+            let message = extract_error_message(&error_payload, "openai request failed");
             return Err(map_http_error(status.as_u16(), message));
         }
 

--- a/sdks/rust/tests/anthropic_chat.rs
+++ b/sdks/rust/tests/anthropic_chat.rs
@@ -3,7 +3,9 @@
 use mockito::Matcher;
 use motosan_ai::providers::anthropic::AnthropicProvider;
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, MotosanError, StopReason, DEFAULT_ANTHROPIC_MODEL};
+use motosan_ai::{
+    ChatRequest, Message, MotosanError, RetryPolicy, StopReason, DEFAULT_ANTHROPIC_MODEL,
+};
 use serde_json::json;
 
 #[tokio::test]
@@ -218,4 +220,52 @@ async fn chat_with_explicit_max_tokens_overrides_default() {
     let response = provider.chat(request).await.expect("chat response");
     assert_eq!(response.content, "ok");
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn anthropic_chat_retries_503_with_non_json_body() {
+    let mut server = mockito::Server::new_async().await;
+    // Canonical proxy/LB failure: retryable status with an HTML (non-JSON) body.
+    let unavailable = server
+        .mock("POST", "/v1/messages")
+        .with_status(503)
+        .with_body("<html>Service Unavailable</html>")
+        .expect(1)
+        .create_async()
+        .await;
+    let success = server
+        .mock("POST", "/v1/messages")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": DEFAULT_ANTHROPIC_MODEL,
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "recovered"}]
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    let provider =
+        AnthropicProvider::new("test-key", None, Some(server.url())).with_retry_policy(policy);
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider
+        .chat(request)
+        .await
+        .expect("503 with non-JSON body should be retried, not aborted with a parse error");
+
+    assert_eq!(response.content, "recovered");
+    unavailable.assert_async().await;
+    success.assert_async().await;
 }

--- a/sdks/rust/tests/ollama_native_provider.rs
+++ b/sdks/rust/tests/ollama_native_provider.rs
@@ -3,7 +3,9 @@
 use mockito::Matcher;
 use motosan_ai::providers::ollama::OllamaProvider;
 use motosan_ai::providers::ProviderImpl;
-use motosan_ai::{ChatRequest, Message, StopReason, StreamEventType, Tool, DEFAULT_OLLAMA_MODEL};
+use motosan_ai::{
+    ChatRequest, Message, RetryPolicy, StopReason, StreamEventType, Tool, DEFAULT_OLLAMA_MODEL,
+};
 use serde_json::json;
 use tokio_stream::StreamExt;
 
@@ -466,4 +468,55 @@ async fn ollama_native_stream_two_tool_calls_emits_6_events() {
     assert_eq!(ends[1].tool_call_id.as_ref().unwrap(), id1);
 
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn ollama_native_chat_retries_non_json_5xx_then_succeeds() {
+    let mut server = mockito::Server::new_async().await;
+    let error_mock = server
+        .mock("POST", "/api/chat")
+        .with_status(503)
+        .with_header("content-type", "text/plain")
+        .with_body("Service Unavailable")
+        .expect(1)
+        .create_async()
+        .await;
+    let success_mock = server
+        .mock("POST", "/api/chat")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": "recovered"},
+                "done": true,
+                "prompt_eval_count": 3,
+                "eval_count": 2
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    let provider = build_provider(server.url()).with_retry_policy(policy);
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider
+        .chat(request)
+        .await
+        .expect("should retry and succeed");
+
+    assert_eq!(response.content, "recovered");
+    assert!(matches!(response.stop_reason, StopReason::Stop));
+    // Exactly 2 requests total: one 503, one 200.
+    error_mock.assert_async().await;
+    success_mock.assert_async().await;
 }

--- a/sdks/rust/tests/openai_retry.rs
+++ b/sdks/rust/tests/openai_retry.rs
@@ -226,3 +226,51 @@ async fn openai_stream_retries_initial_call() {
     assert_eq!(first.content, "ok");
     assert!(second.done);
 }
+
+#[tokio::test]
+async fn openai_chat_retries_502_with_non_json_body() {
+    let mut server = mockito::Server::new_async().await;
+    let bad_gateway = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(502)
+        .with_body("bad gateway")
+        .expect(1)
+        .create_async()
+        .await;
+    let success = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{"message": {"content": "recovered"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    let provider = OpenAIProvider::new("test-key", None)
+        .with_chat_url(format!("{}/v1/chat/completions", server.url()))
+        .with_retry_policy(policy);
+
+    let response = provider
+        .chat(
+            ChatRequest::builder()
+                .message(Message::user("hello"))
+                .build(),
+        )
+        .await
+        .expect("should retry past non-JSON 502 body and succeed");
+
+    assert_eq!(response.content, "recovered");
+    bad_gateway.assert_async().await;
+    success.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- anthropic/openai/ollama `chat()` parsed the response body as JSON **before** the
  `is_retryable_status` check, so a 502/503/529 with an HTML or empty body (the canonical
  proxy/LB failure) aborted on attempt 1 with a misleading JSON-decode error instead of retrying.
- Restructured all three retry loops to the proven `gemini.rs` shape: status + Retry-After decide
  retryability first; the body is parsed only on success or (tolerantly) for the terminal error.
- Also covers `Provider::Minimax` (routes through `AnthropicProvider`). `stream()` paths were
  already correct and are untouched.
- New regression tests: non-JSON 5xx body → exactly 2 requests → success
  (`anthropic_chat.rs`, `openai_retry.rs`, `ollama_native_provider.rs`).

M1 plan Tasks 1–3 (PR-R1): docs/superpowers/plans/2026-07-14-stream-retry-m1-implementation.md
Audit context: docs/superpowers/plans/2026-07-14-stream-retry-milestones.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)