### PR TITLE
fix(python): index-keyed streamed tool calls, codex call-id mapping, tool-use stop reason

### DIFF
--- a/sdks/python/motosan_ai/_stream_collect.py
+++ b/sdks/python/motosan_ai/_stream_collect.py
@@ -22,7 +22,7 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
     thinking = ""
     tool_calls: list[ToolCall] = []
     usage = Usage(0, 0)
-    stop_reason = StopReason.end_turn
+    stop_reason: StopReason | None = None
 
     current_tc_id = ""
     current_tc_name = ""
@@ -73,6 +73,9 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
 
         if event.done and event.stop_reason is not None:
             stop_reason = event.stop_reason
+
+    if stop_reason is None:
+        stop_reason = StopReason.tool_use if tool_calls else StopReason.end_turn
 
     return ChatResponse(
         content=content,

--- a/sdks/python/motosan_ai/providers/chatgpt_codex.py
+++ b/sdks/python/motosan_ai/providers/chatgpt_codex.py
@@ -33,6 +33,7 @@ _ORIGINATOR = "codex_cli_rs"
 @dataclass
 class _ChatGptCodexAdapterState:
     seen_tool_ids: set[str] = field(default_factory=set)
+    item_to_call_id: dict[str, str] = field(default_factory=dict)
     saw_tool_call: bool = False
     error: str | None = None
 
@@ -79,6 +80,9 @@ def _parse_sse_event(data: str, state: _ChatGptCodexAdapterState) -> list[Stream
             if call_id:
                 state.saw_tool_call = True
                 state.seen_tool_ids.add(call_id)
+                item_id = item.get("id")
+                if isinstance(item_id, str) and item_id:
+                    state.item_to_call_id[item_id] = call_id
                 out.append(
                     StreamEvent(
                         content="",
@@ -98,7 +102,10 @@ def _parse_sse_event(data: str, state: _ChatGptCodexAdapterState) -> list[Stream
                     content="",
                     done=False,
                     event_type="tool_call_args",
-                    tool_call_id=item_id,
+                    # Wire fragments are keyed by the item's "fc_..." id; translate
+                    # to the "call_..." call_id announced in output_item.added so
+                    # consumers can correlate. Unknown ids pass through unchanged.
+                    tool_call_id=state.item_to_call_id.get(item_id, item_id),
                     tool_call_args_delta=delta,
                 )
             )

--- a/sdks/python/motosan_ai/providers/openai.py
+++ b/sdks/python/motosan_ai/providers/openai.py
@@ -25,6 +25,12 @@ from motosan_ai.types import (
 
 _DEFAULT_BASE_URL = "https://api.openai.com"
 
+_FINISH_REASON_TO_STOP = {
+    "stop": StopReason.stop,
+    "length": StopReason.max_tokens,
+    "tool_calls": StopReason.tool_use,
+}
+
 
 class OpenAIProvider:
     capabilities: ProviderCapabilities = ProviderCapabilities.with_image()
@@ -191,11 +197,7 @@ class OpenAIProvider:
             )
 
         finish_reason = choice.get("finish_reason")
-        stop_reason = {
-            "stop": StopReason.stop,
-            "length": StopReason.max_tokens,
-            "tool_calls": StopReason.tool_use,
-        }.get(finish_reason, StopReason.other)
+        stop_reason = _FINISH_REASON_TO_STOP.get(finish_reason, StopReason.other)
 
         usage = payload.get("usage") or {}
         return ChatResponse(
@@ -226,12 +228,25 @@ class OpenAIProvider:
                 )
                 raise self._map_http_error(resp.status_code, message)
 
+            # Per-index tool-call tracking (mirrors TS providers/openai.ts):
+            # index -> (id, name); only one tool call is open at a time.
+            tool_buffer: dict[int, tuple[str, str]] = {}
+            open_tool_index: int | None = None
+
             async for line in resp.aiter_lines():
                 if not line.startswith("data: "):
                     continue
                 data = line[6:].strip()
                 if not data or data == "[DONE]":
                     if data == "[DONE]":
+                        if open_tool_index is not None:
+                            yield StreamEvent(
+                                content="",
+                                done=False,
+                                tool_call_id=tool_buffer[open_tool_index][0],
+                                event_type="tool_call_end",
+                            )
+                            open_tool_index = None
                         yield StreamEvent(content="", done=True)
                         return
                     continue
@@ -247,11 +262,25 @@ class OpenAIProvider:
                         yield StreamEvent(content=text, done=False)
 
                     for tc in delta.get("tool_calls") or []:
+                        tc_index = tc.get("index")
+                        if tc_index is None:
+                            continue
                         fn = tc.get("function") or {}
                         tc_id = tc.get("id")
                         tc_name = fn.get("name")
                         tc_args = fn.get("arguments")
                         if tc_id and tc_name:
+                            # First fragment for this index: close any open
+                            # tool call from a different index, then open this one.
+                            if open_tool_index is not None and open_tool_index != tc_index:
+                                yield StreamEvent(
+                                    content="",
+                                    done=False,
+                                    tool_call_id=tool_buffer[open_tool_index][0],
+                                    event_type="tool_call_end",
+                                )
+                            tool_buffer[tc_index] = (tc_id, tc_name)
+                            open_tool_index = tc_index
                             yield StreamEvent(
                                 content="",
                                 done=False,
@@ -259,18 +288,30 @@ class OpenAIProvider:
                                 tool_call_name=tc_name,
                                 event_type="tool_call_start",
                             )
-                        if tc_args:
+                        if tc_args and tc_index in tool_buffer:
                             yield StreamEvent(
                                 content="",
                                 done=False,
+                                tool_call_id=tool_buffer[tc_index][0],
                                 tool_call_args_delta=tc_args,
                                 event_type="tool_call_args",
                             )
 
-                    if choice.get("finish_reason"):
-                        if choice.get("finish_reason") == "tool_calls":
-                            yield StreamEvent(content="", done=False, event_type="tool_call_end")
-                        yield StreamEvent(content="", done=True)
+                    finish_reason = choice.get("finish_reason")
+                    if finish_reason:
+                        if finish_reason == "tool_calls" and open_tool_index is not None:
+                            yield StreamEvent(
+                                content="",
+                                done=False,
+                                tool_call_id=tool_buffer[open_tool_index][0],
+                                event_type="tool_call_end",
+                            )
+                            open_tool_index = None
+                        yield StreamEvent(
+                            content="",
+                            done=True,
+                            stop_reason=_FINISH_REASON_TO_STOP.get(finish_reason, StopReason.other),
+                        )
                         return
         except StreamError:
             raise

--- a/sdks/python/tests/test_chatgpt_codex_http.py
+++ b/sdks/python/tests/test_chatgpt_codex_http.py
@@ -118,16 +118,35 @@ async def test_chat_surfaces_thinking():
 @respx.mock
 @pytest.mark.asyncio
 async def test_chat_tool_call_lifecycle_yields_tool_call():
+    # Distinct item id ("fc_...") vs call_id ("call_..."), matching the real wire.
     sse = _sse_text(
         {
             "type": "response.output_item.added",
-            "item": {"type": "function_call", "call_id": "c1", "name": "get_weather"},
+            "item": {
+                "type": "function_call",
+                "id": "fc_001",
+                "call_id": "call_001",
+                "name": "get_weather",
+            },
         },
-        {"type": "response.function_call_arguments.delta", "item_id": "c1", "delta": '{"city":'},
-        {"type": "response.function_call_arguments.delta", "item_id": "c1", "delta": '"Paris"}'},
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_001",
+            "delta": '{"city":',
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_001",
+            "delta": '"Paris"}',
+        },
         {
             "type": "response.output_item.done",
-            "item": {"type": "function_call", "call_id": "c1", "name": "get_weather"},
+            "item": {
+                "type": "function_call",
+                "id": "fc_001",
+                "call_id": "call_001",
+                "name": "get_weather",
+            },
         },
         {"type": "response.completed", "response": {"status": "completed"}},
     )
@@ -139,7 +158,7 @@ async def test_chat_tool_call_lifecycle_yields_tool_call():
     )
     assert resp.stop_reason == StopReason.tool_use
     assert len(resp.tool_calls) == 1
-    assert resp.tool_calls[0].id == "c1"
+    assert resp.tool_calls[0].id == "call_001"
     assert resp.tool_calls[0].name == "get_weather"
     assert resp.tool_calls[0].input == {"city": "Paris"}
 

--- a/sdks/python/tests/test_chatgpt_codex_stream.py
+++ b/sdks/python/tests/test_chatgpt_codex_stream.py
@@ -123,25 +123,38 @@ def test_adapter_maps_reasoning_delta_to_thinking():
 
 
 def test_adapter_handles_function_call_lifecycle():
+    # Real wire: the item carries both an item id ("fc_...") and a call_id
+    # ("call_..."); argument fragments are keyed by the ITEM id. All emitted
+    # events must use the call_id.
     events = _drive(
         [
             {
                 "type": "response.output_item.added",
-                "item": {"type": "function_call", "call_id": "call_42", "name": "get_weather"},
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_42",
+                    "call_id": "call_42",
+                    "name": "get_weather",
+                },
             },
             {
                 "type": "response.function_call_arguments.delta",
-                "item_id": "call_42",
+                "item_id": "fc_42",
                 "delta": '{"city":',
             },
             {
                 "type": "response.function_call_arguments.delta",
-                "item_id": "call_42",
+                "item_id": "fc_42",
                 "delta": '"Paris"}',
             },
             {
                 "type": "response.output_item.done",
-                "item": {"type": "function_call", "call_id": "call_42", "name": "get_weather"},
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_42",
+                    "call_id": "call_42",
+                    "name": "get_weather",
+                },
             },
             {
                 "type": "response.completed",
@@ -157,14 +170,33 @@ def test_adapter_handles_function_call_lifecycle():
     assert start.tool_call_id == "call_42"
     assert start.tool_call_name == "get_weather"
 
-    args = "".join(e.tool_call_args_delta or "" for e in events if e.event_type == "tool_call_args")
-    assert args == '{"city":"Paris"}'
+    arg_events = [e for e in events if e.event_type == "tool_call_args"]
+    assert [e.tool_call_id for e in arg_events] == ["call_42", "call_42"]
+    assert "".join(e.tool_call_args_delta or "" for e in arg_events) == '{"city":"Paris"}'
 
     end = next(e for e in events if e.event_type == "tool_call_end")
     assert end.tool_call_id == "call_42"
 
     done = next(e for e in events if e.done)
     assert done.stop_reason == StopReason.tool_use
+
+
+def test_args_delta_for_unknown_item_id_passes_through():
+    state = _ChatGptCodexAdapterState()
+    events = _parse_sse_event(
+        json.dumps(
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_orphan",
+                "delta": "{}",
+            }
+        ),
+        state,
+    )
+    assert len(events) == 1
+    assert events[0].event_type == "tool_call_args"
+    assert events[0].tool_call_id == "fc_orphan"
+    assert events[0].tool_call_args_delta == "{}"
 
 
 def test_adapter_maps_incomplete_to_max_tokens():

--- a/sdks/python/tests/test_client_stream_collect.py
+++ b/sdks/python/tests/test_client_stream_collect.py
@@ -258,3 +258,27 @@ async def test_collect_stream_session_id_none_when_absent():
 
     resp = await collect_stream(gen())
     assert resp.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_collect_infers_tool_use_when_done_lacks_stop_reason():
+    events = [
+        StreamEvent(
+            content="",
+            done=False,
+            event_type="tool_call_start",
+            tool_call_id="t1",
+            tool_call_name="get_weather",
+        ),
+        StreamEvent(
+            content="",
+            done=False,
+            event_type="tool_call_args",
+            tool_call_id="t1",
+            tool_call_args_delta='{"city":"Taipei"}',
+        ),
+        StreamEvent(content="", done=False, event_type="tool_call_end", tool_call_id="t1"),
+        StreamEvent(content="", done=True),
+    ]
+    resp = await collect_stream(_events_to_iter(events))
+    assert resp.stop_reason == StopReason.tool_use

--- a/sdks/python/tests/test_openai.py
+++ b/sdks/python/tests/test_openai.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 import respx
 
+from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import StreamError
 from motosan_ai.providers.openai import OpenAIProvider
 from motosan_ai.types import ChatRequest, Message, StopReason, Tool
@@ -262,3 +263,73 @@ async def test_openai_5xx_message_has_status_and_retry_after(provider):
     msg = str(exc_info.value)
     assert "HTTP 503: overloaded" in msg
     assert "Retry-After: 7" in msg
+
+
+# ---------------------------------------------------------------------------
+# stream: parallel tool calls
+# ---------------------------------------------------------------------------
+
+
+def _tool_chunk(index: int, tc_id=None, name=None, args=None) -> dict:
+    fn = {}
+    if name is not None:
+        fn["name"] = name
+    if args is not None:
+        fn["arguments"] = args
+    tc = {"index": index, "function": fn}
+    if tc_id is not None:
+        tc["id"] = tc_id
+    return {"choices": [{"delta": {"tool_calls": [tc]}, "finish_reason": None}]}
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_openai_stream_parallel_tool_calls(provider):
+    # OpenAI streams parallel tool calls sequentially by index: all fragments
+    # for index 0, then all fragments for index 1, then finish_reason.
+    sse = _sse_lines(
+        _tool_chunk(0, tc_id="call_1", name="get_weather", args=""),
+        _tool_chunk(0, args='{"city":'),
+        _tool_chunk(0, args='"Taipei"}'),
+        _tool_chunk(1, tc_id="call_2", name="get_time", args=""),
+        _tool_chunk(1, args='{"tz":"UTC"}'),
+        {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+    )
+    respx.post("https://mock.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(200, text=sse, headers={"content-type": "text/event-stream"})
+    )
+
+    events = [e async for e in provider.stream(ChatRequest(messages=[Message.user("hi")]))]
+
+    starts = [e for e in events if e.event_type == "tool_call_start"]
+    assert [(e.tool_call_id, e.tool_call_name) for e in starts] == [
+        ("call_1", "get_weather"),
+        ("call_2", "get_time"),
+    ]
+
+    ends = [e for e in events if e.event_type == "tool_call_end"]
+    assert [e.tool_call_id for e in ends] == ["call_1", "call_2"]
+
+    # call_1 must be closed before call_2 opens (close-on-index-switch).
+    assert events.index(ends[0]) < events.index(starts[1])
+
+    args_events = [e for e in events if e.event_type == "tool_call_args"]
+    assert [(e.tool_call_id, e.tool_call_args_delta) for e in args_events] == [
+        ("call_1", '{"city":'),
+        ("call_1", '"Taipei"}'),
+        ("call_2", '{"tz":"UTC"}'),
+    ]
+
+    assert events[-1].done is True
+    assert events[-1].stop_reason == StopReason.tool_use
+
+    # Collected end-to-end (fresh stream; the respx mock replays the response):
+    # both calls survive with assembled inputs and stop_reason tool_use.
+    resp = await collect_stream(provider.stream(ChatRequest(messages=[Message.user("hi")])))
+    assert [(tc.id, tc.name) for tc in resp.tool_calls] == [
+        ("call_1", "get_weather"),
+        ("call_2", "get_time"),
+    ]
+    assert resp.tool_calls[0].input == {"city": "Taipei"}
+    assert resp.tool_calls[1].input == {"tz": "UTC"}
+    assert resp.stop_reason == StopReason.tool_use


### PR DESCRIPTION
## Summary
- OpenAI stream(): parallel tool calls are now keyed by `tool_calls[].index` (ports the proven
  TypeScript toolBuffer semantics) — previously only the last call survived and a single
  anonymous end was emitted.
- OpenAI stream(): the terminal event now carries a `finish_reason`-derived `stop_reason`, and
  `collect_stream` gains the tool-use fallback — streamed tool turns report `tool_use` instead of
  `end_turn` (parity with Rust/TS; agent loops no longer silently terminate).
- chatgpt_codex: argument deltas keyed by wire `item_id` (`fc_…`) are translated to the call's
  `call_id` (`call_…`) via an item→call map; the identical-id fixtures that masked the bug now
  use distinct ids in both test files.
- Scope note: OpenAI buffering is close-on-index-switch (TS parity) — correct for OpenAI's actual
  emission pattern; cross-index interleaving re-serialization is Rust-only by design (M1 plan).

M1 plan Tasks 15–16 (PR-P2): docs/superpowers/plans/2026-07-14-stream-retry-m1-implementation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)