### PR TITLE
fix(ts): surface stream error frames and correlate codex call ids

### DIFF
--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -9,7 +9,7 @@ export * from './providers/minimax.js'
 export * from './providers/ollama.js'
 export * from './providers/gemini.js'
 // chatgpt_codex: exports ChatGptCodexProvider + DEFAULT_CHATGPT_CODEX_MODEL.
-// `chatGptCodexErrorMessage` is @internal (test-only) and NOT re-exported.
+// `chatGptCodexErrorMessage` is @internal and NOT re-exported.
 export { ChatGptCodexProvider, DEFAULT_CHATGPT_CODEX_URL } from './providers/chatgpt_codex.js'
 
 export { RetryPolicy } from './retry.js'

--- a/sdks/typescript/src/providers/anthropic.ts
+++ b/sdks/typescript/src/providers/anthropic.ts
@@ -2,6 +2,7 @@ import {
   isRetryableNetworkError,
   isRetryableStatus,
   ProviderError,
+  StreamError,
 } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { DEFAULT_ANTHROPIC_MODEL } from '../models.js'
@@ -375,6 +376,15 @@ export class AnthropicProvider {
             ? doneWithStopReason(state.stopReason)
             : doneEvent()
           return
+        }
+
+        case 'error': {
+          // Anthropic emits `event: error` frames mid-stream on an HTTP 200
+          // (e.g. overloaded_error). Surface them as a StreamError instead
+          // of swallowing them and fabricating a clean done at EOF.
+          const errType = String(data?.error?.type ?? 'error')
+          const errMessage = String(data?.error?.message ?? 'unknown')
+          throw new StreamError(`anthropic stream error (${errType}): ${errMessage}`)
         }
 
         default:

