### PR TITLE
docs: bump stale install/tag version examples to the M1 release

### DIFF
--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -320,7 +320,7 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
 ```toml
-motosan-ai = { version = "0.19.0", features = ["claude-code"] }
+motosan-ai = { version = "0.22.0", features = ["claude-code"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -430,7 +430,7 @@ Notes:
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
 ```toml
-motosan-ai = { version = "0.19.0", features = ["codex-cli"] }
+motosan-ai = { version = "0.22.0", features = ["codex-cli"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -494,7 +494,7 @@ Notes:
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
 ```toml
-motosan-ai = { version = "0.19.0", features = ["gemini-cli"] }
+motosan-ai = { version = "0.22.0", features = ["gemini-cli"] }
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -482,8 +482,8 @@ Automated via `publish-typescript.yml` on a `ts-v*` tag push → npm.
 
 ```bash
 # Bump sdks/typescript/package.json version + CHANGELOG, then:
-git tag ts-v0.11.0
-git push origin ts-v0.11.0
+git tag ts-v0.12.0
+git push origin ts-v0.12.0
 ```
 
 The Rust, Python, and TypeScript SDKs are versioned and released independently.

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-motosan-ai = { version = "0.17.1", features = ["anthropic"] }
+motosan-ai = { version = "0.22.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```


### PR DESCRIPTION
## Summary
Post-M1-release cleanup: the release PR (#218, rust-v0.22.0 / py-v0.15.0 / ts-v0.12.0) updated the root README, AGENTS.md, llms.txt, and SKILL.md, but a few copy-paste **install/tag examples** in secondary docs were left at pre-release versions. Following those examples verbatim would install/tag a stale version.

- `sdks/rust/README.md` — three `Cargo.toml` install snippets (claude-code / codex-cli / gemini-cli): `0.19.0` → `0.22.0`
- `skills/motosan-ai/references/rust-api.md` — `Cargo.toml` install snippet: `0.17.1` → `0.22.0`
- `sdks/typescript/README.md` — the Publishing walkthrough tag example: `ts-v0.11.0` → `ts-v0.12.0`

Docs only — no source or manifest changes. Historical feature-provenance mentions ("since v0.11.0", "removed in 0.18.0", the llms.txt chatgpt-codex `v0.14.0`/`v0.11.0` provenance headers) are intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)