### PR TITLE
fix(python): make 5xx retryable and surface swallowed stream errors

### DIFF
--- a/sdks/python/motosan_ai/providers/anthropic.py
+++ b/sdks/python/motosan_ai/providers/anthropic.py
@@ -418,6 +418,12 @@ class AnthropicProvider(BaseProvider):
 
                 event_type = payload.get("type")
 
+                if event_type == "error":
+                    error = payload.get("error") or {}
+                    error_type = error.get("type") or "unknown_error"
+                    error_message = error.get("message") or ""
+                    raise StreamError(f"anthropic stream error: {error_type}: {error_message}")
+
                 if event_type == "message_start":
                     usage = (payload.get("message") or {}).get("usage")
                     if usage:

--- a/sdks/python/motosan_ai/providers/chatgpt_codex.py
+++ b/sdks/python/motosan_ai/providers/chatgpt_codex.py
@@ -340,7 +340,11 @@ class ChatGptCodexProvider(BaseProvider):
         try:
             if not resp.is_success:
                 error_body = await resp.aread()
-                raise self._map_http_error(resp.status_code, error_body.decode())
+                message = f"HTTP {resp.status_code}: {error_body.decode()}"
+                retry_after = resp.headers.get("retry-after")
+                if retry_after:
+                    message = f"Retry-After: {retry_after}\n{message}"
+                raise self._map_http_error(resp.status_code, message)
 
             state = _ChatGptCodexAdapterState()
             try:

--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -7,7 +7,7 @@ import os
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 
-from motosan_ai.error import ProviderError
+from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.types import (
     ChatRequest,
@@ -95,12 +95,37 @@ def _messages_to_prompt(messages: list[Message]) -> tuple[str | None, str]:
     return system, prompt
 
 
+def _raise_on_error_result(event: dict) -> None:
+    """Raise ``StreamError`` when a terminal ``result`` payload reports an error.
+
+    Claude Code marks failed/truncated turns with ``is_error: true`` and an
+    ``error_*`` subtype (e.g. ``error_max_turns``, ``error_during_execution``).
+    Emitting them as clean completions would let agent loops consume a
+    truncated turn as a genuine one, so surface them as ``StreamError``.
+    """
+    subtype = event.get("subtype")
+    has_error_subtype = isinstance(subtype, str) and subtype.startswith("error")
+    if not (event.get("is_error") or has_error_subtype):
+        return
+    result_text = event.get("result")
+    parts = [p for p in (subtype, result_text) if isinstance(p, str) and p]
+    detail = ": ".join(parts) if parts else "unknown error"
+    raise StreamError(f"claude CLI reported an error result: {detail}")
+
+
 def _parse_agent_json(raw: str) -> tuple[str, Usage, str | None]:
-    """Parse JSON output from agent mode: ``result``, ``usage``, ``session_id``."""
+    """Parse JSON output from agent mode: ``result``, ``usage``, ``session_id``.
+
+    Raises :class:`~motosan_ai.error.StreamError` when the payload reports an
+    error result (``is_error: true`` or an ``error_*`` subtype).
+    """
     try:
         v = json.loads(raw)
     except json.JSONDecodeError as e:
         raise ProviderError(f"failed to parse claude JSON output: {e}") from e
+
+    if isinstance(v, dict):
+        _raise_on_error_result(v)
 
     text = v.get("result", "")
     u = v.get("usage", {})
@@ -186,6 +211,7 @@ def _parse_ndjson_line(line: str) -> list[StreamEvent]:
         return events
 
     if event_type == "result":
+        _raise_on_error_result(event)
         events_out: list[StreamEvent] = []
         sid = event.get("session_id")
         if isinstance(sid, str) and sid:

--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -629,6 +629,7 @@ class ClaudeCodeClient:
         assert proc.stdout is not None
         timeout = self._config.timeout_secs
         saw_tool_call = False
+        saw_done = False
         try:
             while True:
                 if timeout is None:
@@ -641,7 +642,23 @@ class ClaudeCodeClient:
                             f"claude CLI stream read timed out after {timeout}s"
                         ) from exc
                 if not raw_line:
-                    break
+                    if saw_done:
+                        break
+                    # EOF before the terminal event: the child crashed or
+                    # closed stdout early — raise instead of truncating.
+                    returncode = proc.returncode
+                    if returncode is None:
+                        with contextlib.suppress(TimeoutError):
+                            returncode = await asyncio.wait_for(proc.wait(), timeout=5.0)
+                    stderr_excerpt = ""
+                    if proc.stderr is not None:
+                        with contextlib.suppress(TimeoutError, OSError):
+                            stderr_bytes = await asyncio.wait_for(proc.stderr.read(), timeout=5.0)
+                            stderr_excerpt = stderr_bytes.decode(errors="replace").strip()[-2048:]
+                    raise StreamError(
+                        f"claude CLI exited unexpectedly "
+                        f"(returncode {returncode}): {stderr_excerpt}"
+                    )
                 line = raw_line.decode().strip()
                 if not line:
                     continue
@@ -653,6 +670,7 @@ class ClaudeCodeClient:
                     ):
                         saw_tool_call = True
                     if event.done:
+                        saw_done = True
                         event.stop_reason = (
                             StopReason.tool_use if saw_tool_call else StopReason.end_turn
                         )

--- a/sdks/python/motosan_ai/providers/codex_cli.py
+++ b/sdks/python/motosan_ai/providers/codex_cli.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from enum import StrEnum
 
-from motosan_ai.error import ProviderError
+from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.types import (
     ChatRequest,
@@ -412,6 +412,7 @@ class CodexCliClient:
         )
 
         saw_tool_call = False
+        saw_done = False
         try:
             assert proc.stdin is not None and proc.stdout is not None
             proc.stdin.write(prompt.encode())
@@ -433,7 +434,22 @@ class CodexCliClient:
                             f"codex CLI stream read timed out after {timeout}s"
                         ) from exc
                 if not raw:
-                    break
+                    if saw_done:
+                        break
+                    # EOF before the terminal event: the child crashed or
+                    # closed stdout early — raise instead of truncating.
+                    returncode = proc.returncode
+                    if returncode is None:
+                        with contextlib.suppress(TimeoutError):
+                            returncode = await asyncio.wait_for(proc.wait(), timeout=5.0)
+                    stderr_excerpt = ""
+                    if proc.stderr is not None:
+                        with contextlib.suppress(TimeoutError, OSError):
+                            stderr_bytes = await asyncio.wait_for(proc.stderr.read(), timeout=5.0)
+                            stderr_excerpt = stderr_bytes.decode(errors="replace").strip()[-2048:]
+                    raise StreamError(
+                        f"codex CLI exited unexpectedly (returncode {returncode}): {stderr_excerpt}"
+                    )
                 line = raw.decode().rstrip("\n")
                 for event in _parse_jsonl_line(line):
                     if event.event_type in (
@@ -442,6 +458,8 @@ class CodexCliClient:
                         "tool_call_end",
                     ):
                         saw_tool_call = True
+                    if event.done:
+                        saw_done = True
                     if event.done and saw_tool_call:
                         event.stop_reason = StopReason.tool_use
                     yield event

--- a/sdks/python/motosan_ai/providers/gemini_cli.py
+++ b/sdks/python/motosan_ai/providers/gemini_cli.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from enum import StrEnum
 
-from motosan_ai.error import ProviderError
+from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.types import (
     ChatRequest,
@@ -379,6 +379,7 @@ class GeminiCliClient:
             env=self._child_env(),
         )
         saw_tool_call = False
+        saw_done = False
         try:
             assert proc.stdin is not None and proc.stdout is not None
             proc.stdin.write(stdin_payload.encode())
@@ -400,12 +401,29 @@ class GeminiCliClient:
                             f"gemini CLI stream read timed out after {timeout}s"
                         ) from exc
                 if not raw:
-                    break
+                    if saw_done:
+                        break
+                    # EOF before the terminal event: the child crashed or
+                    # closed stdout early — raise instead of truncating.
+                    returncode = proc.returncode
+                    if returncode is None:
+                        with contextlib.suppress(TimeoutError):
+                            returncode = await asyncio.wait_for(proc.wait(), timeout=5.0)
+                    stderr_excerpt = ""
+                    if proc.stderr is not None:
+                        with contextlib.suppress(TimeoutError, OSError):
+                            stderr_bytes = await asyncio.wait_for(proc.stderr.read(), timeout=5.0)
+                            stderr_excerpt = stderr_bytes.decode(errors="replace").strip()[-2048:]
+                    raise StreamError(
+                        f"gemini CLI exited unexpectedly "
+                        f"(returncode {returncode}): {stderr_excerpt}"
+                    )
                 line = raw.decode().rstrip("\n")
                 for event in _parse_jsonl_line(line):
                     if event.event_type == "tool_call_start":
                         saw_tool_call = True
                     if event.done:
+                        saw_done = True
                         event.stop_reason = (
                             StopReason.tool_use if saw_tool_call else StopReason.end_turn
                         )

--- a/sdks/python/motosan_ai/providers/minimax.py
+++ b/sdks/python/motosan_ai/providers/minimax.py
@@ -140,14 +140,21 @@ class MinimaxProvider:
         except Exception as exc:
             raise NetworkError(str(exc)) from exc
 
-        payload = response.json() if response.content else {}
         if response.status_code >= 400:
-            message = (
-                (payload.get("error") or {}).get("message")
-                or response.text
-                or "minimax request failed"
-            )
+            try:
+                error_payload = response.json() if response.content else {}
+                detail = str((error_payload.get("error") or {}).get("message") or "")
+            except (json.JSONDecodeError, TypeError, AttributeError):
+                detail = ""
+            if not detail:
+                detail = response.text or "minimax request failed"
+            message = f"HTTP {response.status_code}: {detail}"
+            retry_after = response.headers.get("retry-after")
+            if retry_after:
+                message = f"Retry-After: {retry_after}\n{message}"
             self._raise_for_status(response.status_code, message)
+
+        payload = response.json() if response.content else {}
 
         choice = (payload.get("choices") or [{}])[0]
         message_obj = choice.get("message") or {}
@@ -214,7 +221,11 @@ class MinimaxProvider:
             ) as response:
                 if response.status_code >= 400:
                     text = await response.aread()
-                    message = text.decode("utf-8", errors="ignore") or "minimax stream failed"
+                    detail = text.decode("utf-8", errors="ignore") or "minimax stream failed"
+                    message = f"HTTP {response.status_code}: {detail}"
+                    retry_after = response.headers.get("retry-after")
+                    if retry_after:
+                        message = f"Retry-After: {retry_after}\n{message}"
                     self._raise_for_status(response.status_code, message)
 
                 async for line in response.aiter_lines():

--- a/sdks/python/motosan_ai/providers/openai.py
+++ b/sdks/python/motosan_ai/providers/openai.py
@@ -155,6 +155,14 @@ class OpenAIProvider:
             return RateLimitError(message)
         return ProviderError(message)
 
+    @staticmethod
+    def _response_error_message(status: int, headers: httpx.Headers, text: str) -> str:
+        message = f"HTTP {status}: {text}"
+        retry_after = headers.get("retry-after")
+        if retry_after:
+            message = f"Retry-After: {retry_after}\n{message}"
+        return message
+
     async def chat(self, request: ChatRequest) -> ChatResponse:
         body = self._build_body(request)
         try:
@@ -163,7 +171,8 @@ class OpenAIProvider:
             raise NetworkError(str(exc)) from exc
 
         if not resp.is_success:
-            raise self._map_http_error(resp.status_code, resp.text)
+            message = self._response_error_message(resp.status_code, resp.headers, resp.text)
+            raise self._map_http_error(resp.status_code, message)
 
         payload = resp.json()
         choice = (payload.get("choices") or [{}])[0]
@@ -212,7 +221,10 @@ class OpenAIProvider:
         try:
             if not resp.is_success:
                 error_body = await resp.aread()
-                raise self._map_http_error(resp.status_code, error_body.decode())
+                message = self._response_error_message(
+                    resp.status_code, resp.headers, error_body.decode()
+                )
+                raise self._map_http_error(resp.status_code, message)
 
             async for line in resp.aiter_lines():
                 if not line.startswith("data: "):