--- a/sdks/typescript/src/providers/chatgpt_codex.ts
+++ b/sdks/typescript/src/providers/chatgpt_codex.ts
@@ -249,6 +249,11 @@ export class ChatGptCodexProvider {
     // which also track a seen-ids set that is write-only — dropped here per plan R1).
     let sawToolCall = false
 
+    // Real wire: output_item.added carries BOTH item.id ("fc_…") and call_id
+    // ("call_…"), but function_call_arguments.delta frames are keyed by item_id
+    // only. Map item.id → call_id so every tool event carries the call_id.
+    const itemIdToCallId = new Map<string, string>()
+
     // Fatal `error` / `response.failed` frames throw a StreamError (Rust/
     // Python parity). Other post-start body errors still end silently (M3).
     try {
@@ -272,6 +277,7 @@ export class ChatGptCodexProvider {
             const item = data.item
             if (item && item.type === 'function_call' && item.call_id) {
               sawToolCall = true
+              if (item.id) itemIdToCallId.set(String(item.id), String(item.call_id))
               yield toolCallStart(String(item.call_id), String(item.name ?? ''))
             }
             break
@@ -280,7 +286,8 @@ export class ChatGptCodexProvider {
             const itemId = data.item_id
             const delta = data.delta
             if (itemId && typeof delta === 'string') {
-              yield toolCallArgsWithId(String(itemId), delta)
+              const callId = itemIdToCallId.get(String(itemId)) ?? String(itemId)
+              yield toolCallArgsWithId(callId, delta)
             }
             break
           }

--- a/sdks/typescript/src/providers/chatgpt_codex.ts
+++ b/sdks/typescript/src/providers/chatgpt_codex.ts
@@ -3,12 +3,12 @@
  * `https://chatgpt.com/backend-api/codex/responses` using a caller-supplied
  * OAuth `accessToken` + `accountId` (codex CLI headers; no api key). Mirrors the
  * verified Python `chatgpt_codex.py` (a port of authoritative Rust
- * `chatgpt_codex.rs`) in idiomatic TS, with one deliberate divergence: a
- * mid-stream `error` / `response.failed` frame terminates the stream SILENTLY
- * (TS convention — ollama.ts:362-366), instead of the Python mid-stream raise.
+ * `chatgpt_codex.rs`) in idiomatic TS: a mid-stream `error` / `response.failed`
+ * frame throws a `StreamError` (parity with Rust `MotosanError::Stream` and
+ * the Python mid-stream `StreamError` raise).
  */
 
-import { isRetryableNetworkError, isRetryableStatus } from '../error.js'
+import { StreamError, isRetryableNetworkError, isRetryableStatus } from '../error.js'
 import { postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_CHATGPT_CODEX_MODEL } from '../models.js'
@@ -38,9 +38,8 @@ export { DEFAULT_CHATGPT_CODEX_MODEL }
 /**
  * Extract the error message from an `error` / `response.failed` Responses frame.
  * First non-empty wins: top-level `message` → `response.error.message` →
- * `error.message` → fallback. Pure; used by tests only. The stream path silently
- * terminates without surfacing this (plan §C), so this is NOT re-exported from
- * `src/index.ts`.
+ * `error.message` → fallback. Used by the stream adapter to build the
+ * `StreamError` for fatal frames. NOT re-exported from `src/index.ts`.
  *
  * @internal
  */
@@ -250,8 +249,8 @@ export class ChatGptCodexProvider {
     // which also track a seen-ids set that is write-only — dropped here per plan R1).
     let sawToolCall = false
 
-    // Mid-stream body errors terminate the stream SILENTLY (TS convention;
-    // ollama.ts:362-366, providers-ollama.test.ts:377). NO mid-stream throw.
+    // Fatal `error` / `response.failed` frames throw a StreamError (Rust/
+    // Python parity). Other post-start body errors still end silently (M3).
     try {
       for await (const evt of parseSse(responseBody)) {
         const data = evt.data
@@ -316,16 +315,19 @@ export class ChatGptCodexProvider {
           }
           case 'error':
           case 'response.failed':
-            // Silent terminate (TS convention). The Python `raise StreamError`
-            // path is intentionally NOT ported. See plan §C.
-            return
+            // Fatal stream error frame: surface it (Rust MotosanError::Stream
+            // / Python StreamError parity).
+            throw new StreamError(chatGptCodexErrorMessage(data))
           default:
             break
         }
       }
-    } catch {
-      // Ignore post-start stream-body errors; end without a terminal done
-      // (mirrors ollama.ts:362-366).
+    } catch (error) {
+      if (error instanceof StreamError) {
+        throw error
+      }
+      // Ignore other post-start stream-body errors; end without a terminal
+      // done (mirrors ollama.ts:362-366). Surfacing these is milestone M3.
       return
     }
 

--- a/sdks/typescript/tests/providers-anthropic.test.ts
+++ b/sdks/typescript/tests/providers-anthropic.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { StreamError } from '../src/error.js'
 import { AnthropicProvider } from '../src/providers/anthropic.js'
 import type { ChatRequest, StreamEvent } from '../src/types.js'
 
@@ -451,6 +452,41 @@ describe('AnthropicProvider stream', () => {
     expect(events.filter((e) => e.eventType === 'text' && !e.done).map((e) => e.content)).toEqual([
       'hi',
     ])
+  })
+
+  it('rejects with a StreamError on a mid-stream error frame (deltas already emitted survive)', async () => {
+    const sse =
+      'event: message_start\n' +
+      'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":3,"output_tokens":0}}}\n\n' +
+      'event: content_block_start\n' +
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+      'event: content_block_delta\n' +
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n' +
+      'event: error\n' +
+      'data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n'
+
+    streamFromTranscript(sse)
+
+    const provider = new AnthropicProvider('key', 'claude-3-5-sonnet-20241022')
+    const events: StreamEvent[] = []
+    let error: unknown
+    try {
+      for await (const event of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+        events.push(event)
+      }
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).toBeInstanceOf(StreamError)
+    expect((error as Error).message).toContain('overloaded_error')
+    expect((error as Error).message).toContain('Overloaded')
+    // The text delta emitted before the error frame was still yielded,
+    // and NO fabricated done event followed the error.
+    expect(
+      events.filter((e) => e.eventType === 'text' && !e.done).map((e) => e.content),
+    ).toEqual(['partial'])
+    expect(events.some((e) => e.done)).toBe(false)
   })
 })
 

