### PR TITLE
fix(ts): cancel abandoned stream readers, CRLF-correct SSE parsing, usage replace-merge

### DIFF
--- a/sdks/typescript/src/http/ndjson.ts
+++ b/sdks/typescript/src/http/ndjson.ts
@@ -65,6 +65,11 @@ export async function* parseNdjson(
       }
     }
   } finally {
+    try {
+      await reader.cancel()
+    } catch {
+      // Ignore cancel errors — the stream may already be closed or errored.
+    }
     reader.releaseLock()
   }
 }

--- a/sdks/typescript/src/http/sse.ts
+++ b/sdks/typescript/src/http/sse.ts
@@ -3,7 +3,9 @@
  *
  * Parses a ReadableStream<Uint8Array> into an async generator of SSE events.
  * Uses TextDecoder to handle UTF-8 decoding across chunk boundaries, buffers
- * incomplete events, splits on \n\n boundaries, and parses event:/data: lines.
+ * incomplete events, normalizes \r\n / bare \r to \n, splits on blank-line
+ * boundaries, and parses event:/data: lines (at most one leading space is
+ * removed after the colon, per the WHATWG SSE spec).
  * Malformed JSON in data fields is silently skipped. [DONE] is recognized as
  * data but does NOT terminate the stream (completion is adapter-specific).
  */
@@ -32,7 +34,23 @@ export async function* parseSse(
   const reader = body.getReader()
   const decoder = new TextDecoder()
   let buffer = ''
+  let pendingCr = false
   let pendingEventName: string | undefined
+
+  // Normalize \r\n and bare \r line terminators to \n (WHATWG SSE spec).
+  // A chunk ending in \r is held back (pendingCr) so a \r\n pair split
+  // across chunk boundaries is not mistaken for two terminators.
+  function normalizeNewlines(text: string): string {
+    if (pendingCr) {
+      text = '\r' + text
+      pendingCr = false
+    }
+    if (text.endsWith('\r')) {
+      pendingCr = true
+      text = text.substring(0, text.length - 1)
+    }
+    return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+  }
 
   function eventFromText(text: string): SseEvent | null {
     const parsed = parseEventText(text)
@@ -54,12 +72,17 @@ export async function* parseSse(
       const { done, value } = await reader.read()
 
       if (value) {
-        buffer += decoder.decode(value, { stream: true })
+        buffer += normalizeNewlines(decoder.decode(value, { stream: true }))
       }
 
       if (done) {
         // Flush any remaining decoded bytes
-        buffer += decoder.decode()
+        buffer += normalizeNewlines(decoder.decode())
+        if (pendingCr) {
+          // A trailing lone \r is a line terminator too
+          buffer += '\n'
+          pendingCr = false
+        }
         // Process final event if buffer is non-empty
         if (buffer.trim()) {
           const event = eventFromText(buffer)
@@ -106,15 +129,23 @@ function parseEventText(text: string): ParsedEventText {
   const dataLines: string[] = []
 
   for (const line of lines) {
-    const trimmed = line.trim()
-    if (!trimmed) {
-      continue
+    if (!line || line.startsWith(':')) {
+      continue // empty line or comment
     }
 
-    if (trimmed.startsWith('event:')) {
-      eventName = trimmed.substring('event:'.length).trim()
-    } else if (trimmed.startsWith('data:')) {
-      dataLines.push(trimmed.substring('data:'.length).trim())
+    const colonIndex = line.indexOf(':')
+    const field = colonIndex === -1 ? line : line.substring(0, colonIndex)
+    let value = colonIndex === -1 ? '' : line.substring(colonIndex + 1)
+    // WHATWG SSE spec: remove at most ONE leading space after the colon;
+    // the rest of the value is preserved verbatim.
+    if (value.startsWith(' ')) {
+      value = value.substring(1)
+    }
+
+    if (field === 'event') {
+      eventName = value
+    } else if (field === 'data') {
+      dataLines.push(value)
     }
   }
 

--- a/sdks/typescript/src/http/sse.ts
+++ b/sdks/typescript/src/http/sse.ts
@@ -87,6 +87,11 @@ export async function* parseSse(
       }
     }
   } finally {
+    try {
+      await reader.cancel()
+    } catch {
+      // Ignore cancel errors — the stream may already be closed or errored.
+    }
     reader.releaseLock()
   }
 }

--- a/sdks/typescript/src/stream.ts
+++ b/sdks/typescript/src/stream.ts
@@ -127,15 +127,18 @@ export async function collectStream(stream: BoxStream): Promise<ChatResponse> {
 
       case 'usage':
         if (event.usage) {
-          inputTokens += event.usage.inputTokens
-          outputTokens += event.usage.outputTokens
+          // Replace-with-fallback, mirroring Python _stream_collect.py:
+          // Anthropic message_delta usage is CUMULATIVE, so summing would
+          // double-count output tokens. A zero field keeps the previous
+          // value (message_delta carries no input_tokens, mapped to 0);
+          // an absent cache field keeps the previous cache value.
+          inputTokens = event.usage.inputTokens || inputTokens
+          outputTokens = event.usage.outputTokens || outputTokens
           if (event.usage.cacheCreationInputTokens !== undefined) {
-            cacheCreationInputTokens =
-              (cacheCreationInputTokens ?? 0) + event.usage.cacheCreationInputTokens
+            cacheCreationInputTokens = event.usage.cacheCreationInputTokens
           }
           if (event.usage.cacheReadInputTokens !== undefined) {
-            cacheReadInputTokens =
-              (cacheReadInputTokens ?? 0) + event.usage.cacheReadInputTokens
+            cacheReadInputTokens = event.usage.cacheReadInputTokens
           }
         }
         break

--- a/sdks/typescript/tests/http.ndjson.test.ts
+++ b/sdks/typescript/tests/http.ndjson.test.ts
@@ -248,4 +248,24 @@ describe('parseNdjson', () => {
     expect(objects[0].message.content).toBe('ok1')
     expect(objects[1].done).toBe(true)
   })
+
+  it('cancels the underlying stream when the consumer exits early', async () => {
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"n":1}\n{"n":2}\n'))
+        // Never close: simulates a long-lived HTTP body held open by the server.
+      },
+      cancel() {
+        cancelled = true
+      }
+    })
+
+    for await (const obj of parseNdjson(stream)) {
+      expect(obj).toEqual({ n: 1 })
+      break // early exit after the first object
+    }
+
+    expect(cancelled).toBe(true)
+  })
 })

