### PR TITLE
chore(release): M1 reliability release — Rust 0.22.0 / Python 0.15.0 / TS 0.12.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,13 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`) + TypeScript (`sdks/typescript/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.21.1 · Python v0.14.0 (PyPI) · TypeScript v0.11.0 (npm)
+Rust v0.22.0 · Python v0.15.0 (PyPI) · TypeScript v0.12.0 (npm)
 
 Python 0.13.0 adds CLI-runtime setters (`.cwd()`, session continuity via `session_id` + `resume()`, per-run `.env()/.envs()`, CLI tool-call stream events, configurable `.timeout()/.no_timeout()`) and a **breaking** fallible stream: HTTP provider `stream()` now raises `motosan_ai.error.StreamError` mid-stream instead of swallowing transport/parse faults (`collect_stream` propagates it; `Client.stream_with` does not retry after a mid-stream raise).
 
 Python 0.14.0 and TypeScript 0.11.0 add the **chatgpt-codex** provider — a native ChatGPT-backend HTTP client over the OpenAI Responses API (`chatgpt.com/backend-api/codex/responses`; pre-obtained OAuth token + account id, no `api_key`). Python: `Client.chatgpt_codex(access_token, account_id, model, reasoning_effort=None)`; TypeScript: `Client.builder().chatgptCodex(accessToken, accountId, model?, { reasoningEffort })`. Mirrors the Rust `ChatGptCodexProvider`.
+
+Rust 0.22.0 / Python 0.15.0 / TypeScript 0.12.0 are the M1 reliability releases: retry survives non-JSON 5xx bodies, mid-stream error frames, Claude Code terminal error results, and CLI child-process death surface as errors, parallel tool-call `index` and chatgpt-codex `item_id`→`call_id` are handled correctly, Rust/TypeScript streamed usage merges by replacement, Python streamed tool turns report the tool-use stop reason, and the TypeScript SSE reader cancels on abort and accepts CRLF.
 
 ## Current Rust Tool Schema Note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [rust-0.22.0 / python-0.15.0 / ts-0.12.0] — 2026-07-15