--- a/sdks/typescript/tests/providers-chatgpt-codex.test.ts
+++ b/sdks/typescript/tests/providers-chatgpt-codex.test.ts
@@ -290,28 +290,41 @@ describe('ChatGptCodexProvider SSE adapter', () => {
   })
 
   it('runs the function_call lifecycle and ends with tool_use', async () => {
+    // Distinct ids as on the real wire: item.id "fc_001" keys the argument
+    // deltas; call_id "call_001" keys start/end. Every tool event must carry
+    // the call_id.
     const sse =
-      'data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_42","name":"get_weather"}}\n\n' +
-      'data: {"type":"response.function_call_arguments.delta","item_id":"call_42","delta":"{\\"city\\":"}\n\n' +
-      'data: {"type":"response.function_call_arguments.delta","item_id":"call_42","delta":"\\"Paris\\"}"}\n\n' +
-      'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_42"}}\n\n' +
+      'data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_001","call_id":"call_001","name":"get_weather"}}\n\n' +
+      'data: {"type":"response.function_call_arguments.delta","item_id":"fc_001","delta":"{\\"city\\":"}\n\n' +
+      'data: {"type":"response.function_call_arguments.delta","item_id":"fc_001","delta":"\\"Paris\\"}"}\n\n' +
+      'data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_001","call_id":"call_001"}}\n\n' +
       'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
     const events = await collect(sse)
     const tool = events.filter((e) => e.eventType.startsWith('tool_call'))
     expect(tool[0]).toMatchObject({
       eventType: 'tool_call_start',
-      toolCallId: 'call_42',
+      toolCallId: 'call_001',
       toolCallName: 'get_weather',
     })
-    expect(tool[1]).toMatchObject({ eventType: 'tool_call_args', toolCallId: 'call_42' })
-    expect(tool[2]).toMatchObject({ eventType: 'tool_call_args', toolCallId: 'call_42' })
-    expect(tool[3]).toMatchObject({ eventType: 'tool_call_end', toolCallId: 'call_42' })
+    expect(tool[1]).toMatchObject({ eventType: 'tool_call_args', toolCallId: 'call_001' })
+    expect(tool[2]).toMatchObject({ eventType: 'tool_call_args', toolCallId: 'call_001' })
+    expect(tool[3]).toMatchObject({ eventType: 'tool_call_end', toolCallId: 'call_001' })
     const argText = tool
       .filter((e) => e.eventType === 'tool_call_args')
       .map((e) => e.toolCallArgsDelta)
       .join('')
     expect(argText).toBe('{"city":"Paris"}')
     expect(events[events.length - 1]).toMatchObject({ done: true, stopReason: 'tool_use' })
+  })
+
+  it('passes an unmapped item_id through on argument deltas (fallback)', async () => {
+    const sse =
+      'data: {"type":"response.function_call_arguments.delta","item_id":"fc_orphan","delta":"{}"}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+    const events = await collect(sse)
+    const args = events.filter((e) => e.eventType === 'tool_call_args')
+    expect(args).toHaveLength(1)
+    expect(args[0]).toMatchObject({ toolCallId: 'fc_orphan', toolCallArgsDelta: '{}' })
   })
 
   it('maps status:"incomplete" to max_tokens', async () => {
@@ -449,15 +462,15 @@ describe('ChatGptCodexProvider HTTP', () => {
 
   it('chat() yields a tool call from the lifecycle', async () => {
     streamFromTranscript(
-      'data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_9","name":"lookup"}}\n\n' +
-        'data: {"type":"response.function_call_arguments.delta","item_id":"call_9","delta":"{\\"q\\":\\"x\\"}"}\n\n' +
-        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_9"}}\n\n' +
+      'data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_001","call_id":"call_001","name":"lookup"}}\n\n' +
+        'data: {"type":"response.function_call_arguments.delta","item_id":"fc_001","delta":"{\\"q\\":\\"x\\"}"}\n\n' +
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_001","call_id":"call_001"}}\n\n' +
         'data: {"type":"response.completed","response":{"status":"completed"}}\n\n',
     )
     const resp = await new ChatGptCodexProvider('t', 'a').chat(REQ)
     expect(resp.stopReason).toBe('tool_use')
     expect(resp.toolCalls).toHaveLength(1)
-    expect(resp.toolCalls[0]).toMatchObject({ id: 'call_9', name: 'lookup', input: { q: 'x' } })
+    expect(resp.toolCalls[0]).toMatchObject({ id: 'call_001', name: 'lookup', input: { q: 'x' } })
   })
 
   function stubError(status: number): void {

--- a/sdks/typescript/tests/providers-chatgpt-codex.test.ts
+++ b/sdks/typescript/tests/providers-chatgpt-codex.test.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_CHATGPT_CODEX_MODEL,
   chatGptCodexErrorMessage,
 } from '../src/providers/chatgpt_codex.js'
-import { AuthError, NetworkError, ProviderError, RateLimitError } from '../src/error.js'
+import { AuthError, NetworkError, ProviderError, RateLimitError, StreamError } from '../src/error.js'
 import { RetryPolicy } from '../src/retry.js'
 import type { ChatRequest, StreamEvent } from '../src/types.js'
 
@@ -320,33 +320,39 @@ describe('ChatGptCodexProvider SSE adapter', () => {
     expect(events[events.length - 1]).toMatchObject({ done: true, stopReason: 'max_tokens' })
   })
 
-  it('terminates silently (no throw) on a top-level error frame', async () => {
+  it('rejects with a StreamError on a top-level error frame (partial text still emitted)', async () => {
     streamFromTranscript(
       'data: {"type":"response.output_text.delta","delta":"partial"}\n\n' +
         'data: {"type":"error","message":"rate limited"}\n\n',
     )
     const prov = new ChatGptCodexProvider('tok', 'acct')
     const events: StreamEvent[] = []
-    await expect(
-      (async () => {
-        for await (const e of prov.stream(REQ)) events.push(e)
-      })(),
-    ).resolves.toBeUndefined()
-    // the partial text was yielded; NO terminal done; NO throw
+    let error: unknown
+    try {
+      for await (const e of prov.stream(REQ)) events.push(e)
+    } catch (e) {
+      error = e
+    }
+    expect(error).toBeInstanceOf(StreamError)
+    expect((error as Error).message).toBe('rate limited')
+    // the partial text was yielded before the throw; NO terminal done
     expect(events).toEqual([{ content: 'partial', done: false, eventType: 'text' }])
   })
 
-  it('terminates silently on a response.failed frame', async () => {
+  it('rejects with the helper-formatted message on a response.failed frame', async () => {
     streamFromTranscript(
       'data: {"type":"response.failed","response":{"error":{"message":"boom"}}}\n\n',
     )
     const prov = new ChatGptCodexProvider('tok', 'acct')
     const events: StreamEvent[] = []
-    await expect(
-      (async () => {
-        for await (const e of prov.stream(REQ)) events.push(e)
-      })(),
-    ).resolves.toBeUndefined()
+    let error: unknown
+    try {
+      for await (const e of prov.stream(REQ)) events.push(e)
+    } catch (e) {
+      error = e
+    }
+    expect(error).toBeInstanceOf(StreamError)
+    expect((error as Error).message).toBe('boom')
     expect(events).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
- Anthropic stream: mid-stream `error` frames (e.g. `overloaded_error` on HTTP 200) now reject
  with `StreamError` instead of being ignored — truncated streams no longer read as clean
  successes. EOF behavior is deliberately unchanged (M3 scope).
- chatgpt_codex: `error` / `response.failed` frames now throw (via the previously-unused
  `chatGptCodexErrorMessage` helper) instead of silently ending the stream — brings TS to parity
  with Rust/Python; the two tests that pinned the silent behavior are flipped.
- chatgpt_codex: argument deltas keyed by wire `item_id` (`fc_…`) are now translated to the
  call's `call_id` (`call_…`) via an item→call map, so streamed tool calls assemble their
  arguments on the real wire; fixtures updated to distinct ids (identical-id fixtures were
  masking the bug).
- Out of scope (deliberate): EOF-without-terminal-event contract (M3), SSE parser hygiene (PR-T2).

M1 plan Tasks 11, 12, 17 (PR-T1): docs/superpowers/plans/2026-07-14-stream-retry-m1-implementation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)