--- a/sdks/typescript/tests/http.sse.test.ts
+++ b/sdks/typescript/tests/http.sse.test.ts
@@ -208,4 +208,110 @@ describe('parseSse', () => {
 
     expect(cancelled).toBe(true)
   })
+
+  it('parses CRLF line endings and CRLF CRLF event separators (WHATWG spec)', async () => {
+    // Identical payload to the LF multi-event test, delivered with \r\n.
+    const input =
+      'event: start\r\ndata: {"id":1}\r\n\r\nevent: delta\r\ndata: {"text":"hi"}\r\n\r\nevent: done\r\ndata: [DONE]\r\n\r\n'
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(input))
+        controller.close()
+      }
+    })
+
+    const events: Array<{ event?: string; data: any }> = []
+    for await (const event of parseSse(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toHaveLength(3)
+    expect(events[0].event).toBe('start')
+    expect(events[0].data).toEqual({ id: 1 })
+    expect(events[1].event).toBe('delta')
+    expect(events[1].data).toEqual({ text: 'hi' })
+    expect(events[2].event).toBe('done')
+    expect(events[2].data).toBe('[DONE]')
+  })
+
+  it('parses bare CR line endings and CR CR event separators', async () => {
+    const input = 'event: message\rdata: {"n":1}\r\r'
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(input))
+        controller.close()
+      }
+    })
+
+    const events: Array<{ event?: string; data: any }> = []
+    for await (const event of parseSse(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toHaveLength(1)
+    expect(events[0].event).toBe('message')
+    expect(events[0].data).toEqual({ n: 1 })
+  })
+
+  it('parses a CRLF pair split across chunk boundaries', async () => {
+    const full = 'event: a\r\ndata: {"n":1}\r\n\r\nevent: b\r\ndata: {"n":2}\r\n\r\n'
+    const splitAt = full.indexOf('\r\n\r\n') + 1 // chunk1 ends with a lone \r
+    const chunk1 = full.substring(0, splitAt)
+    const chunk2 = full.substring(splitAt) // starts with \n\r\n
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(chunk1))
+        controller.enqueue(new TextEncoder().encode(chunk2))
+        controller.close()
+      }
+    })
+
+    const events: Array<{ event?: string; data: any }> = []
+    for await (const event of parseSse(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toHaveLength(2)
+    expect(events[0].event).toBe('a')
+    expect(events[0].data).toEqual({ n: 1 })
+    expect(events[1].event).toBe('b')
+    expect(events[1].data).toEqual({ n: 2 })
+  })
+
+  it('preserves data bytes verbatim after removing at most one leading space', async () => {
+    const input = 'data: {"text":"  two leading spaces kept"}\n\n'
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(input))
+        controller.close()
+      }
+    })
+
+    const events: Array<{ event?: string; data: any }> = []
+    for await (const event of parseSse(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toHaveLength(1)
+    expect(events[0].data).toEqual({ text: '  two leading spaces kept' })
+  })
+
+  it('parses a data field with no space after the colon', async () => {
+    const input = 'data:{"n":7}\n\n'
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(input))
+        controller.close()
+      }
+    })
+
+    const events: Array<{ event?: string; data: any }> = []
+    for await (const event of parseSse(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toHaveLength(1)
+    expect(events[0].data).toEqual({ n: 7 })
+  })
 })