--- a/sdks/python/tests/test_anthropic_stream_usage.py
+++ b/sdks/python/tests/test_anthropic_stream_usage.py
@@ -124,3 +124,34 @@ async def test_stream_raises_on_malformed_chunk(provider):
         async for ev in provider.stream(ChatRequest(messages=[Message.user("hi")])):
             seen.append(ev)
     assert any(e.content == "hi" for e in seen)  # the good delta was yielded first
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_raises_on_error_event(provider):
+    # message_start + one good text delta, then a mid-stream error frame on HTTP 200
+    sse = _sse(
+        {"type": "message_start", "message": {"usage": {"input_tokens": 3, "output_tokens": 0}}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "par"}},
+        {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}},
+    )
+    respx.post("https://mock.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, text=sse, headers={"content-type": "text/event-stream"})
+    )
+    seen = []
+    with pytest.raises(StreamError, match="anthropic stream error: overloaded_error: Overloaded"):
+        async for ev in provider.stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(ev)
+    assert any(e.content == "par" for e in seen)  # text before the error was still yielded
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_error_event_with_missing_fields(provider):
+    sse = _sse({"type": "error"})
+    respx.post("https://mock.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, text=sse, headers={"content-type": "text/event-stream"})
+    )
+    with pytest.raises(StreamError, match="anthropic stream error: unknown_error"):
+        async for _ in provider.stream(ChatRequest(messages=[Message.user("hi")])):
+            pass

--- a/sdks/python/tests/test_chatgpt_codex_http.py
+++ b/sdks/python/tests/test_chatgpt_codex_http.py
@@ -186,3 +186,39 @@ async def test_stream_transport_error_raises_network_error():
     with pytest.raises(NetworkError):
         async for _ in p.stream(ChatRequest(messages=[Message.user("hi")])):
             pass
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_chat_502_then_200_is_retried():
+    from motosan_ai.retry import with_retry
+
+    route = respx.post(_URL).mock(
+        side_effect=[
+            httpx.Response(502, text="<html>bad gateway</html>"),
+            httpx.Response(200, text=_text_stream(), headers={"content-type": "text/event-stream"}),
+        ]
+    )
+    p = ChatGptCodexProvider("tok", "acct-123", "gpt-5.5", None)
+    resp = await with_retry(
+        lambda: p.chat(ChatRequest(messages=[Message.user("hi")])),
+        max_retries=2,
+        initial_backoff=0.001,
+    )
+    assert resp.content == "Hello world."
+    assert route.call_count == 2
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_5xx_message_has_status_and_retry_after():
+    respx.post(_URL).mock(
+        return_value=httpx.Response(503, text="overloaded", headers={"retry-after": "7"})
+    )
+    p = ChatGptCodexProvider("tok", "acct-123", "gpt-5.5", None)
+    with pytest.raises(ProviderError) as exc_info:
+        async for _ in p.stream(ChatRequest(messages=[Message.user("hi")])):
+            pass
+    msg = str(exc_info.value)
+    assert "HTTP 503: overloaded" in msg
+    assert "Retry-After: 7" in msg

--- a/sdks/python/tests/test_claude_code.py
+++ b/sdks/python/tests/test_claude_code.py
@@ -117,6 +117,13 @@ class TestParseAgentJson:
         text, usage, sid = _parse_agent_json('{"result":"hi"}')
         assert sid is None
 
+    def test_error_result_raises_stream_error(self):
+        from motosan_ai.error import StreamError
+
+        raw = json.dumps({"type": "result", "subtype": "error_max_turns", "is_error": True})
+        with pytest.raises(StreamError, match="error_max_turns"):
+            _parse_agent_json(raw)
+
 
 # ---------------------------------------------------------------------------
 # parse_ndjson_line
@@ -192,6 +199,20 @@ class TestParseNdjsonLine:
         events = _parse_ndjson_line('{"type":"result","subtype":"success","result":"done"}')
         assert len(events) == 1
         assert events[0].done
+
+    def test_result_is_error_raises_stream_error(self):
+        from motosan_ai.error import StreamError
+
+        line = '{"type":"result","subtype":"error_max_turns","is_error":true}'
+        with pytest.raises(StreamError, match="error_max_turns"):
+            _parse_ndjson_line(line)
+
+    def test_result_error_subtype_without_is_error_flag_raises(self):
+        from motosan_ai.error import StreamError
+
+        line = '{"type":"result","subtype":"error_during_execution","result":"boom"}'
+        with pytest.raises(StreamError, match="error_during_execution: boom"):
+            _parse_ndjson_line(line)
 
     def test_unknown_type_ignored(self):
         assert _parse_ndjson_line('{"type":"system","subtype":"init"}') == []

