### PR TITLE
fix(stream): index-aware tool buffering, codex call-id mapping, usage replace-merge

### DIFF
--- a/sdks/rust/src/providers/chatgpt_codex.rs
+++ b/sdks/rust/src/providers/chatgpt_codex.rs
@@ -13,7 +13,7 @@ use eventsource_stream::Eventsource;
 use futures_core::Stream;
 use reqwest::Client;
 use serde_json::{json, Value};
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::pin::Pin;
 use std::task::Poll;
 
@@ -295,6 +295,7 @@ impl ProviderImpl for ChatGptCodexProvider {
                     let adapter = ChatGptCodexStreamAdapter {
                         inner: Box::pin(sse),
                         pending: VecDeque::new(),
+                        item_to_call_id: HashMap::new(),
                         seen_tool_ids: HashSet::new(),
                         saw_tool_call: false,
                         error: None,
@@ -328,6 +329,9 @@ struct ChatGptCodexStreamAdapter {
         >,
     >,
     pending: VecDeque<StreamEvent>,
+    /// Map Responses output item ids (`fc_*`) to public tool call ids
+    /// (`call_*`) for argument deltas, which arrive keyed by `item_id`.
+    item_to_call_id: HashMap<String, String>,
     /// `call_id`s seen via `response.output_item.added` (function_call) so the
     /// matching `response.output_item.done` can close the same id.
     seen_tool_ids: HashSet<String>,
@@ -343,8 +347,9 @@ struct ChatGptCodexStreamAdapter {
 impl ChatGptCodexStreamAdapter {
     /// Map a single decoded Responses SSE `data` JSON value to zero or more
     /// [`StreamEvent`]s, queued onto `pending`. Pure (no I/O); the only side
-    /// effects are mutations of `pending` / `seen_tool_ids` / `saw_tool_call`
-    /// / `error`. See the module-level mapping table.
+    /// effects are mutations of `pending` / `item_to_call_id` /
+    /// `seen_tool_ids` / `saw_tool_call` / `error`. See the module-level
+    /// mapping table.
     fn handle_event(&mut self, data: &Value) {
         let event_type = data.get("type").and_then(Value::as_str).unwrap_or("");
 
@@ -383,6 +388,12 @@ impl ChatGptCodexStreamAdapter {
                             .unwrap_or("")
                             .to_string();
                         if !call_id.is_empty() {
+                            if let Some(item_id) = item.get("id").and_then(Value::as_str) {
+                                if !item_id.is_empty() {
+                                    self.item_to_call_id
+                                        .insert(item_id.to_string(), call_id.clone());
+                                }
+                            }
                             self.saw_tool_call = true;
                             self.seen_tool_ids.insert(call_id.clone());
                             self.pending
@@ -394,13 +405,18 @@ impl ChatGptCodexStreamAdapter {
 
             // Streamed tool-call argument fragments. The wire key is `item_id`.
             "response.function_call_arguments.delta" => {
-                let id = data
+                let wire_id = data
                     .get("item_id")
                     .and_then(Value::as_str)
                     .unwrap_or("")
                     .to_string();
                 if let Some(delta) = data.get("delta").and_then(Value::as_str) {
-                    if !id.is_empty() {
+                    if !wire_id.is_empty() {
+                        let id = self
+                            .item_to_call_id
+                            .get(&wire_id)
+                            .cloned()
+                            .unwrap_or(wire_id);
                         self.pending
                             .push_back(StreamEvent::tool_call_args_with_id(&id, delta));
                     }
@@ -737,7 +753,7 @@ mod tests {
         use super::super::ChatGptCodexStreamAdapter;
         use crate::types::{StopReason, StreamEvent, StreamEventType};
         use serde_json::Value;
-        use std::collections::{HashSet, VecDeque};
+        use std::collections::{HashMap, HashSet, VecDeque};
 
         /// A fresh adapter wired to an empty inner stream — `handle_event` is
         /// driven directly, so the `inner` stream is never polled in these
@@ -746,6 +762,7 @@ mod tests {
             ChatGptCodexStreamAdapter {
                 inner: Box::pin(tokio_stream::iter(Vec::new())),
                 pending: VecDeque::new(),
+                item_to_call_id: HashMap::new(),
                 seen_tool_ids: HashSet::new(),
                 saw_tool_call: false,
                 error: None,
@@ -832,15 +849,16 @@ mod tests {
 
         #[test]
         fn adapter_handles_function_call_lifecycle() {
-            // Synthetic added/args.delta/done triple for a function_call item.
+            // Real ChatGPT-backend Responses frames key argument deltas by
+            // output item id (`fc_*`) while public tool events use `call_id`.
             let mut adapter = fresh_adapter();
             let events = drive(
                 &mut adapter,
                 &[
-                    r#"{"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_42","name":"get_weather"}}"#,
-                    r#"{"type":"response.function_call_arguments.delta","item_id":"call_42","delta":"{\"city\":"}"#,
-                    r#"{"type":"response.function_call_arguments.delta","item_id":"call_42","delta":"\"Paris\"}"}"#,
-                    r#"{"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_42","name":"get_weather"}}"#,
+                    r#"{"type":"response.output_item.added","item":{"type":"function_call","id":"fc_001","call_id":"call_001","name":"get_weather"}}"#,
+                    r#"{"type":"response.function_call_arguments.delta","item_id":"fc_001","delta":"{\"city\":"}"#,
+                    r#"{"type":"response.function_call_arguments.delta","item_id":"fc_001","delta":"\"Paris\"}"}"#,
+                    r#"{"type":"response.output_item.done","item":{"type":"function_call","id":"fc_001","call_id":"call_001","name":"get_weather"}}"#,
                     r#"{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":3,"output_tokens":7}}}"#,
                 ],
             );
@@ -849,9 +867,16 @@ mod tests {
                 .iter()
                 .find(|e| e.event_type == StreamEventType::ToolCallStart)
                 .expect("tool_call_start");
-            assert_eq!(start.tool_call_id.as_deref(), Some("call_42"));
+            assert_eq!(start.tool_call_id.as_deref(), Some("call_001"));
             assert_eq!(start.tool_call_name.as_deref(), Some("get_weather"));
 
+            let arg_events: Vec<&StreamEvent> = events
+                .iter()
+                .filter(|e| e.event_type == StreamEventType::ToolCallArgs)
+                .collect();
+            assert_eq!(arg_events.len(), 2);
+            assert_eq!(arg_events[0].tool_call_id.as_deref(), Some("call_001"));
+            assert_eq!(arg_events[1].tool_call_id.as_deref(), Some("call_001"));
             let args: String = events
                 .iter()
                 .filter(|e| e.event_type == StreamEventType::ToolCallArgs)
@@ -863,11 +888,29 @@ mod tests {
                 .iter()
                 .find(|e| e.event_type == StreamEventType::ToolCallEnd)
                 .expect("tool_call_end");
-            assert_eq!(end.tool_call_id.as_deref(), Some("call_42"));
+            assert_eq!(end.tool_call_id.as_deref(), Some("call_001"));
 
             // Any tool call seen => terminal stop reason is ToolUse, not EndTurn.
             let done = events.iter().find(|e| e.done).expect("a done event");
             assert_eq!(done.stop_reason, Some(StopReason::ToolUse));
+        }
+
+        #[test]
+        fn adapter_passes_through_unknown_arg_item_id() {
+            let mut adapter = fresh_adapter();
+            let events = drive(
+                &mut adapter,
+                &[
+                    r#"{"type":"response.function_call_arguments.delta","item_id":"fc_unseen","delta":"{}"}"#,
+                ],
+            );
+
+            let args = events
+                .iter()
+                .find(|e| e.event_type == StreamEventType::ToolCallArgs)
+                .expect("tool_call_args");
+            assert_eq!(args.tool_call_id.as_deref(), Some("fc_unseen"));
+            assert_eq!(args.tool_call_args_delta.as_deref(), Some("{}"));
         }
 
         #[test]
@@ -897,6 +940,7 @@ mod tests {
             let mut adapter = ChatGptCodexStreamAdapter {
                 inner: Box::pin(tokio_stream::iter(items)),
                 pending: VecDeque::new(),
+                item_to_call_id: HashMap::new(),
                 seen_tool_ids: HashSet::new(),
                 saw_tool_call: false,
                 error: None,

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -16,6 +16,7 @@ use eventsource_stream::Eventsource;
 use futures_core::Stream;
 use reqwest::Client;
 use serde_json::{json, Value};
+use std::collections::{BTreeMap, VecDeque};
 use std::pin::Pin;
 use std::task::Poll;
 
@@ -636,8 +637,9 @@ impl ProviderImpl for OpenAIProvider {
         let raw_stream = response.bytes_stream().eventsource();
         let adapter = OpenAIStreamAdapter {
             inner: Box::pin(raw_stream),
-            pending: std::collections::VecDeque::new(),
-            seen_tool_ids: Vec::new(),
+            pending: VecDeque::new(),
+            tool_buffers: BTreeMap::new(),
+            open_tool_index: None,
             pending_stop_reason: None,
             done_emitted: false,
         };
@@ -658,8 +660,9 @@ struct OpenAIStreamAdapter {
                 > + Send,
         >,
     >,
-    pending: std::collections::VecDeque<StreamEvent>,
-    seen_tool_ids: Vec<String>,
+    pending: VecDeque<StreamEvent>,
+    tool_buffers: BTreeMap<u64, ToolBuf>,
+    open_tool_index: Option<u64>,
     /// Captured from the last chunk's `choices[0].finish_reason`. Stashed
     /// rather than emitted immediately so we can attach it to a single
     /// terminal `done` event when the `[DONE]` sentinel arrives — this
@@ -671,9 +674,17 @@ struct OpenAIStreamAdapter {
     done_emitted: bool,
 }
 
+#[derive(Debug, Default)]
+struct ToolBuf {
+    id: String,
+    name: String,
+    args: String,
+}
+
 impl OpenAIStreamAdapter {
     fn parse_event(&mut self, data: &str) -> bool {
         if data.trim() == "[DONE]" {
+            self.flush_tool_calls();
             // Emit a single terminal done event, attaching any stop_reason
             // captured from the previous chunk's finish_reason field.
             let done = match self.pending_stop_reason.take() {
@@ -722,23 +733,44 @@ impl OpenAIStreamAdapter {
             // Tool calls in delta
             if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
                 for tc in tool_calls {
-                    let tc_id = tc.get("id").and_then(Value::as_str);
+                    let index = tc.get("index").and_then(Value::as_u64).unwrap_or(0);
+                    let tc_id = tc
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .filter(|id| !id.is_empty());
                     let function = tc.get("function");
-                    let tc_name = function.and_then(|f| f.get("name")).and_then(Value::as_str);
+                    let tc_name = function
+                        .and_then(|f| f.get("name"))
+                        .and_then(Value::as_str)
+                        .filter(|name| !name.is_empty());
                     let tc_args = function
                         .and_then(|f| f.get("arguments"))
                         .and_then(Value::as_str);
 
                     if let (Some(id), Some(name)) = (tc_id, tc_name) {
-                        self.seen_tool_ids.push(id.to_string());
-                        self.pending
-                            .push_back(StreamEvent::tool_call_start(id, name));
+                        let buf = self.tool_buffers.entry(index).or_default();
+                        buf.id = id.to_string();
+                        buf.name = name.to_string();
+
+                        if self.open_tool_index.is_none() {
+                            self.open_tool_index = Some(index);
+                            self.pending
+                                .push_back(StreamEvent::tool_call_start(id, name));
+                        }
                     }
+
                     if let Some(args) = tc_args {
                         if !args.is_empty() {
-                            let id = tc_id.unwrap_or("");
-                            self.pending
-                                .push_back(StreamEvent::tool_call_args_with_id(id, args));
+                            let Some(buf) = self.tool_buffers.get_mut(&index) else {
+                                continue;
+                            };
+
+                            if self.open_tool_index == Some(index) {
+                                self.pending
+                                    .push_back(StreamEvent::tool_call_args_with_id(&buf.id, args));
+                            } else {
+                                buf.args.push_str(args);
+                            }
                         }
                     }
                 }
@@ -750,16 +782,39 @@ impl OpenAIStreamAdapter {
         let finish_reason = choice.get("finish_reason").and_then(Value::as_str);
         if let Some(reason) = finish_reason {
             if reason == "tool_calls" {
-                let ids: Vec<String> = self.seen_tool_ids.drain(..).collect();
-                for id in &ids {
-                    self.pending
-                        .push_back(StreamEvent::tool_call_end_with_id(id));
-                }
+                self.flush_tool_calls();
             }
             self.pending_stop_reason = Some(map_finish_reason(reason));
         }
 
         false
+    }
+
+    fn flush_tool_calls(&mut self) {
+        if let Some(index) = self.open_tool_index.take() {
+            if let Some(buf) = self.tool_buffers.remove(&index) {
+                if !buf.id.is_empty() {
+                    self.pending
+                        .push_back(StreamEvent::tool_call_end_with_id(buf.id));
+                }
+            }
+        }
+
+        let buffers = std::mem::take(&mut self.tool_buffers);
+        for (_, buf) in buffers {
+            if buf.id.is_empty() || buf.name.is_empty() {
+                continue;
+            }
+
+            self.pending
+                .push_back(StreamEvent::tool_call_start(&buf.id, &buf.name));
+            if !buf.args.is_empty() {
+                self.pending
+                    .push_back(StreamEvent::tool_call_args_with_id(&buf.id, &buf.args));
+            }
+            self.pending
+                .push_back(StreamEvent::tool_call_end_with_id(buf.id));
+        }
     }
 }
 
@@ -844,8 +899,9 @@ mod tests {
         let inner = tokio_stream::iter(vec![Err(EventStreamError::Utf8(utf8))]);
         let mut adapter = OpenAIStreamAdapter {
             inner: Box::pin(inner),
-            pending: std::collections::VecDeque::new(),
-            seen_tool_ids: Vec::new(),
+            pending: VecDeque::new(),
+            tool_buffers: BTreeMap::new(),
+            open_tool_index: None,
             pending_stop_reason: None,
             done_emitted: false,
         };

--- a/sdks/rust/src/stream.rs
+++ b/sdks/rust/src/stream.rs
@@ -73,13 +73,21 @@ pub async fn collect_stream(
             }
             StreamEventType::Usage => {
                 if let Some(ref usage) = event.usage {
-                    input_tokens += usage.input_tokens;
-                    output_tokens += usage.output_tokens;
+                    // Mirror Python collection semantics: Anthropic emits
+                    // cumulative usage, so token counts are last-writer-wins
+                    // and later zero values do not erase earlier non-zero
+                    // counts. Cache fields replace whenever reported.
+                    if usage.input_tokens != 0 {
+                        input_tokens = usage.input_tokens;
+                    }
+                    if usage.output_tokens != 0 {
+                        output_tokens = usage.output_tokens;
+                    }
                     if let Some(v) = usage.cache_creation_input_tokens {
-                        *cache_creation_input_tokens.get_or_insert(0) += v;
+                        cache_creation_input_tokens = Some(v);
                     }
                     if let Some(v) = usage.cache_read_input_tokens {
-                        *cache_read_input_tokens.get_or_insert(0) += v;
+                        cache_read_input_tokens = Some(v);
                     }
                 }
             }

--- a/sdks/rust/tests/chatgpt_codex_live.rs
+++ b/sdks/rust/tests/chatgpt_codex_live.rs
@@ -1,0 +1,91 @@
+//! Live ChatGptCodexProvider smoke test.
+//!
+//! This hits the real ChatGPT-backend API and requires `~/.codex/auth.json`.
+//! Run manually with:
+//! `cargo test --features chatgpt-codex --test chatgpt_codex_live -- --ignored --nocapture`
+
+#![cfg(feature = "chatgpt-codex")]
+
+use motosan_ai::providers::chatgpt_codex::ChatGptCodexProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, Message, StreamEventType, Tool, ToolSchema};
+use serde_json::{json, Value};
+use std::{env, fs};
+use tokio_stream::StreamExt;
+
+fn load_codex_auth() -> Option<(String, String)> {
+    let home = env::var("HOME").ok()?;
+    let path = std::path::Path::new(&home).join(".codex/auth.json");
+    let raw = fs::read_to_string(path).ok()?;
+    let auth: Value = serde_json::from_str(&raw).ok()?;
+    let tokens = auth.get("tokens")?;
+    let access_token = tokens.get("access_token")?.as_str()?.to_string();
+    let account_id = tokens.get("account_id")?.as_str()?.to_string();
+    Some((access_token, account_id))
+}
+
+#[tokio::test]
+#[ignore = "live: makes a real chatgpt.com call; needs ~/.codex/auth.json"]
+async fn live_codex_streamed_tool_call_ids_are_consistent() {
+    let Some((access_token, account_id)) = load_codex_auth() else {
+        eprintln!("skipping live test: missing ~/.codex/auth.json tokens");
+        return;
+    };
+
+    let provider = ChatGptCodexProvider::new(access_token, account_id, "gpt-5.5", None);
+    let add_schema = ToolSchema::new(
+        "add",
+        "Add two integers.",
+        json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": "integer"}
+            },
+            "required": ["a", "b"]
+        }),
+    );
+    let tool = Tool::from(add_schema);
+    let request = ChatRequest::builder()
+        .messages(vec![Message::user(
+            "You MUST call the `add` tool with a=2 and b=3. Do not answer in text.",
+        )])
+        .tools(vec![tool])
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream starts");
+    let mut events = Vec::new();
+    while let Some(item) = stream.next().await {
+        events.push(item.expect("stream event"));
+    }
+
+    let start = events
+        .iter()
+        .find(|event| event.event_type == StreamEventType::ToolCallStart)
+        .expect("tool call start");
+    let call_id = start.tool_call_id.as_deref().expect("tool call start id");
+    assert!(
+        call_id.starts_with("call_"),
+        "expected call_* id, got {call_id}"
+    );
+
+    let mut args = String::new();
+    for event in events
+        .iter()
+        .filter(|event| event.event_type == StreamEventType::ToolCallArgs)
+    {
+        assert_eq!(event.tool_call_id.as_deref(), Some(call_id));
+        args.push_str(event.tool_call_args_delta.as_deref().expect("args delta"));
+    }
+
+    let parsed_args: Value = serde_json::from_str(&args).expect("tool args json");
+    let parsed_obj = parsed_args.as_object().expect("tool args object");
+    assert_eq!(parsed_obj.get("a"), Some(&json!(2)));
+    assert_eq!(parsed_obj.get("b"), Some(&json!(3)));
+
+    let end = events
+        .iter()
+        .find(|event| event.event_type == StreamEventType::ToolCallEnd)
+        .expect("tool call end");
+    assert_eq!(end.tool_call_id.as_deref(), Some(call_id));
+}

--- a/sdks/rust/tests/collect_stream.rs
+++ b/sdks/rust/tests/collect_stream.rs
@@ -426,3 +426,76 @@ async fn anthropic_stream_emits_max_tokens_stop_reason() {
 
     mock.assert_async().await;
 }
+
+// ---------------------------------------------------------------------------
+// Usage merge semantics: last-writer-wins per field, never summed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn collect_stream_usage_is_last_writer_wins_not_summed() {
+    let events = vec![
+        StreamEvent::usage(motosan_ai::Usage {
+            input_tokens: 100,
+            output_tokens: 5,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        }),
+        StreamEvent::text("hi"),
+        StreamEvent::usage(motosan_ai::Usage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        }),
+        StreamEvent::done(),
+    ];
+    let response = collect_stream(boxed_stream(events)).await.unwrap();
+
+    assert_eq!(response.usage.input_tokens, 100);
+    assert_eq!(response.usage.output_tokens, 50);
+}
+
+#[tokio::test]
+async fn collect_stream_usage_single_event_unchanged() {
+    let events = vec![
+        StreamEvent::text("done"),
+        StreamEvent::usage(motosan_ai::Usage {
+            input_tokens: 20,
+            output_tokens: 9,
+            cache_creation_input_tokens: Some(3),
+            cache_read_input_tokens: Some(4),
+        }),
+        StreamEvent::done(),
+    ];
+    let response = collect_stream(boxed_stream(events)).await.unwrap();
+
+    assert_eq!(response.usage.input_tokens, 20);
+    assert_eq!(response.usage.output_tokens, 9);
+    assert_eq!(response.usage.cache_creation_input_tokens, Some(3));
+    assert_eq!(response.usage.cache_read_input_tokens, Some(4));
+}
+
+#[tokio::test]
+async fn collect_stream_usage_zero_does_not_clobber_and_cache_replaces() {
+    let events = vec![
+        StreamEvent::usage(motosan_ai::Usage {
+            input_tokens: 100,
+            output_tokens: 1,
+            cache_creation_input_tokens: Some(7),
+            cache_read_input_tokens: Some(11),
+        }),
+        StreamEvent::usage(motosan_ai::Usage {
+            input_tokens: 0,
+            output_tokens: 50,
+            cache_creation_input_tokens: Some(7),
+            cache_read_input_tokens: Some(11),
+        }),
+        StreamEvent::done(),
+    ];
+    let response = collect_stream(boxed_stream(events)).await.unwrap();
+
+    assert_eq!(response.usage.input_tokens, 100);
+    assert_eq!(response.usage.output_tokens, 50);
+    assert_eq!(response.usage.cache_creation_input_tokens, Some(7));
+    assert_eq!(response.usage.cache_read_input_tokens, Some(11));
+}

--- a/sdks/rust/tests/openai_live.rs
+++ b/sdks/rust/tests/openai_live.rs
@@ -7,7 +7,8 @@
 
 #![cfg(feature = "openai")]
 
-use motosan_ai::{ChatRequest, Client, Message, Provider, StopReason};
+use motosan_ai::{ChatRequest, Client, Message, Provider, StopReason, Tool};
+use serde_json::json;
 use std::time::Duration;
 use tokio_stream::StreamExt;
 
@@ -97,6 +98,87 @@ async fn live_openai_collect_stream_records_max_tokens_on_chat_response() {
         "collect_stream should backfill MaxTokens from terminal done event, got: {:?}",
         response.stop_reason
     );
+
+    cooldown().await;
+}
+
+#[tokio::test]
+async fn live_openai_parallel_tool_calls_collect_intact() {
+    let Some(client) = client() else {
+        eprintln!("OPENAI_API_KEY not set, skipping");
+        return;
+    };
+
+    let tools = vec![
+        Tool {
+            schema: motosan_agent_primitives::ToolSchema {
+                name: "get_weather".to_string(),
+                description: "Get current weather for a city.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "city": {
+                            "type": "string",
+                            "description": "City name"
+                        }
+                    },
+                    "required": ["city"]
+                }),
+            },
+            cache: false,
+        },
+        Tool {
+            schema: motosan_agent_primitives::ToolSchema {
+                name: "get_time".to_string(),
+                description: "Get current local time for a timezone.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "tz": {
+                            "type": "string",
+                            "description": "IANA timezone name"
+                        }
+                    },
+                    "required": ["tz"]
+                }),
+            },
+            cache: false,
+        },
+    ];
+
+    let request = ChatRequest::builder()
+        .message(Message::user(
+            "Call both tools in this turn: get_weather with city Taipei, and get_time with tz Asia/Tokyo.",
+        ))
+        .tools(tools)
+        .tool_choice(motosan_ai::ToolChoice::Required)
+        .provider_options(json!({"parallel_tool_calls": true}))
+        .build();
+
+    let stream = client.stream_with(request).await.expect("stream failed");
+    let response = motosan_ai::collect_stream(stream).await.unwrap();
+
+    assert!(
+        !response.tool_calls.is_empty(),
+        "expected at least one streamed tool call"
+    );
+    assert!(
+        response
+            .tool_calls
+            .iter()
+            .all(|tool_call| !tool_call.id.is_empty() && !tool_call.name.is_empty()),
+        "tool call ids and names should be non-empty: {:?}",
+        response.tool_calls
+    );
+    assert!(
+        response
+            .tool_calls
+            .iter()
+            .all(|tool_call| tool_call.input.is_object()),
+        "tool call inputs should be JSON objects: {:?}",
+        response.tool_calls
+    );
+    assert_eq!(response.stop_reason, StopReason::ToolUse);
 
     cooldown().await;
 }

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -448,6 +448,142 @@ async fn openai_stream_emits_tool_call_events() {
 }
 
 #[tokio::test]
+async fn openai_stream_parallel_tool_calls_interleaved_stay_sequential_per_call() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_A\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_B\",\"function\":{\"name\":\"get_time\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"city\\\":\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\"{\\\"tz\\\":\\\"Asia/Tokyo\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"Taipei\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None)
+        .with_chat_url(format!("{}/v1/chat/completions", server.url()));
+    let request = ChatRequest::builder()
+        .message(Message::user("weather in Taipei and time in Tokyo?"))
+        .tools(vec![
+            Tool {
+                schema: motosan_agent_primitives::ToolSchema {
+                    name: "get_weather".to_string(),
+                    description: "Get weather".to_string(),
+                    input_schema: json!({
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}}
+                    }),
+                },
+                cache: false,
+            },
+            Tool {
+                schema: motosan_agent_primitives::ToolSchema {
+                    name: "get_time".to_string(),
+                    description: "Get local time".to_string(),
+                    input_schema: json!({
+                        "type": "object",
+                        "properties": {"tz": {"type": "string"}}
+                    }),
+                },
+                cache: false,
+            },
+        ])
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut received = Vec::new();
+    while let Some(event_item) = stream.next().await {
+        let event = event_item.expect("stream item should not fail");
+        received.push(event);
+    }
+
+    let tool_sequence: Vec<_> = received
+        .iter()
+        .filter(|event| {
+            matches!(
+                event.event_type,
+                StreamEventType::ToolCallStart
+                    | StreamEventType::ToolCallArgs
+                    | StreamEventType::ToolCallEnd
+            )
+        })
+        .map(|event| {
+            (
+                event.event_type.clone(),
+                event.tool_call_id.as_deref(),
+                event.tool_call_name.as_deref(),
+                event.tool_call_args_delta.as_deref(),
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        tool_sequence,
+        vec![
+            (
+                StreamEventType::ToolCallStart,
+                Some("call_A"),
+                Some("get_weather"),
+                None
+            ),
+            (
+                StreamEventType::ToolCallArgs,
+                Some("call_A"),
+                None,
+                Some("{\"city\":")
+            ),
+            (
+                StreamEventType::ToolCallArgs,
+                Some("call_A"),
+                None,
+                Some("\"Taipei\"}")
+            ),
+            (StreamEventType::ToolCallEnd, Some("call_A"), None, None),
+            (
+                StreamEventType::ToolCallStart,
+                Some("call_B"),
+                Some("get_time"),
+                None
+            ),
+            (
+                StreamEventType::ToolCallArgs,
+                Some("call_B"),
+                None,
+                Some("{\"tz\":\"Asia/Tokyo\"}")
+            ),
+            (StreamEventType::ToolCallEnd, Some("call_B"), None, None),
+        ]
+    );
+
+    let collected_stream = Box::pin(tokio_stream::iter(
+        received.into_iter().map(Ok::<_, MotosanError>),
+    ));
+    let response = motosan_ai::collect_stream(collected_stream)
+        .await
+        .expect("collect stream");
+
+    assert_eq!(response.tool_calls.len(), 2);
+    assert_eq!(response.tool_calls[0].id, "call_A");
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+    assert_eq!(response.tool_calls[0].input, json!({"city": "Taipei"}));
+    assert_eq!(response.tool_calls[1].id, "call_B");
+    assert_eq!(response.tool_calls[1].name, "get_time");
+    assert_eq!(response.tool_calls[1].input, json!({"tz": "Asia/Tokyo"}));
+    assert_eq!(response.stop_reason, StopReason::ToolUse);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn openai_stream_propagates_finish_reason_max_tokens() {
     let mut server = mockito::Server::new_async().await;
     let sse_body = concat!(


### PR DESCRIPTION
## Summary
- OpenAI stream adapter now keys parallel tool calls by `tool_calls[].index`, buffers argument deltas per index, and flushes whole calls sequentially so parallel calls are no longer dropped, merged, or emitted as phantom empty-id calls.
- chatgpt-codex streamed argument deltas keyed by wire `item_id` (`fc_…`) are translated to the call's `call_id` (`call_…`), with distinct-id fixtures and a new ignored live smoke for the real wire shape.
- `collect_stream` usage merge now mirrors Python replace-with-fallback semantics, so cumulative Anthropic usage no longer double-counts tokens while single-final-usage streams remain correct.

M1 plan Tasks 13, 14, 21 (PR-R3): docs/superpowers/plans/2026-07-14-stream-retry-m1-implementation.md

## Verification
- `cargo fmt`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
- `./scripts/pre-push-gate.sh` (Python unit, Rust unit, Python live Anthropic, Rust live Anthropic)