--- a/sdks/typescript/tests/http.sse.test.ts
+++ b/sdks/typescript/tests/http.sse.test.ts
@@ -187,4 +187,25 @@ describe('parseSse', () => {
     expect(events[0].event).toBe('last')
     expect(events[0].data).toEqual({ final: true })
   })
+
+  it('cancels the underlying stream when the consumer exits early', async () => {
+    let cancelled = false
+    const input = 'event: first\ndata: {"n":1}\n\nevent: second\ndata: {"n":2}\n\n'
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(input))
+        // Never close: simulates a long-lived HTTP body held open by the server.
+      },
+      cancel() {
+        cancelled = true
+      }
+    })
+
+    for await (const event of parseSse(stream)) {
+      expect(event.data).toEqual({ n: 1 })
+      break // early exit after the first event
+    }
+
+    expect(cancelled).toBe(true)
+  })
 })

--- a/sdks/typescript/tests/stream.test.ts
+++ b/sdks/typescript/tests/stream.test.ts
@@ -179,7 +179,7 @@ describe('stream.ts', () => {
       expect(toolResponse.stopReason).toBe('tool_use')
     })
 
-    it('sums cache tokens with lazy initialization', async () => {
+    it('keeps last-provided cache tokens (replace-with-fallback, not summed)', async () => {
       const events: StreamEvent[] = [
         usageEvent({
           inputTokens: 10,
@@ -204,10 +204,54 @@ describe('stream.ts', () => {
 
       const response = await collectStream(stream)
 
-      expect(response.usage.inputTokens).toBe(17)
-      expect(response.usage.outputTokens).toBe(9)
-      expect(response.usage.cacheCreationInputTokens).toBe(120)
+      expect(response.usage.inputTokens).toBe(2)
+      expect(response.usage.outputTokens).toBe(1)
+      expect(response.usage.cacheCreationInputTokens).toBe(20)
       expect(response.usage.cacheReadInputTokens).toBe(50)
+    })
+
+    it('replaces usage instead of summing (Anthropic cumulative message_delta)', async () => {
+      // Anthropic emits usage on message_start (input tokens + a few output
+      // tokens) and again on message_delta with CUMULATIVE output tokens.
+      // Summing would report 200 input / 55 output.
+      const events: StreamEvent[] = [
+        usageEvent({ inputTokens: 100, outputTokens: 5 }),
+        usageEvent({ inputTokens: 100, outputTokens: 50 }),
+        doneEvent(),
+      ]
+      const stream = (async function* () {
+        for (const ev of events) yield ev
+      })() as BoxStream
+
+      const response = await collectStream(stream)
+
+      expect(response.usage.inputTokens).toBe(100)
+      expect(response.usage.outputTokens).toBe(50)
+    })
+
+    it('zero fields fall back to previous values; absent cache fields are kept', async () => {
+      // message_delta usage carries no input_tokens (adapter maps it to 0)
+      // and no cache fields — neither may clobber message_start values.
+      const events: StreamEvent[] = [
+        usageEvent({
+          inputTokens: 100,
+          outputTokens: 5,
+          cacheCreationInputTokens: 30,
+          cacheReadInputTokens: 70,
+        }),
+        usageEvent({ inputTokens: 0, outputTokens: 50 }),
+        doneEvent(),
+      ]
+      const stream = (async function* () {
+        for (const ev of events) yield ev
+      })() as BoxStream
+
+      const response = await collectStream(stream)
+
+      expect(response.usage.inputTokens).toBe(100)
+      expect(response.usage.outputTokens).toBe(50)
+      expect(response.usage.cacheCreationInputTokens).toBe(30)
+      expect(response.usage.cacheReadInputTokens).toBe(70)
     })
   })
 


### PR DESCRIPTION
## Summary
- parseSse / parseNdjson now `reader.cancel()` before releasing the lock on early exit — an
  abandoned stream (the normal consumption pattern) no longer pins its HTTP connection open.
- SSE parser accepts all WHATWG line terminators (`\r\n`, `\r`, `\n` — including a `\r\n` pair
  split across chunk boundaries) — a spec-valid CRLF stream previously yielded ZERO events and
  read as a clean empty completion. Field parsing now strips at most one leading space after the
  colon and preserves payloads verbatim, per spec.
- collectStream usage merge switches from summing to Python's replace-with-fallback semantics —
  Anthropic's cumulative `message_delta` usage no longer double-counts output tokens
  (billing-visible fix); the old test that encoded the summing behavior is rewritten.

M1 plan Tasks 18–20 (PR-T2): docs/superpowers/plans/2026-07-14-stream-retry-m1-implementation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)