--- a/sdks/python/tests/test_claude_code_runtime.py
+++ b/sdks/python/tests/test_claude_code_runtime.py
@@ -85,6 +85,31 @@ async def test_stream_tool_use_sets_terminal_stop_reason(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_stream_child_death_raises_stream_error(monkeypatch):
+    # One valid assistant event, then EOF with exit code 1 and stderr "boom".
+    stdout = b'{"type":"assistant","message":{"content":[{"type":"text","text":"par"}]}}\n'
+    proc = _make_proc(stdout=stdout)
+    proc.returncode = 1
+    proc.wait = AsyncMock(return_value=1)
+    proc.stderr = AsyncMock()
+    proc.stderr.read = AsyncMock(return_value=b"boom\n")
+    monkeypatch.setattr(
+        "motosan_ai.providers.claude_code.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=proc),
+    )
+    events = []
+    with pytest.raises(StreamError, match="returncode 1") as excinfo:
+        async for ev in ClaudeCodeClient().stream(
+            ChatRequest(messages=[Message(role=Role.user, content="hi")])
+        ):
+            events.append(ev)
+
+    assert "boom" in str(excinfo.value)
+    assert [e.content for e in events] == ["par"]
+    assert not any(e.done for e in events)
+
+
+@pytest.mark.asyncio
 async def test_chat_no_timeout_skips_wait_for(monkeypatch):
     proc = _make_proc()
     monkeypatch.setattr(

--- a/sdks/python/tests/test_claude_code_runtime.py
+++ b/sdks/python/tests/test_claude_code_runtime.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from motosan_ai.error import StreamError
 from motosan_ai.providers.claude_code import ClaudeCodeClient
 from motosan_ai.types import ChatRequest, Message, Role, StopReason
 
@@ -97,3 +98,40 @@ async def test_chat_no_timeout_skips_wait_for(monkeypatch):
     monkeypatch.setattr("motosan_ai.providers.claude_code.asyncio.wait_for", _boom)
     client = ClaudeCodeClient().no_timeout()
     await client.chat(ChatRequest(messages=[Message(role=Role.user, content="hi")]))
+
+
+@pytest.mark.asyncio
+async def test_stream_error_result_raises_stream_error(monkeypatch):
+    stdout = (
+        b'{"type":"assistant","message":{"content":[{"type":"text","text":"partial"}]}}\n'
+        b'{"type":"result","subtype":"error_max_turns","is_error":true}\n'
+    )
+    proc = _make_proc(stdout=stdout)
+    monkeypatch.setattr(
+        "motosan_ai.providers.claude_code.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=proc),
+    )
+    events = []
+    with pytest.raises(StreamError, match="error_max_turns"):
+        async for ev in ClaudeCodeClient().stream(
+            ChatRequest(messages=[Message(role=Role.user, content="hi")])
+        ):
+            events.append(ev)
+    # partial text already yielded is kept; no fabricated clean done event
+    assert [e.content for e in events] == ["partial"]
+    assert not any(e.done for e in events)
+
+
+@pytest.mark.asyncio
+async def test_chat_agent_mode_error_result_raises_stream_error(monkeypatch):
+    stdout = (
+        b'{"type":"result","subtype":"error_during_execution","is_error":true,"result":"boom"}\n'
+    )
+    proc = _make_proc(stdout=stdout)
+    monkeypatch.setattr(
+        "motosan_ai.providers.claude_code.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=proc),
+    )
+    client = ClaudeCodeClient().agent_mode(True)
+    with pytest.raises(StreamError, match="error_during_execution"):
+        await client.chat(ChatRequest(messages=[Message(role=Role.user, content="hi")]))

--- a/sdks/python/tests/test_codex_cli_stream.py
+++ b/sdks/python/tests/test_codex_cli_stream.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from motosan_ai.error import ProviderError
+from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.providers.codex_cli import (
     CodexCliClient,
     _compose_prompt,
@@ -185,6 +185,14 @@ class _FakeStdout:
             raise StopAsyncIteration from exc
 
 
+class _FakeStderr:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
 class _FakeProc:
     def __init__(self, stdout: str, returncode: int | None = 0, stderr: str = "") -> None:
         self._stdout_bytes = stdout.encode()
@@ -192,6 +200,7 @@ class _FakeProc:
         self.returncode = returncode
         self.stdin = _FakeStdin()
         self.stdout = _FakeStdout(stdout)
+        self.stderr = _FakeStderr(self._stderr)
         self.killed = False
 
     async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
@@ -355,6 +364,23 @@ async def test_stream_tool_call_sets_tool_use_stop_reason(monkeypatch):
     ]
     done = [e for e in events if e.done][-1]
     assert done.stop_reason == StopReason.tool_use
+
+
+@pytest.mark.asyncio
+async def test_stream_child_death_raises_stream_error(monkeypatch):
+    # One valid event, then EOF with exit code 1: the child crashed mid-turn.
+    jsonl = '{"type": "item.completed", "item": {"type": "agent_message", "text": "par"}}\n'
+    _stub_subprocess(monkeypatch, _FakeProc(jsonl, returncode=1, stderr="boom\n"))
+
+    client = CodexCliClient(binary_path="codex")
+    events = []
+    with pytest.raises(StreamError, match="returncode 1") as excinfo:
+        async for event in client.stream(ChatRequest(messages=[Message.user("hi")])):
+            events.append(event)
+
+    assert "boom" in str(excinfo.value)
+    assert [e.content for e in events] == ["par"]
+    assert not any(e.done for e in events)
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_gemini_cli_stream.py
+++ b/sdks/python/tests/test_gemini_cli_stream.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from motosan_ai.error import ProviderError
+from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.providers.gemini_cli import (
     GeminiCliClient,
     _merge_system_into_prompt,
@@ -185,6 +185,14 @@ class _FakeStdout:
             raise StopAsyncIteration from exc
 
 
+class _FakeStderr:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
 class _FakeProc:
     def __init__(self, stdout: str, returncode: int | None = 0, stderr: str = "") -> None:
         self._stdout_bytes = stdout.encode()
@@ -192,6 +200,7 @@ class _FakeProc:
         self.returncode = returncode
         self.stdin = _FakeStdin()
         self.stdout = _FakeStdout(stdout)
+        self.stderr = _FakeStderr(self._stderr)
         self.killed = False
 
     async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
@@ -354,6 +363,23 @@ async def test_stream_tool_call_terminal_is_tool_use(monkeypatch):
     ]
     done = [e for e in events if e.done][-1]
     assert done.stop_reason == StopReason.tool_use
+
+
+@pytest.mark.asyncio
+async def test_stream_child_death_raises_stream_error(monkeypatch):
+    # One valid event, then EOF with exit code 1: the child crashed mid-turn.
+    jsonl = '{"type": "message", "role": "assistant", "content": "par", "delta": true}\n'
+    _stub_subprocess(monkeypatch, _FakeProc(jsonl, returncode=1, stderr="boom\n"))
+
+    client = GeminiCliClient(binary_path="gemini")
+    events = []
+    with pytest.raises(StreamError, match="returncode 1") as excinfo:
+        async for event in client.stream(ChatRequest(messages=[Message.user("hi")])):
+            events.append(event)
+
+    assert "boom" in str(excinfo.value)
+    assert [e.content for e in events] == ["par"]
+    assert not any(e.done for e in events)
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_minimax.py
+++ b/sdks/python/tests/test_minimax.py
@@ -76,3 +76,47 @@ async def test_stream_raises_stream_error_not_network_error():
         async for ev in provider.stream(ChatRequest(messages=[Message.user("hi")])):
             seen.append(ev)
     assert any(e.content == "hi" for e in seen)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_minimax_502_then_200_is_retried():
+    from motosan_ai.retry import with_retry
+
+    route = respx.post("https://api.minimax.chat/v1/text/chatcompletion_v2").mock(
+        side_effect=[
+            Response(502, text="<html>bad gateway</html>"),
+            Response(
+                200,
+                json={
+                    "model": "MiniMax-Text-01",
+                    "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                },
+            ),
+        ]
+    )
+    provider = MinimaxProvider("test-key")
+    resp = await with_retry(
+        lambda: provider.chat(ChatRequest(messages=[Message.user("hi")])),
+        max_retries=2,
+        initial_backoff=0.001,
+    )
+    assert resp.content == "ok"
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_minimax_5xx_message_has_status_and_retry_after():
+    from motosan_ai.error import ProviderError
+
+    respx.post("https://api.minimax.chat/v1/text/chatcompletion_v2").mock(
+        return_value=Response(503, text="overloaded", headers={"retry-after": "7"})
+    )
+    provider = MinimaxProvider("test-key")
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.chat(ChatRequest(messages=[Message.user("hi")]))
+    msg = str(exc_info.value)
+    assert "HTTP 503: overloaded" in msg
+    assert "Retry-After: 7" in msg

--- a/sdks/python/tests/test_openai.py
+++ b/sdks/python/tests/test_openai.py
@@ -219,3 +219,46 @@ async def test_stream_raises_on_malformed_chunk(provider):
         async for ev in provider.stream(ChatRequest(messages=[Message.user("hi")])):
             seen.append(ev)
     assert any(e.content == "hi" for e in seen)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_openai_502_then_200_is_retried(provider):
+    from motosan_ai.retry import with_retry
+
+    route = respx.post("https://mock.openai.com/v1/chat/completions").mock(
+        side_effect=[
+            httpx.Response(502, text="<html>bad gateway</html>"),
+            httpx.Response(
+                200,
+                json={
+                    "model": "gpt-4o",
+                    "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                },
+            ),
+        ]
+    )
+
+    resp = await with_retry(
+        lambda: provider.chat(ChatRequest(messages=[Message.user("hi")])),
+        max_retries=2,
+        initial_backoff=0.001,
+    )
+    assert resp.content == "ok"
+    assert route.call_count == 2
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_openai_5xx_message_has_status_and_retry_after(provider):
+    from motosan_ai.error import ProviderError
+
+    respx.post("https://mock.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(503, text="overloaded", headers={"retry-after": "7"})
+    )
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.chat(ChatRequest(messages=[Message.user("hi")]))
+    msg = str(exc_info.value)
+    assert "HTTP 503: overloaded" in msg
+    assert "Retry-After: 7" in msg

--- a/sdks/python/tests/test_retry.py
+++ b/sdks/python/tests/test_retry.py
@@ -200,3 +200,16 @@ class TestWithRetry:
         result = await with_retry(fn, max_retries=3, initial_backoff=0.001)
         assert result == "ok"
         assert calls == 3
+
+
+class TestProviderErrorHttpMessageFormat:
+    """Pins the message format providers must emit for retry classification."""
+
+    def test_http_prefixed_502_is_retryable(self):
+        assert _is_retryable(ProviderError("HTTP 502: <html>bad gateway</html>")) is True
+
+    def test_retry_after_prefixed_message_is_retryable(self):
+        assert _is_retryable(ProviderError("Retry-After: 3\nHTTP 503: overloaded")) is True
+
+    def test_retry_after_prefix_is_parsed(self):
+        assert _parse_retry_after("Retry-After: 3\nHTTP 503: overloaded") == 3.0


### PR DESCRIPTION
## Summary
- openai / minimax / chatgpt_codex now embed `HTTP {status}` + `Retry-After` in raised
  `ProviderError`s (anthropic.py's format), so `retry.py` actually retries their genuine 5xx —
  previously these providers were NEVER retried; codex also stops dropping the Retry-After header.
  MiniMax additionally checks status before parsing the body (non-JSON 5xx no longer crashes).
- Anthropic stream: mid-stream `error` frames (e.g. `overloaded_error` on HTTP 200) raise
  `StreamError` instead of falling through silently.
- claude_code: `is_error: true` terminal results raise in BOTH stream and blocking paths
  (closes a Python-only gap — Rust already errored).
- codex_cli / gemini_cli / claude_code streams: child death / EOF-without-terminal-event raises
  `StreamError` with returncode + stderr instead of ending as a clean truncated stream.
- Regression tests: respx non-JSON 5xx retry per provider; mid-stream error fixture; fake-CLI
  children dying mid-stream per backend.
- Out of scope (deliberate): structured error fields (M2), read-timeout knobs (M3).

M1 plan Tasks 4, 8–10 (PR-P1): docs/superpowers/plans/2026-07-14-stream-retry-m1-implementation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