+
+M1 reliability release — cross-SDK bug-fix pass. No new features, no public API changes.
+
+### Fixed
+
+- **Retry on non-JSON 5xx** (Rust · Python): a 5xx response whose body is not valid JSON no longer breaks the retry loop — classification falls back to the HTTP status code, so transient server errors are retried again. (TypeScript already classified by status at baseline.)
+- **Mid-stream error frames surfaced** (Rust · Python · TypeScript): Anthropic provider `error` events and TypeScript chatgpt-codex `error` / `response.failed` frames arriving mid-stream now surface as stream errors instead of being dropped and letting the stream end as if the turn had completed.
+- **CLI failures surfaced** (Rust · Python): a `claude` / `codex` / `gemini` child process dying mid-run, and Claude Code terminal error results, now produce explicit errors instead of a silently truncated, seemingly successful response.
+- **Parallel tool-call index handling** (Rust · Python): OpenAI-style streamed tool calls are keyed by `tool_calls[].index`, so parallel calls are no longer dropped or merged. Rust additionally buffers argument deltas per index and flushes calls whole; TypeScript already keyed by index at baseline.
+- **chatgpt-codex `item_id` → `call_id`** (Rust · Python · TypeScript): function-call events are correlated by `item_id` and emitted with the correct `call_id`, fixing tool-call round-trips when the two ids differ.
+- **Streamed tool-call stop reason** (Python): streamed turns that emit tool calls now finish with the tool-use stop reason instead of a generic end-of-turn.
+- **Usage replace-merge** (Rust · TypeScript): later usage frames replace previously seen fields instead of accumulating into double-counted totals.
+- **Stream cancel + CRLF SSE** (TypeScript): aborting a stream now cancels the underlying `ReadableStream` reader (releasing the HTTP connection), and the SSE parser accepts `\r\n` line terminators.
+
+Per-SDK detail: [`sdks/rust/CHANGELOG.md`](sdks/rust/CHANGELOG.md), [`sdks/python/CHANGELOG.md`](sdks/python/CHANGELOG.md), [`sdks/typescript/CHANGELOG.md`](sdks/typescript/CHANGELOG.md).
+
 ## [rust-0.18.0] — 2026-05-29
 
 ### Breaking (Rust only)

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.18.0 |
-| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.12.1 |
-| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) | v0.10.0 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.22.0 |
+| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.15.0 |
+| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) | v0.12.0 |
 
 ## Install
 
 ```toml
 # Rust (Cargo.toml)
 [dependencies]
-motosan-ai = { version = "0.18.0", features = ["anthropic"] }
+motosan-ai = { version = "0.22.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.14.0 · TypeScript 0.11.0 · Rust 0.21.1
+- Python 0.15.0 · TypeScript 0.12.0 · Rust 0.22.0
 - Python 0.13.0: CLI-runtime setters (`.cwd()`, `session_id` + `resume()`, `.env()/.envs()`, CLI tool-call stream events, `.timeout()/.no_timeout()`) and a **breaking** fallible stream — HTTP provider `stream()` raises `motosan_ai.error.StreamError` mid-stream instead of swallowing transport/parse faults (`collect_stream` propagates it; `Client.stream_with` does not retry after a mid-stream raise).
 - Python 0.14.0 / TypeScript 0.11.0: **chatgpt-codex** provider — native ChatGPT-backend HTTP client over the OpenAI Responses API (`chatgpt.com/backend-api/codex/responses`; pre-obtained OAuth token + account id, no `api_key`). Python `Client.chatgpt_codex(...)`, TypeScript `Client.builder().chatgptCodex(...)`.
 - GitHub: https://github.com/motosan-dev/motosan-ai
@@ -21,7 +21,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.20.0", features = ["anthropic"] }
+motosan-ai = { version = "0.22.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient):
@@ -920,7 +920,7 @@ Python, Rust, and TypeScript SDKs are versioned and released **independently**.
 |--------------|-----------------------|-----------------------|
 | Python       | `python-vX.Y.Z`       | `python-v0.4.2`       |
 | Rust         | `rust-vX.Y.Z`         | `rust-v0.3.3`         |
-| TypeScript   | `ts-vX.Y.Z`           | `ts-v0.11.0`          |
+| TypeScript   | `ts-vX.Y.Z`           | `ts-v0.12.0`          |
 | motosan-ai-oauth | `motosan-ai-oauth-vX.Y.Z` | `motosan-ai-oauth-v0.2.0` |
 | codex-oauth  | `codex-oauth-vX.Y.Z`  | `codex-oauth-v0.1.0`  |
 | anthropic-oauth | `anthropic-oauth-vX.Y.Z` | `anthropic-oauth-v0.1.0` |

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `motosan-ai` Python SDK are documented in this file.
 
+## [0.15.0] - 2026-07-15
+
+### Fixed
+- Retry: 5xx responses with non-JSON bodies are classified by HTTP status and retried instead of aborting the retry loop.
+- Streaming: mid-stream `error` frames raise `StreamError` instead of being dropped.
+- Claude Code: `is_error` terminal results raise `StreamError` instead of being dropped.
+- CLI providers (`claude_code` / `codex_cli` / `gemini_cli`): child-process death mid-run surfaces as an error instead of a truncated success.
+- OpenAI streaming: parallel tool calls are keyed by `tool_calls[].index` (ports the TypeScript adapter), so parallel calls are no longer dropped or merged.
+- chatgpt-codex: function-call events are correlated by `item_id` and emitted with the correct `call_id`.
+- Streaming: turns that emit tool calls now finish with the tool-use stop reason instead of a generic end-of-turn.
+
 ## [0.14.0] - 2026-06-23
 
 ### Added

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motosan-ai"
-version = "0.14.0"
+version = "0.15.0"
 description = "Python SDK for Anthropic, OpenAI, MiniMax, Gemini, Ollama, and CLI AI providers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-15
+
+### Fixed
+- Retry: 5xx responses with non-JSON bodies are classified by HTTP status and retried instead of aborting the retry loop.
+- Streaming: mid-stream `error` frames surface as stream errors instead of being dropped.
+- Claude Code: error-subtype terminal events surface as errors instead of being dropped.
+- CLI providers (`claude-code` / `codex-cli` / `gemini-cli`): child-process death mid-run surfaces as an error instead of a truncated success.
+- OpenAI streaming: parallel tool calls are buffered per `tool_calls[].index` and flushed whole, so interleaved argument deltas no longer corrupt one another.
+- chatgpt-codex: function-call events are correlated by `item_id` and emitted with the correct `call_id`.
+- Streaming usage: later usage frames replace earlier fields instead of double-counting.
+
 ## 0.21.1 — 2026-06-13
 
 ### Added

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@motosan-ai/sdk` TypeScript SDK are documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.12.0] - 2026-07-15
+
+### Fixed
+- Streaming: mid-stream `error` frames surface as stream errors instead of being dropped.
+- chatgpt-codex: `error` / `response.failed` frames now reject the stream instead of ending it silently.
+- Streaming: aborting a stream cancels the underlying `ReadableStream` reader, releasing the HTTP connection.
+- SSE parser accepts `\r\n` (CRLF) line terminators and strips at most one leading space after `data:` per the SSE spec.
+- chatgpt-codex: function-call events are correlated by `item_id` and emitted with the correct `call_id`.
+- Usage: later usage frames replace earlier fields instead of double-counting.
+
 ## [0.11.0] - 2026-06-23
 
 ### Added

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@motosan-ai/sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@motosan-ai/sdk",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.13.10",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motosan-ai/sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Multi-provider TypeScript/ESM SDK for Anthropic, OpenAI, MiniMax, Ollama, Gemini, and ChatGPT Codex. Self-implemented wire protocol via native fetch — zero official-provider-SDK dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.14.0 / Rust 0.20.0 / TypeScript 0.11.0
+Multi-provider LLM SDK — Python 0.15.0 / Rust 0.22.0 / TypeScript 0.12.0
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI, ChatGPT Codex (Responses API)
 
@@ -22,7 +22,7 @@ pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.20.0", features = ["anthropic"] }
+motosan-ai = { version = "0.22.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli

--- a/uv.lock
+++ b/uv.lock
@@ -95,7 +95,7 @@ wheels = [
 
 [[package]]
 name = "motosan-ai"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "sdks/python" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Version bumps for the M1 stream/retry reliability release: Rust 0.21.1 → 0.22.0,
  Python 0.14.0 → 0.15.0, TypeScript 0.11.0 → 0.12.0.
- Root + per-SDK changelog entries for the 7 merged M1 PRs (#211–#217), cross-checked
  bullet-by-bullet against `git log 3e3f413..HEAD`.
- Doc version lines updated: AGENTS.md, llms.txt, skills/motosan-ai/SKILL.md, README.md.
- No source changes. Tagging + publishing to follow per llms.txt § Release after merge.

M1 plan Task 22 (PR-REL): docs/superpowers/plans/2026-07-14-stream-retry-m1-implementation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)