### PR TITLE
fix(stream): surface swallowed mid-stream errors in Rust adapters

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -1112,6 +1112,16 @@ impl Stream for AnthropicStreamAdapter {
                             };
                             return Poll::Ready(Some(Ok(done)));
                         }
+                        "error" => {
+                            let err_type =
+                                payload["error"]["type"].as_str().unwrap_or("unknown_error");
+                            let message = payload["error"]["message"]
+                                .as_str()
+                                .unwrap_or("unknown stream error");
+                            return Poll::Ready(Some(Err(MotosanError::Stream(format!(
+                                "anthropic stream error: {err_type}: {message}"
+                            )))));
+                        }
                         _ => continue,
                     }
                 }

--- a/sdks/rust/src/providers/claude_code/mod.rs
+++ b/sdks/rust/src/providers/claude_code/mod.rs
@@ -559,8 +559,15 @@ where
 
             let line = match next {
                 Ok(Some(line)) => line.trim().to_string(),
-                Ok(None) => break,
-                Err(_) => break,
+                // EOF/read error before a terminal event surfaces an abnormal child exit.
+                Ok(None) => {
+                    yield Err(abnormal_exit_error(&mut child, None).await);
+                    break;
+                }
+                Err(e) => {
+                    yield Err(abnormal_exit_error(&mut child, Some(e)).await);
+                    break;
+                }
             };
             if line.is_empty() {
                 continue;
@@ -622,6 +629,121 @@ async fn reap_child(child: &mut Option<tokio::process::Child>, kill: bool) {
             }
         }
     }
+}
+
+const CLI_LABEL: &str = "claude CLI";
+
+async fn abnormal_exit_error(
+    child: &mut Option<tokio::process::Child>,
+    read_err: Option<std::io::Error>,
+) -> MotosanError {
+    use std::future::{poll_fn, Future};
+    use std::pin::Pin;
+    use std::task::Poll;
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    let mut status = "unknown".to_string();
+    let mut stderr_excerpt = String::new();
+
+    if let Some(mut c) = child.take() {
+        let mut stderr = c.stderr.take();
+        let mut stderr_buf = Vec::with_capacity(8000);
+        let mut read_buf = [0_u8; 8192];
+        let mut child_done = false;
+        let mut stderr_done = stderr.is_none();
+        let mut wait_failed = false;
+
+        let collection_timed_out = {
+            let wait = c.wait();
+            tokio::pin!(wait);
+            let collect = poll_fn(|cx| {
+                if !child_done {
+                    match wait.as_mut().poll(cx) {
+                        Poll::Ready(Ok(exit)) => {
+                            child_done = true;
+                            status = exit
+                                .code()
+                                .map_or_else(|| exit.to_string(), |code| code.to_string());
+                        }
+                        Poll::Ready(Err(_)) => {
+                            wait_failed = true;
+                            return Poll::Ready(());
+                        }
+                        Poll::Pending => {}
+                    }
+                }
+
+                if !stderr_done {
+                    if let Some(pipe) = stderr.as_mut() {
+                        let mut reads = 0;
+                        loop {
+                            let read = {
+                                let mut buf = ReadBuf::new(&mut read_buf);
+                                match Pin::new(&mut *pipe).poll_read(cx, &mut buf) {
+                                    Poll::Ready(Ok(())) => Poll::Ready(Ok(buf.filled().len())),
+                                    Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+                                    Poll::Pending => Poll::Pending,
+                                }
+                            };
+                            match read {
+                                Poll::Ready(Ok(0)) | Poll::Ready(Err(_)) => {
+                                    stderr_done = true;
+                                    break;
+                                }
+                                Poll::Ready(Ok(n)) => {
+                                    let retained = (8000 - stderr_buf.len()).min(n);
+                                    stderr_buf.extend_from_slice(&read_buf[..retained]);
+                                    reads += 1;
+                                    if reads == 16 {
+                                        cx.waker().wake_by_ref();
+                                        break;
+                                    }
+                                }
+                                Poll::Pending => break,
+                            }
+                        }
+                    }
+                }
+
+                if child_done && stderr_done {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            });
+
+            tokio::time::timeout(Duration::from_secs(5), collect)
+                .await
+                .is_err()
+        };
+
+        if wait_failed || (collection_timed_out && !child_done) {
+            let _ = c.start_kill();
+            if let Ok(exit) = c.wait().await {
+                status = exit
+                    .code()
+                    .map_or_else(|| exit.to_string(), |code| code.to_string());
+            }
+        }
+
+        stderr_excerpt = String::from_utf8_lossy(&stderr_buf)
+            .trim()
+            .chars()
+            .take(2000)
+            .collect();
+    }
+
+    let detail = if !stderr_excerpt.is_empty() {
+        stderr_excerpt
+    } else if let Some(err) = read_err {
+        format!("stdout read error: {err}")
+    } else {
+        "stream ended before a terminal event".to_string()
+    };
+
+    MotosanError::Stream(format!(
+        "{CLI_LABEL} exited unexpectedly (status {status}): {detail}"
+    ))
 }
 
 impl Default for ClaudeCodeProvider {
@@ -703,6 +825,110 @@ mod tests {
         match s.next().await {
             Some(Err(crate::error::MotosanError::StreamReadTimeout(_))) => {}
             other => panic!("expected StreamReadTimeout, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn premature_child_exit_surfaces_status_and_stderr() {
+        use std::process::Stdio;
+        use std::time::Duration;
+        use tokio::io::BufReader;
+        use tokio::process::Command;
+        use tokio_stream::StreamExt;
+
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("printf '%s\n' '{\"type\":\"text\",\"text\":\"hello\"}'; echo boom >&2; exit 1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn child");
+        let stdout = child.stdout.take().expect("child stdout");
+        let mut stream = super::drive_lines(
+            Some(child),
+            BufReader::new(stdout),
+            Some(Duration::from_secs(10)),
+        );
+
+        let first = stream
+            .next()
+            .await
+            .expect("first event")
+            .expect("text event");
+        assert_eq!(first.content, "hello");
+        assert!(!first.done);
+        match stream.next().await {
+            Some(Err(crate::error::MotosanError::Stream(msg))) => {
+                assert!(msg.contains("exited unexpectedly"), "got: {msg}");
+                assert!(msg.contains("status 1"), "got: {msg}");
+                assert!(msg.contains("boom"), "got: {msg}");
+            }
+            other => panic!("expected Stream error, got {other:?}"),
+        }
+        assert!(stream.next().await.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn abnormal_exit_retains_buffered_stderr_when_read_times_out() {
+        use std::process::Stdio;
+        use tokio::process::Command;
+
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("echo boom >&2; sleep 10 & exit 1")
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn child");
+        let mut child = Some(child);
+
+        match super::abnormal_exit_error(&mut child, None).await {
+            crate::error::MotosanError::Stream(msg) => {
+                assert!(msg.contains("status 1"), "got: {msg}");
+                assert!(msg.contains("boom"), "got: {msg}");
+            }
+            other => panic!("expected Stream error, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn abnormal_exit_drains_large_stderr_without_losing_status() {
+        use std::process::Stdio;
+        use std::time::Duration;
+        use tokio::process::Command;
+
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("yes x | head -c 1048576 >&2; exit 7")
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn child");
+        let mut child = Some(child);
+
+        let error = tokio::time::timeout(
+            Duration::from_secs(2),
+            super::abnormal_exit_error(&mut child, None),
+        )
+        .await
+        .expect("abnormal exit collection should not block on a full stderr pipe");
+
+        match error {
+            crate::error::MotosanError::Stream(msg) => {
+                assert!(msg.contains("status 7"), "got: {msg}");
+                assert!(
+                    msg.len() <= 2100,
+                    "diagnostic was not capped: {} bytes",
+                    msg.len()
+                );
+            }
+            other => panic!("expected Stream error, got {other:?}"),
         }
     }
 

--- a/sdks/rust/src/providers/claude_code/mod.rs
+++ b/sdks/rust/src/providers/claude_code/mod.rs
@@ -731,6 +731,26 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn stream_error_subtype_terminal_yields_provider_error() {
+        use std::io::Cursor;
+        use tokio::io::BufReader;
+        use tokio_stream::StreamExt;
+
+        let raw = b"{\"type\":\"result\",\"subtype\":\"error_max_turns\",\"is_error\":true,\"duration_ms\":42,\"num_turns\":10}\n";
+        let mut s = super::drive_lines(
+            None::<tokio::process::Child>,
+            BufReader::new(Cursor::new(&raw[..])),
+            None,
+        );
+        match s.next().await {
+            Some(Err(crate::error::MotosanError::ProviderError(msg))) => {
+                assert!(msg.contains("error_max_turns"), "got: {msg}");
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn terminal_error_reaps_child_before_yield() {

--- a/sdks/rust/src/providers/claude_code/spawn.rs
+++ b/sdks/rust/src/providers/claude_code/spawn.rs
@@ -452,6 +452,24 @@ fn parse_agent_json(raw: &str) -> Result<(String, Usage, Option<String>), Motosa
         MotosanError::ProviderError(format!("failed to parse claude JSON output: {e}"))
     })?;
 
+    let subtype = v.get("subtype").and_then(|subtype| subtype.as_str());
+    let is_error = v
+        .get("is_error")
+        .and_then(|is_error| is_error.as_bool())
+        .unwrap_or(false);
+    let subtype_is_error = subtype.is_some_and(|subtype| subtype.starts_with("error"));
+    if is_error || subtype_is_error {
+        let subtype = subtype.unwrap_or("unknown");
+        let detail = v
+            .get("result")
+            .and_then(|result| result.as_str())
+            .filter(|result| !result.is_empty())
+            .unwrap_or("no result message");
+        return Err(MotosanError::ProviderError(format!(
+            "claude_code terminal error ({subtype}): {detail}"
+        )));
+    }
+
     let text = v
         .get("result")
         .and_then(|r| r.as_str())
@@ -1003,5 +1021,28 @@ mod tests {
                 "3",
             ]
         );
+    }
+
+    #[test]
+    fn agent_json_error_subtype_without_result_is_err() {
+        let raw = r#"{"type":"result","subtype":"error_max_turns","is_error":true}"#;
+        match parse_agent_json(raw) {
+            Err(MotosanError::ProviderError(msg)) => {
+                assert!(msg.contains("error_max_turns"), "got: {msg}");
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_json_is_error_with_result_surfaces_message() {
+        let raw = r#"{"type":"result","subtype":"error_during_execution","is_error":true,"result":"boom"}"#;
+        match parse_agent_json(raw) {
+            Err(MotosanError::ProviderError(msg)) => {
+                assert!(msg.contains("error_during_execution"), "got: {msg}");
+                assert!(msg.contains("boom"), "got: {msg}");
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
     }
 }

--- a/sdks/rust/src/providers/claude_code/stream_json.rs
+++ b/sdks/rust/src/providers/claude_code/stream_json.rs
@@ -19,10 +19,11 @@ pub enum ClaudeStreamEvent {
 
     #[serde(rename = "result")]
     Result {
-        // The `result` field on a terminal `result` event duplicates what
-        // we already yielded as Text from the preceding `assistant` event.
-        // Kept parsed so the variant matches the wire shape, and used as the
-        // provider error message when `is_error` is true.
+        // The `result` field on a successful terminal `result` event duplicates
+        // what we already yielded as Text from the preceding `assistant` event.
+        // Error-subtype terminals may omit it, so default to an empty string and
+        // use a fallback detail when surfacing the provider error.
+        #[serde(default)]
         result: String,
         #[serde(default)]
         usage: Option<ClaudeStreamUsage>,
@@ -128,13 +129,19 @@ pub fn parse_ndjson_line(line: &str) -> Option<NdjsonAction> {
             is_error,
             subtype,
         } => {
-            if is_error {
-                let msg = if result.is_empty() {
-                    subtype.unwrap_or_else(|| "claude CLI provider error".to_string())
+            let subtype_is_error = subtype
+                .as_deref()
+                .is_some_and(|subtype| subtype.starts_with("error"));
+            if is_error || subtype_is_error {
+                let subtype = subtype.as_deref().unwrap_or("unknown");
+                let detail = if result.is_empty() {
+                    "no result message"
                 } else {
-                    result
+                    result.as_str()
                 };
-                return Some(NdjsonAction::Error(msg));
+                return Some(NdjsonAction::Error(format!(
+                    "claude_code terminal error ({subtype}): {detail}"
+                )));
             }
             let usage_event = usage.map(|u| {
                 StreamEvent::usage(Usage {
@@ -204,6 +211,29 @@ mod tests {
         let line = r#"{"type":"result","subtype":"success","is_error":true,"result":"bad model"}"#;
         match parse_ndjson_line(line).expect("parse") {
             NdjsonAction::Error(msg) => assert!(msg.contains("bad model")),
+            _ => panic!("expected Error action"),
+        }
+    }
+
+    #[test]
+    fn result_error_subtype_without_result_field_maps_to_error() {
+        let line = r#"{"type":"result","subtype":"error_max_turns","is_error":true,"duration_ms":42,"num_turns":10,"session_id":"sess_1"}"#;
+        match parse_ndjson_line(line).expect("parse") {
+            NdjsonAction::Error(msg) => {
+                assert!(msg.contains("error_max_turns"), "got: {msg}");
+                assert!(msg.contains("claude_code terminal error"), "got: {msg}");
+            }
+            _ => panic!("expected Error action"),
+        }
+    }
+
+    #[test]
+    fn result_error_subtype_without_is_error_flag_maps_to_error() {
+        let line = r#"{"type":"result","subtype":"error_during_execution"}"#;
+        match parse_ndjson_line(line).expect("parse") {
+            NdjsonAction::Error(msg) => {
+                assert!(msg.contains("error_during_execution"), "got: {msg}");
+            }
             _ => panic!("expected Error action"),
         }
     }

--- a/sdks/rust/src/providers/codex_cli/mod.rs
+++ b/sdks/rust/src/providers/codex_cli/mod.rs
@@ -541,8 +541,15 @@ where
 
             let line = match next {
                 Ok(Some(line)) => line.trim().to_string(),
-                Ok(None) => break,
-                Err(_) => break,
+                // EOF/read error before a terminal event surfaces an abnormal child exit.
+                Ok(None) => {
+                    yield Err(abnormal_exit_error(&mut child, None).await);
+                    break;
+                }
+                Err(e) => {
+                    yield Err(abnormal_exit_error(&mut child, Some(e)).await);
+                    break;
+                }
             };
             if line.is_empty() {
                 continue;
@@ -603,6 +610,121 @@ async fn reap_child(child: &mut Option<tokio::process::Child>, kill: bool) {
             }
         }
     }
+}
+
+const CLI_LABEL: &str = "codex CLI";
+
+async fn abnormal_exit_error(
+    child: &mut Option<tokio::process::Child>,
+    read_err: Option<std::io::Error>,
+) -> MotosanError {
+    use std::future::{poll_fn, Future};
+    use std::pin::Pin;
+    use std::task::Poll;
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    let mut status = "unknown".to_string();
+    let mut stderr_excerpt = String::new();
+
+    if let Some(mut c) = child.take() {
+        let mut stderr = c.stderr.take();
+        let mut stderr_buf = Vec::with_capacity(8000);
+        let mut read_buf = [0_u8; 8192];
+        let mut child_done = false;
+        let mut stderr_done = stderr.is_none();
+        let mut wait_failed = false;
+
+        let collection_timed_out = {
+            let wait = c.wait();
+            tokio::pin!(wait);
+            let collect = poll_fn(|cx| {
+                if !child_done {
+                    match wait.as_mut().poll(cx) {
+                        Poll::Ready(Ok(exit)) => {
+                            child_done = true;
+                            status = exit
+                                .code()
+                                .map_or_else(|| exit.to_string(), |code| code.to_string());
+                        }
+                        Poll::Ready(Err(_)) => {
+                            wait_failed = true;
+                            return Poll::Ready(());
+                        }
+                        Poll::Pending => {}
+                    }
+                }
+
+                if !stderr_done {
+                    if let Some(pipe) = stderr.as_mut() {
+                        let mut reads = 0;
+                        loop {
+                            let read = {
+                                let mut buf = ReadBuf::new(&mut read_buf);
+                                match Pin::new(&mut *pipe).poll_read(cx, &mut buf) {
+                                    Poll::Ready(Ok(())) => Poll::Ready(Ok(buf.filled().len())),
+                                    Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+                                    Poll::Pending => Poll::Pending,
+                                }
+                            };
+                            match read {
+                                Poll::Ready(Ok(0)) | Poll::Ready(Err(_)) => {
+                                    stderr_done = true;
+                                    break;
+                                }
+                                Poll::Ready(Ok(n)) => {
+                                    let retained = (8000 - stderr_buf.len()).min(n);
+                                    stderr_buf.extend_from_slice(&read_buf[..retained]);
+                                    reads += 1;
+                                    if reads == 16 {
+                                        cx.waker().wake_by_ref();
+                                        break;
+                                    }
+                                }
+                                Poll::Pending => break,
+                            }
+                        }
+                    }
+                }
+
+                if child_done && stderr_done {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            });
+
+            tokio::time::timeout(Duration::from_secs(5), collect)
+                .await
+                .is_err()
+        };
+
+        if wait_failed || (collection_timed_out && !child_done) {
+            let _ = c.start_kill();
+            if let Ok(exit) = c.wait().await {
+                status = exit
+                    .code()
+                    .map_or_else(|| exit.to_string(), |code| code.to_string());
+            }
+        }
+
+        stderr_excerpt = String::from_utf8_lossy(&stderr_buf)
+            .trim()
+            .chars()
+            .take(2000)
+            .collect();
+    }
+
+    let detail = if !stderr_excerpt.is_empty() {
+        stderr_excerpt
+    } else if let Some(err) = read_err {
+        format!("stdout read error: {err}")
+    } else {
+        "stream ended before a terminal event".to_string()
+    };
+
+    MotosanError::Stream(format!(
+        "{CLI_LABEL} exited unexpectedly (status {status}): {detail}"
+    ))
 }
 
 impl Default for CodexCliProvider {
@@ -695,6 +817,48 @@ mod tests {
             Some(Err(crate::error::MotosanError::StreamReadTimeout(_))) => {}
             other => panic!("expected StreamReadTimeout, got {other:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn premature_child_exit_surfaces_status_and_stderr() {
+        use std::process::Stdio;
+        use std::time::Duration;
+        use tokio::io::BufReader;
+        use tokio::process::Command;
+        use tokio_stream::StreamExt;
+
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("printf '%s\n' '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"hello\"}}'; echo boom >&2; exit 1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn child");
+        let stdout = child.stdout.take().expect("child stdout");
+        let mut stream = super::drive_lines(
+            Some(child),
+            BufReader::new(stdout),
+            Some(Duration::from_secs(10)),
+        );
+
+        let first = stream
+            .next()
+            .await
+            .expect("first event")
+            .expect("text event");
+        assert_eq!(first.content, "hello");
+        assert!(!first.done);
+        match stream.next().await {
+            Some(Err(crate::error::MotosanError::Stream(msg))) => {
+                assert!(msg.contains("exited unexpectedly"), "got: {msg}");
+                assert!(msg.contains("status 1"), "got: {msg}");
+                assert!(msg.contains("boom"), "got: {msg}");
+            }
+            other => panic!("expected Stream error, got {other:?}"),
+        }
+        assert!(stream.next().await.is_none());
     }
 
     #[tokio::test]

--- a/sdks/rust/src/providers/gemini_cli/mod.rs
+++ b/sdks/rust/src/providers/gemini_cli/mod.rs
@@ -340,8 +340,15 @@ where
 
             let line = match next {
                 Ok(Some(line)) => line.trim().to_string(),
-                Ok(None) => break,
-                Err(_) => break,
+                // EOF/read error before a terminal event surfaces an abnormal child exit.
+                Ok(None) => {
+                    yield Err(abnormal_exit_error(&mut child, None).await);
+                    break;
+                }
+                Err(e) => {
+                    yield Err(abnormal_exit_error(&mut child, Some(e)).await);
+                    break;
+                }
             };
             if line.is_empty() {
                 continue;
@@ -401,6 +408,121 @@ async fn reap_child(child: &mut Option<tokio::process::Child>, kill: bool) {
             }
         }
     }
+}
+
+const CLI_LABEL: &str = "gemini CLI";
+
+async fn abnormal_exit_error(
+    child: &mut Option<tokio::process::Child>,
+    read_err: Option<std::io::Error>,
+) -> MotosanError {
+    use std::future::{poll_fn, Future};
+    use std::pin::Pin;
+    use std::task::Poll;
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    let mut status = "unknown".to_string();
+    let mut stderr_excerpt = String::new();
+
+    if let Some(mut c) = child.take() {
+        let mut stderr = c.stderr.take();
+        let mut stderr_buf = Vec::with_capacity(8000);
+        let mut read_buf = [0_u8; 8192];
+        let mut child_done = false;
+        let mut stderr_done = stderr.is_none();
+        let mut wait_failed = false;
+
+        let collection_timed_out = {
+            let wait = c.wait();
+            tokio::pin!(wait);
+            let collect = poll_fn(|cx| {
+                if !child_done {
+                    match wait.as_mut().poll(cx) {
+                        Poll::Ready(Ok(exit)) => {
+                            child_done = true;
+                            status = exit
+                                .code()
+                                .map_or_else(|| exit.to_string(), |code| code.to_string());
+                        }
+                        Poll::Ready(Err(_)) => {
+                            wait_failed = true;
+                            return Poll::Ready(());
+                        }
+                        Poll::Pending => {}
+                    }
+                }
+
+                if !stderr_done {
+                    if let Some(pipe) = stderr.as_mut() {
+                        let mut reads = 0;
+                        loop {
+                            let read = {
+                                let mut buf = ReadBuf::new(&mut read_buf);
+                                match Pin::new(&mut *pipe).poll_read(cx, &mut buf) {
+                                    Poll::Ready(Ok(())) => Poll::Ready(Ok(buf.filled().len())),
+                                    Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+                                    Poll::Pending => Poll::Pending,
+                                }
+                            };
+                            match read {
+                                Poll::Ready(Ok(0)) | Poll::Ready(Err(_)) => {
+                                    stderr_done = true;
+                                    break;
+                                }
+                                Poll::Ready(Ok(n)) => {
+                                    let retained = (8000 - stderr_buf.len()).min(n);
+                                    stderr_buf.extend_from_slice(&read_buf[..retained]);
+                                    reads += 1;
+                                    if reads == 16 {
+                                        cx.waker().wake_by_ref();
+                                        break;
+                                    }
+                                }
+                                Poll::Pending => break,
+                            }
+                        }
+                    }
+                }
+
+                if child_done && stderr_done {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            });
+
+            tokio::time::timeout(Duration::from_secs(5), collect)
+                .await
+                .is_err()
+        };
+
+        if wait_failed || (collection_timed_out && !child_done) {
+            let _ = c.start_kill();
+            if let Ok(exit) = c.wait().await {
+                status = exit
+                    .code()
+                    .map_or_else(|| exit.to_string(), |code| code.to_string());
+            }
+        }
+
+        stderr_excerpt = String::from_utf8_lossy(&stderr_buf)
+            .trim()
+            .chars()
+            .take(2000)
+            .collect();
+    }
+
+    let detail = if !stderr_excerpt.is_empty() {
+        stderr_excerpt
+    } else if let Some(err) = read_err {
+        format!("stdout read error: {err}")
+    } else {
+        "stream ended before a terminal event".to_string()
+    };
+
+    MotosanError::Stream(format!(
+        "{CLI_LABEL} exited unexpectedly (status {status}): {detail}"
+    ))
 }
 
 /// Merge the system prompt onto the user prompt for stdin delivery.
@@ -489,6 +611,48 @@ mod tests {
             Some(Err(crate::error::MotosanError::StreamReadTimeout(_))) => {}
             other => panic!("expected StreamReadTimeout, got {other:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn premature_child_exit_surfaces_status_and_stderr() {
+        use std::process::Stdio;
+        use std::time::Duration;
+        use tokio::io::BufReader;
+        use tokio::process::Command;
+        use tokio_stream::StreamExt;
+
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("printf '%s\n' '{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"hello\",\"delta\":true}'; echo boom >&2; exit 1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn child");
+        let stdout = child.stdout.take().expect("child stdout");
+        let mut stream = super::drive_lines(
+            Some(child),
+            BufReader::new(stdout),
+            Some(Duration::from_secs(10)),
+        );
+
+        let first = stream
+            .next()
+            .await
+            .expect("first event")
+            .expect("text event");
+        assert_eq!(first.content, "hello");
+        assert!(!first.done);
+        match stream.next().await {
+            Some(Err(crate::error::MotosanError::Stream(msg))) => {
+                assert!(msg.contains("exited unexpectedly"), "got: {msg}");
+                assert!(msg.contains("status 1"), "got: {msg}");
+                assert!(msg.contains("boom"), "got: {msg}");
+            }
+            other => panic!("expected Stream error, got {other:?}"),
+        }
+        assert!(stream.next().await.is_none());
     }
 
     #[tokio::test]

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -777,3 +777,56 @@ async fn orphan_thinking_delta_without_start_does_not_crash() {
     );
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn anthropic_stream_surfaces_mid_stream_error_frame() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"partial\"}}\n\n",
+        "event: error\n",
+        "data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n",
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+    let mut stream = provider.stream(request).await.expect("stream");
+
+    let mut ok_events = Vec::new();
+    let mut stream_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(event) => ok_events.push(event),
+            Err(err) => {
+                stream_err = Some(err);
+                break;
+            }
+        }
+    }
+
+    assert!(ok_events
+        .iter()
+        .any(|event| { event.event_type == StreamEventType::Text && event.content == "partial" }));
+    assert!(!ok_events.iter().any(|event| event.done));
+    let err = stream_err.expect("stream must yield Err for the error frame");
+    match err {
+        motosan_ai::MotosanError::Stream(message) => {
+            assert!(message.contains("overloaded_error"));
+            assert!(message.contains("Overloaded"));
+        }
+        other => panic!("expected MotosanError::Stream, got {other:?}"),
+    }
+
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- Anthropic stream adapter: mid-stream `error` frames (e.g. `overloaded_error` on HTTP 200) now
  surface as `MotosanError::Stream` instead of being dropped by the catch-all — truncated streams
  no longer collect as clean successes.
- claude_code: terminal results with error subtypes (`error_max_turns`, `error_during_execution`)
  no longer vanish on serde (`result` is now `#[serde(default)]`); they reach the SAME
  `ProviderError` variant the existing `is_error` path already used (no variant changes).
- All three CLI backends (claude_code / codex_cli / gemini_cli): read errors and
  EOF-without-terminal-event now await the child and yield a typed stream error carrying exit
  status + stderr, instead of ending the stream as if it completed.
- New regression tests per adapter, including fake `sh -c` children that die mid-stream.
- Out of scope (deliberate, M3): clean-EOF fabricated-done behavior, cancellation paths.

M1 plan Tasks 5–7 (PR-R2): docs/superpowers/plans/2026-07-14-stream-retry-m1-implementation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
