### PR TITLE
feat(rust): structured error metadata + Retry-After/jitter/on_retry (M2, BREAKING)

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -82,6 +82,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
 thiserror = "2"
+fastrand = "2"
 
 motosan-agent-primitives = "0.4.0"
 bytes = { version = "1", optional = true }

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -16,12 +16,14 @@ categories = ["api-bindings", "asynchronous"]
 default = []
 anthropic = [
   "dep:reqwest",
+  "dep:chrono",
   "dep:eventsource-stream",
   "dep:tokio-stream",
   "dep:tokio",
 ]
 openai = [
   "dep:reqwest",
+  "dep:chrono",
   "dep:eventsource-stream",
   "dep:tokio-stream",
   "dep:tokio",
@@ -39,6 +41,7 @@ codex-cli = ["dep:tokio", "dep:tokio-stream", "dep:async-stream"]
 gemini-cli = ["dep:tokio", "dep:tokio-stream", "dep:async-stream"]
 gemini = [
   "dep:reqwest",
+  "dep:chrono",
   "dep:eventsource-stream",
   "dep:tokio-stream",
   "dep:tokio",
@@ -46,6 +49,7 @@ gemini = [
 gemini-code-assist = [
   "gemini",
   "dep:reqwest",
+  "dep:chrono",
   "dep:eventsource-stream",
   "dep:tokio-stream",
   "dep:tokio",
@@ -55,6 +59,7 @@ gemini-code-assist = [
 # feature itself.
 chatgpt-codex = [
   "dep:reqwest",
+  "dep:chrono",
   "dep:eventsource-stream",
   "dep:tokio-stream",
   "dep:tokio",
@@ -80,6 +85,9 @@ thiserror = "2"
 
 motosan-agent-primitives = "0.4.0"
 bytes = { version = "1", optional = true }
+chrono = { version = "0.4", optional = true, default-features = false, features = [
+  "clock",
+] }
 reqwest = { version = "0.12", optional = true, features = [
   "json",
   "stream",

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -1,17 +1,38 @@
+use std::time::Duration;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Error)]
 pub enum MotosanError {
-    #[error("auth error: {0}")]
-    Auth(String),
-    #[error("rate limit error: {0}")]
-    RateLimit(String),
-    #[error("invalid request: {0}")]
-    InvalidRequest(String),
+    #[error("auth error: {message}")]
+    Auth {
+        message: String,
+        status_code: Option<u16>,
+        retry_after: Option<Duration>,
+        request_id: Option<String>,
+    },
+    #[error("rate limit error: {message}")]
+    RateLimit {
+        message: String,
+        status_code: Option<u16>,
+        retry_after: Option<Duration>,
+        request_id: Option<String>,
+    },
+    #[error("invalid request: {message}")]
+    InvalidRequest {
+        message: String,
+        status_code: Option<u16>,
+        retry_after: Option<Duration>,
+        request_id: Option<String>,
+    },
     #[error("config error: {0}")]
     Config(String),
-    #[error("provider error: {0}")]
-    ProviderError(String),
+    #[error("provider error: {message}")]
+    ProviderError {
+        message: String,
+        status_code: Option<u16>,
+        retry_after: Option<Duration>,
+        request_id: Option<String>,
+    },
     #[error("network error: {0}")]
     Network(String),
     #[error("stream error: {0}")]
@@ -20,4 +41,130 @@ pub enum MotosanError {
     StreamReadTimeout(u64),
     #[error("unsupported feature: {0}")]
     UnsupportedFeature(String),
+}
+
+impl MotosanError {
+    /// HTTP status that produced this error, when it came from an HTTP response.
+    pub fn status_code(&self) -> Option<u16> {
+        match self {
+            Self::Auth { status_code, .. }
+            | Self::RateLimit { status_code, .. }
+            | Self::InvalidRequest { status_code, .. }
+            | Self::ProviderError { status_code, .. } => *status_code,
+            _ => None,
+        }
+    }
+
+    /// Parsed `Retry-After` from the failing HTTP response, if present.
+    pub fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::Auth { retry_after, .. }
+            | Self::RateLimit { retry_after, .. }
+            | Self::InvalidRequest { retry_after, .. }
+            | Self::ProviderError { retry_after, .. } => *retry_after,
+            _ => None,
+        }
+    }
+
+    /// Provider request id (`request-id` / `x-request-id` header), if present.
+    pub fn request_id(&self) -> Option<&str> {
+        match self {
+            Self::Auth { request_id, .. }
+            | Self::RateLimit { request_id, .. }
+            | Self::InvalidRequest { request_id, .. }
+            | Self::ProviderError { request_id, .. } => request_id.as_deref(),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn display_strings_unchanged() {
+        let cases: Vec<(MotosanError, &str)> = vec![
+            (
+                MotosanError::Auth {
+                    message: "bad key".into(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                },
+                "auth error: bad key",
+            ),
+            (
+                MotosanError::RateLimit {
+                    message: "too many".into(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                },
+                "rate limit error: too many",
+            ),
+            (
+                MotosanError::InvalidRequest {
+                    message: "bad field".into(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                },
+                "invalid request: bad field",
+            ),
+            (
+                MotosanError::ProviderError {
+                    message: "boom".into(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                },
+                "provider error: boom",
+            ),
+            (MotosanError::Config("c".into()), "config error: c"),
+            (MotosanError::Network("n".into()), "network error: n"),
+            (MotosanError::Stream("s".into()), "stream error: s"),
+            (
+                MotosanError::StreamReadTimeout(5),
+                "stream read timeout: no data received within 5 seconds",
+            ),
+            (
+                MotosanError::UnsupportedFeature("u".into()),
+                "unsupported feature: u",
+            ),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(err.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn accessors_expose_metadata_on_http_variants() {
+        let err = MotosanError::RateLimit {
+            message: "too many".into(),
+            status_code: Some(429),
+            retry_after: Some(Duration::from_secs(7)),
+            request_id: Some("req_123".into()),
+        };
+        assert_eq!(err.status_code(), Some(429));
+        assert_eq!(err.retry_after(), Some(Duration::from_secs(7)));
+        assert_eq!(err.request_id(), Some("req_123"));
+    }
+
+    #[test]
+    fn accessors_return_none_on_non_http_variants() {
+        let errors = [
+            MotosanError::Config("c".into()),
+            MotosanError::Network("n".into()),
+            MotosanError::Stream("s".into()),
+            MotosanError::StreamReadTimeout(5),
+            MotosanError::UnsupportedFeature("u".into()),
+        ];
+        for err in errors {
+            assert_eq!(err.status_code(), None);
+            assert_eq!(err.retry_after(), None);
+            assert_eq!(err.request_id(), None);
+        }
+    }
 }

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -30,7 +30,7 @@ pub use models::{
 };
 pub use motosan_agent_primitives::ToolSchema;
 pub use providers::Provider;
-pub use retry::RetryPolicy;
+pub use retry::{RetryCause, RetryEvent, RetryPolicy};
 #[cfg(any(
     feature = "anthropic",
     feature = "openai",

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -3,8 +3,8 @@ const DEFAULT_MAX_TOKENS: u32 = 8192;
 use crate::error::MotosanError;
 use crate::models::DEFAULT_ANTHROPIC_MODEL;
 use crate::providers::{
-    extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
-    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
+    map_http_error, parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -491,12 +491,18 @@ impl ProviderImpl for AnthropicProvider {
 
             let status = response.status();
             let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
 
             if status.is_success() {
                 payload = response
                     .json()
                     .await
-                    .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+                    .map_err(|error| MotosanError::ProviderError {
+                        message: error.to_string(),
+                        status_code: None,
+                        retry_after: None,
+                        request_id: None,
+                    })?;
                 break;
             }
 
@@ -513,7 +519,12 @@ impl ProviderImpl for AnthropicProvider {
                 message,
                 Self::is_setup_token(&self.api_key),
             );
-            return Err(map_http_error(status.as_u16(), message));
+            return Err(map_http_error(
+                status.as_u16(),
+                message,
+                retry_after,
+                request_id,
+            ));
         }
 
         let content_blocks = payload.get("content").and_then(Value::as_array);
@@ -827,6 +838,7 @@ impl ProviderImpl for AnthropicProvider {
             }
 
             let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
             if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
                 attempt += 1;
                 sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
@@ -842,7 +854,12 @@ impl ProviderImpl for AnthropicProvider {
                 message,
                 Self::is_setup_token(&self.api_key),
             );
-            return Err(map_http_error(status.as_u16(), message));
+            return Err(map_http_error(
+                status.as_u16(),
+                message,
+                retry_after,
+                request_id,
+            ));
         };
 
         let raw_stream = response.bytes_stream().eventsource();

--- a/sdks/rust/src/providers/chatgpt_codex.rs
+++ b/sdks/rust/src/providers/chatgpt_codex.rs
@@ -1,7 +1,7 @@
 use crate::error::MotosanError;
 use crate::providers::{
-    extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
-    parse_retry_after, sleep_before_retry, ProviderImpl,
+    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
+    map_http_error, parse_retry_after, sleep_before_retry, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::{collect_stream, BoxStream};
@@ -282,6 +282,7 @@ impl ProviderImpl for ChatGptCodexProvider {
                     let status = resp.status().as_u16();
                     if status != 200 {
                         let retry_after = parse_retry_after(resp.headers());
+                        let request_id = extract_request_id(resp.headers());
                         let payload: Value = resp.json().await.unwrap_or(json!({}));
                         let msg = extract_error_message(&payload, "ChatGPT-backend error");
                         if is_retryable_status(status) && attempt < self.retry_policy.max_retries {
@@ -289,7 +290,7 @@ impl ProviderImpl for ChatGptCodexProvider {
                             sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
                             continue;
                         }
-                        return Err(map_http_error(status, msg));
+                        return Err(map_http_error(status, msg, retry_after, request_id));
                     }
                     let sse = resp.bytes_stream().eventsource();
                     let adapter = ChatGptCodexStreamAdapter {

--- a/sdks/rust/src/providers/claude_code/mod.rs
+++ b/sdks/rust/src/providers/claude_code/mod.rs
@@ -505,24 +505,44 @@ impl ClaudeCodeProvider {
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
 
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| MotosanError::ProviderError(format!("failed to spawn claude CLI: {e}")))?;
+        let mut child = cmd.spawn().map_err(|e| MotosanError::ProviderError {
+            message: format!("failed to spawn claude CLI: {e}"),
+            status_code: None,
+            retry_after: None,
+            request_id: None,
+        })?;
 
         // Write prompt to stdin then close it.
         {
-            let mut stdin = child.stdin.take().ok_or_else(|| {
-                MotosanError::ProviderError("failed to open claude CLI stdin".to_string())
-            })?;
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| MotosanError::ProviderError {
+                    message: "failed to open claude CLI stdin".to_string(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                })?;
             stdin.write_all(user_prompt.as_bytes()).await.map_err(|e| {
-                MotosanError::ProviderError(format!("failed to write to claude stdin: {e}"))
+                MotosanError::ProviderError {
+                    message: format!("failed to write to claude stdin: {e}"),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                }
             })?;
             // stdin dropped here, sending EOF
         }
 
-        let stdout = child.stdout.take().ok_or_else(|| {
-            MotosanError::ProviderError("failed to open claude CLI stdout".to_string())
-        })?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| MotosanError::ProviderError {
+                message: "failed to open claude CLI stdout".to_string(),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?;
 
         let reader = BufReader::new(stdout);
 
@@ -599,7 +619,12 @@ where
                     }
                     stream_json::NdjsonAction::Error(msg) => {
                         reap_child(&mut child, true).await;
-                        yield Err(MotosanError::ProviderError(msg));
+                        yield Err(MotosanError::ProviderError {
+                            message: msg,
+                            status_code: None,
+                            retry_after: None,
+                            request_id: None,
+                        });
                         break;
                     }
                 }
@@ -951,7 +976,7 @@ mod tests {
         assert!(
             matches!(
                 last,
-                Some(Err(crate::error::MotosanError::ProviderError(_)))
+                Some(Err(crate::error::MotosanError::ProviderError { .. }))
             ),
             "a provider-error line must surface as a terminal Err item, got {last:?}"
         );
@@ -970,7 +995,7 @@ mod tests {
             None,
         );
         match s.next().await {
-            Some(Err(crate::error::MotosanError::ProviderError(msg))) => {
+            Some(Err(crate::error::MotosanError::ProviderError { message: msg, .. })) => {
                 assert!(msg.contains("error_max_turns"), "got: {msg}");
             }
             other => panic!("expected ProviderError, got {other:?}"),
@@ -1016,7 +1041,7 @@ mod tests {
         );
         assert!(matches!(
             s.next().await,
-            Some(Err(crate::error::MotosanError::ProviderError(_)))
+            Some(Err(crate::error::MotosanError::ProviderError { .. }))
         ));
         // BEFORE drop: the reap must already have killed the otherwise-alive child.
         assert!(

--- a/sdks/rust/src/providers/claude_code/spawn.rs
+++ b/sdks/rust/src/providers/claude_code/spawn.rs
@@ -392,40 +392,64 @@ pub async fn invoke_cli(
 ) -> Result<(String, Usage, Option<String>), MotosanError> {
     let mut cmd = build_command(config);
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| MotosanError::ProviderError(format!("failed to spawn claude CLI: {e}")))?;
+    let mut child = cmd.spawn().map_err(|e| MotosanError::ProviderError {
+        message: format!("failed to spawn claude CLI: {e}"),
+        status_code: None,
+        retry_after: None,
+        request_id: None,
+    })?;
 
     if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(prompt.as_bytes()).await.map_err(|e| {
-            MotosanError::ProviderError(format!("failed to write to claude stdin: {e}"))
-        })?;
+        stdin
+            .write_all(prompt.as_bytes())
+            .await
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("failed to write to claude stdin: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?;
         // Drop stdin to close it so the child reads EOF.
     }
 
     let result = match config.timeout {
         Some(dur) => tokio::time::timeout(dur, child.wait_with_output())
             .await
-            .map_err(|_| {
-                MotosanError::ProviderError(format!(
-                    "claude CLI timed out after {} seconds",
-                    dur.as_secs()
-                ))
+            .map_err(|_| MotosanError::ProviderError {
+                message: format!("claude CLI timed out after {} seconds", dur.as_secs()),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
             })?
-            .map_err(|e| MotosanError::ProviderError(format!("claude CLI process error: {e}")))?,
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("claude CLI process error: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?,
         None => child
             .wait_with_output()
             .await
-            .map_err(|e| MotosanError::ProviderError(format!("claude CLI process error: {e}")))?,
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("claude CLI process error: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?,
     };
 
     if !result.status.success() {
         let stderr = String::from_utf8_lossy(&result.stderr);
-        return Err(MotosanError::ProviderError(format!(
-            "claude CLI exited with {}: {}",
-            result.status,
-            stderr.trim()
-        )));
+        return Err(MotosanError::ProviderError {
+            message: format!(
+                "claude CLI exited with {}: {}",
+                result.status,
+                stderr.trim()
+            ),
+            status_code: None,
+            retry_after: None,
+            request_id: None,
+        });
     }
 
     let stdout = String::from_utf8_lossy(&result.stdout).to_string();
@@ -448,9 +472,13 @@ pub async fn invoke_cli(
 
 /// Parse the JSON output from agent mode, extracting `result`, `usage`, and `session_id`.
 fn parse_agent_json(raw: &str) -> Result<(String, Usage, Option<String>), MotosanError> {
-    let v: serde_json::Value = serde_json::from_str(raw).map_err(|e| {
-        MotosanError::ProviderError(format!("failed to parse claude JSON output: {e}"))
-    })?;
+    let v: serde_json::Value =
+        serde_json::from_str(raw).map_err(|e| MotosanError::ProviderError {
+            message: format!("failed to parse claude JSON output: {e}"),
+            status_code: None,
+            retry_after: None,
+            request_id: None,
+        })?;
 
     let subtype = v.get("subtype").and_then(|subtype| subtype.as_str());
     let is_error = v
@@ -465,9 +493,12 @@ fn parse_agent_json(raw: &str) -> Result<(String, Usage, Option<String>), Motosa
             .and_then(|result| result.as_str())
             .filter(|result| !result.is_empty())
             .unwrap_or("no result message");
-        return Err(MotosanError::ProviderError(format!(
-            "claude_code terminal error ({subtype}): {detail}"
-        )));
+        return Err(MotosanError::ProviderError {
+            message: format!("claude_code terminal error ({subtype}): {detail}"),
+            status_code: None,
+            retry_after: None,
+            request_id: None,
+        });
     }
 
     let text = v
@@ -1027,7 +1058,7 @@ mod tests {
     fn agent_json_error_subtype_without_result_is_err() {
         let raw = r#"{"type":"result","subtype":"error_max_turns","is_error":true}"#;
         match parse_agent_json(raw) {
-            Err(MotosanError::ProviderError(msg)) => {
+            Err(MotosanError::ProviderError { message: msg, .. }) => {
                 assert!(msg.contains("error_max_turns"), "got: {msg}");
             }
             other => panic!("expected ProviderError, got {other:?}"),
@@ -1038,7 +1069,7 @@ mod tests {
     fn agent_json_is_error_with_result_surfaces_message() {
         let raw = r#"{"type":"result","subtype":"error_during_execution","is_error":true,"result":"boom"}"#;
         match parse_agent_json(raw) {
-            Err(MotosanError::ProviderError(msg)) => {
+            Err(MotosanError::ProviderError { message: msg, .. }) => {
                 assert!(msg.contains("error_during_execution"), "got: {msg}");
                 assert!(msg.contains("boom"), "got: {msg}");
             }

--- a/sdks/rust/src/providers/codex_cli/mod.rs
+++ b/sdks/rust/src/providers/codex_cli/mod.rs
@@ -489,22 +489,42 @@ impl CodexCliProvider {
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
 
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| MotosanError::ProviderError(format!("failed to spawn codex CLI: {e}")))?;
+        let mut child = cmd.spawn().map_err(|e| MotosanError::ProviderError {
+            message: format!("failed to spawn codex CLI: {e}"),
+            status_code: None,
+            retry_after: None,
+            request_id: None,
+        })?;
 
         {
-            let mut stdin = child.stdin.take().ok_or_else(|| {
-                MotosanError::ProviderError("failed to open codex CLI stdin".to_string())
-            })?;
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| MotosanError::ProviderError {
+                    message: "failed to open codex CLI stdin".to_string(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                })?;
             stdin.write_all(composed.as_bytes()).await.map_err(|e| {
-                MotosanError::ProviderError(format!("failed to write to codex stdin: {e}"))
+                MotosanError::ProviderError {
+                    message: format!("failed to write to codex stdin: {e}"),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                }
             })?;
         }
 
-        let stdout = child.stdout.take().ok_or_else(|| {
-            MotosanError::ProviderError("failed to open codex CLI stdout".to_string())
-        })?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| MotosanError::ProviderError {
+                message: "failed to open codex CLI stdout".to_string(),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?;
 
         let reader = BufReader::new(stdout);
 
@@ -580,7 +600,12 @@ where
                     }
                     stream_json::NdjsonAction::Error(msg) => {
                         reap_child(&mut child, true).await;
-                        yield Err(MotosanError::ProviderError(msg));
+                        yield Err(MotosanError::ProviderError {
+                            message: msg,
+                            status_code: None,
+                            retry_after: None,
+                            request_id: None,
+                        });
                         break;
                     }
                 }
@@ -880,7 +905,7 @@ mod tests {
         assert!(
             matches!(
                 last,
-                Some(Err(crate::error::MotosanError::ProviderError(_)))
+                Some(Err(crate::error::MotosanError::ProviderError { .. }))
             ),
             "a provider-error line must surface as a terminal Err item, got {last:?}"
         );

--- a/sdks/rust/src/providers/codex_cli/spawn.rs
+++ b/sdks/rust/src/providers/codex_cli/spawn.rs
@@ -277,39 +277,59 @@ pub async fn invoke_cli(
 ) -> Result<(String, Option<String>, Usage, Option<String>), MotosanError> {
     let mut cmd = build_command(config);
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| MotosanError::ProviderError(format!("failed to spawn codex CLI: {e}")))?;
+    let mut child = cmd.spawn().map_err(|e| MotosanError::ProviderError {
+        message: format!("failed to spawn codex CLI: {e}"),
+        status_code: None,
+        retry_after: None,
+        request_id: None,
+    })?;
 
     if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(prompt.as_bytes()).await.map_err(|e| {
-            MotosanError::ProviderError(format!("failed to write to codex stdin: {e}"))
-        })?;
+        stdin
+            .write_all(prompt.as_bytes())
+            .await
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("failed to write to codex stdin: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?;
     }
 
     let result = match config.timeout {
         Some(dur) => tokio::time::timeout(dur, child.wait_with_output())
             .await
-            .map_err(|_| {
-                MotosanError::ProviderError(format!(
-                    "codex CLI timed out after {} seconds",
-                    dur.as_secs()
-                ))
+            .map_err(|_| MotosanError::ProviderError {
+                message: format!("codex CLI timed out after {} seconds", dur.as_secs()),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
             })?
-            .map_err(|e| MotosanError::ProviderError(format!("codex CLI process error: {e}")))?,
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("codex CLI process error: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?,
         None => child
             .wait_with_output()
             .await
-            .map_err(|e| MotosanError::ProviderError(format!("codex CLI process error: {e}")))?,
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("codex CLI process error: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?,
     };
 
     if !result.status.success() {
         let stderr = String::from_utf8_lossy(&result.stderr);
-        return Err(MotosanError::ProviderError(format!(
-            "codex CLI exited with {}: {}",
-            result.status,
-            stderr.trim()
-        )));
+        return Err(MotosanError::ProviderError {
+            message: format!("codex CLI exited with {}: {}", result.status, stderr.trim()),
+            status_code: None,
+            retry_after: None,
+            request_id: None,
+        });
     }
 
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -355,7 +375,12 @@ fn parse_collected_stream(
             }
             Some(NdjsonAction::Done { usage: None, .. }) => {}
             Some(NdjsonAction::Error(msg)) => {
-                return Err(MotosanError::ProviderError(format!("codex CLI: {msg}")));
+                return Err(MotosanError::ProviderError {
+                    message: format!("codex CLI: {msg}"),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                });
             }
             None => {}
         }
@@ -802,7 +827,7 @@ mod tests {
     fn parse_collected_stream_surfaces_error() {
         let raw = r#"{"type":"error","message":"nope"}"#;
         let err = parse_collected_stream(raw).unwrap_err();
-        let MotosanError::ProviderError(msg) = err else {
+        let MotosanError::ProviderError { message: msg, .. } = err else {
             panic!("expected ProviderError");
         };
         assert!(msg.contains("nope"));

--- a/sdks/rust/src/providers/gemini.rs
+++ b/sdks/rust/src/providers/gemini.rs
@@ -1138,6 +1138,7 @@ mod tests {
                 max_delay_ms: 10,
                 jitter: false,
                 respect_retry_after: false,
+                on_retry: None,
             };
             let provider =
                 GeminiProvider::new("fake-key", None, Some(server.url())).with_retry_policy(policy);

--- a/sdks/rust/src/providers/gemini.rs
+++ b/sdks/rust/src/providers/gemini.rs
@@ -3,8 +3,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::error::MotosanError;
 use crate::models::DEFAULT_GEMINI_MODEL;
 use crate::providers::{
-    extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
-    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
+    map_http_error, parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -347,6 +347,7 @@ impl ProviderImpl for GeminiProvider {
                     let status = resp.status().as_u16();
                     if status != 200 {
                         let retry_after = parse_retry_after(resp.headers());
+                        let request_id = extract_request_id(resp.headers());
                         let payload: Value = resp.json().await.unwrap_or(json!({}));
                         let msg = extract_error_message(&payload, "Gemini API error");
                         if is_retryable_status(status) && attempt < self.retry_policy.max_retries {
@@ -354,11 +355,15 @@ impl ProviderImpl for GeminiProvider {
                             sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
                             continue;
                         }
-                        return Err(map_http_error(status, msg));
+                        return Err(map_http_error(status, msg, retry_after, request_id));
                     }
-                    let payload: Value = resp.json().await.map_err(|e| {
-                        MotosanError::ProviderError(format!("failed to parse Gemini response: {e}"))
-                    })?;
+                    let payload: Value =
+                        resp.json().await.map_err(|e| MotosanError::ProviderError {
+                            message: format!("failed to parse Gemini response: {e}"),
+                            status_code: None,
+                            retry_after: None,
+                            request_id: None,
+                        })?;
                     return Ok(Self::parse_response(&payload, &model));
                 }
             }
@@ -395,6 +400,7 @@ impl ProviderImpl for GeminiProvider {
                     let status = resp.status().as_u16();
                     if status != 200 {
                         let retry_after = parse_retry_after(resp.headers());
+                        let request_id = extract_request_id(resp.headers());
                         let payload: Value = resp.json().await.unwrap_or(json!({}));
                         let msg = extract_error_message(&payload, "Gemini stream error");
                         if is_retryable_status(status) && attempt < self.retry_policy.max_retries {
@@ -402,7 +408,7 @@ impl ProviderImpl for GeminiProvider {
                             sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
                             continue;
                         }
-                        return Err(map_http_error(status, msg));
+                        return Err(map_http_error(status, msg, retry_after, request_id));
                     }
                     let sse = resp.bytes_stream().eventsource();
                     let adapter = GeminiStreamAdapter {

--- a/sdks/rust/src/providers/gemini_cli/mod.rs
+++ b/sdks/rust/src/providers/gemini_cli/mod.rs
@@ -285,25 +285,43 @@ impl GeminiCliProvider {
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
 
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| MotosanError::ProviderError(format!("failed to spawn gemini CLI: {e}")))?;
+        let mut child = cmd.spawn().map_err(|e| MotosanError::ProviderError {
+            message: format!("failed to spawn gemini CLI: {e}"),
+            status_code: None,
+            retry_after: None,
+            request_id: None,
+        })?;
 
         {
-            let mut stdin = child.stdin.take().ok_or_else(|| {
-                MotosanError::ProviderError("failed to open gemini CLI stdin".to_string())
-            })?;
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| MotosanError::ProviderError {
+                    message: "failed to open gemini CLI stdin".to_string(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                })?;
             stdin
                 .write_all(stdin_payload.as_bytes())
                 .await
-                .map_err(|e| {
-                    MotosanError::ProviderError(format!("failed to write to gemini stdin: {e}"))
+                .map_err(|e| MotosanError::ProviderError {
+                    message: format!("failed to write to gemini stdin: {e}"),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
                 })?;
         }
 
-        let stdout = child.stdout.take().ok_or_else(|| {
-            MotosanError::ProviderError("failed to open gemini CLI stdout".to_string())
-        })?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| MotosanError::ProviderError {
+                message: "failed to open gemini CLI stdout".to_string(),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?;
 
         let reader = BufReader::new(stdout);
 
@@ -378,7 +396,12 @@ where
                 }
                 Some(stream_json::NdjsonAction::Error(msg)) => {
                     reap_child(&mut child, true).await;
-                    yield Err(MotosanError::ProviderError(msg));
+                    yield Err(MotosanError::ProviderError {
+                        message: msg,
+                        status_code: None,
+                        retry_after: None,
+                        request_id: None,
+                    });
                     break;
                 }
                 None => {}
@@ -674,7 +697,7 @@ mod tests {
         assert!(
             matches!(
                 last,
-                Some(Err(crate::error::MotosanError::ProviderError(_)))
+                Some(Err(crate::error::MotosanError::ProviderError { .. }))
             ),
             "a provider-error line must surface as a terminal Err item, got {last:?}"
         );

--- a/sdks/rust/src/providers/gemini_cli/spawn.rs
+++ b/sdks/rust/src/providers/gemini_cli/spawn.rs
@@ -217,39 +217,63 @@ pub async fn invoke_cli(
 ) -> Result<(String, Usage, Option<String>), MotosanError> {
     let mut cmd = build_command(config);
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| MotosanError::ProviderError(format!("failed to spawn gemini CLI: {e}")))?;
+    let mut child = cmd.spawn().map_err(|e| MotosanError::ProviderError {
+        message: format!("failed to spawn gemini CLI: {e}"),
+        status_code: None,
+        retry_after: None,
+        request_id: None,
+    })?;
 
     if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(prompt.as_bytes()).await.map_err(|e| {
-            MotosanError::ProviderError(format!("failed to write to gemini stdin: {e}"))
-        })?;
+        stdin
+            .write_all(prompt.as_bytes())
+            .await
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("failed to write to gemini stdin: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?;
     }
 
     let result = match config.timeout {
         Some(dur) => tokio::time::timeout(dur, child.wait_with_output())
             .await
-            .map_err(|_| {
-                MotosanError::ProviderError(format!(
-                    "gemini CLI timed out after {} seconds",
-                    dur.as_secs()
-                ))
+            .map_err(|_| MotosanError::ProviderError {
+                message: format!("gemini CLI timed out after {} seconds", dur.as_secs()),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
             })?
-            .map_err(|e| MotosanError::ProviderError(format!("gemini CLI process error: {e}")))?,
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("gemini CLI process error: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?,
         None => child
             .wait_with_output()
             .await
-            .map_err(|e| MotosanError::ProviderError(format!("gemini CLI process error: {e}")))?,
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("gemini CLI process error: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?,
     };
 
     if !result.status.success() {
         let stderr = String::from_utf8_lossy(&result.stderr);
-        return Err(MotosanError::ProviderError(format!(
-            "gemini CLI exited with {}: {}",
-            result.status,
-            stderr.trim()
-        )));
+        return Err(MotosanError::ProviderError {
+            message: format!(
+                "gemini CLI exited with {}: {}",
+                result.status,
+                stderr.trim()
+            ),
+            status_code: None,
+            retry_after: None,
+            request_id: None,
+        });
     }
 
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -292,7 +316,12 @@ fn parse_collected_stream(raw: &str) -> Result<(String, Usage, Option<String>), 
             }
             Some(NdjsonAction::Result { usage: None, .. }) => {}
             Some(NdjsonAction::Error(msg)) => {
-                return Err(MotosanError::ProviderError(format!("gemini CLI: {msg}")));
+                return Err(MotosanError::ProviderError {
+                    message: format!("gemini CLI: {msg}"),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                });
             }
             None => {}
         }
@@ -644,7 +673,7 @@ mod tests {
     fn parse_collected_stream_surfaces_non_success_result() {
         let raw = r#"{"type":"result","status":"failed"}"#;
         let err = parse_collected_stream(raw).unwrap_err();
-        let MotosanError::ProviderError(msg) = err else {
+        let MotosanError::ProviderError { message: msg, .. } = err else {
             panic!("expected ProviderError");
         };
         assert!(msg.contains("failed"));

--- a/sdks/rust/src/providers/gemini_code_assist.rs
+++ b/sdks/rust/src/providers/gemini_code_assist.rs
@@ -4,8 +4,8 @@ use crate::error::MotosanError;
 use crate::models::{DEFAULT_GEMINI_CODE_ASSIST_MODEL, GEMINI_CODE_ASSIST_BASE_URL};
 use crate::providers::gemini::GeminiProvider;
 use crate::providers::{
-    extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
-    parse_retry_after, sleep_before_retry, ProviderImpl,
+    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
+    map_http_error, parse_retry_after, sleep_before_retry, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::{collect_stream, BoxStream};
@@ -148,6 +148,7 @@ impl ProviderImpl for GeminiCodeAssistProvider {
                     let status = resp.status().as_u16();
                     if status != 200 {
                         let retry_after = parse_retry_after(resp.headers());
+                        let request_id = extract_request_id(resp.headers());
                         let payload: Value = resp.json().await.unwrap_or(json!({}));
                         let msg = extract_error_message(&payload, "Gemini Code Assist error");
                         if is_retryable_status(status) && attempt < self.retry_policy.max_retries {
@@ -155,7 +156,7 @@ impl ProviderImpl for GeminiCodeAssistProvider {
                             sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
                             continue;
                         }
-                        return Err(map_http_error(status, msg));
+                        return Err(map_http_error(status, msg, retry_after, request_id));
                     }
                     let sse = resp.bytes_stream().eventsource();
                     let adapter = CodeAssistStreamAdapter {

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -234,12 +234,37 @@ pub(crate) fn extract_error_message(payload: &Value, fallback: &str) -> String {
     feature = "gemini-code-assist",
     feature = "chatgpt-codex",
 ))]
-pub(crate) fn map_http_error(status_code: u16, message: String) -> MotosanError {
+pub(crate) fn map_http_error(
+    status_code: u16,
+    message: String,
+    retry_after: Option<Duration>,
+    request_id: Option<String>,
+) -> MotosanError {
     match status_code {
-        401 => MotosanError::Auth(message),
-        429 => MotosanError::RateLimit(message),
-        400 => MotosanError::InvalidRequest(message),
-        _ => MotosanError::ProviderError(message),
+        401 => MotosanError::Auth {
+            message,
+            status_code: Some(status_code),
+            retry_after,
+            request_id,
+        },
+        429 => MotosanError::RateLimit {
+            message,
+            status_code: Some(status_code),
+            retry_after,
+            request_id,
+        },
+        400 => MotosanError::InvalidRequest {
+            message,
+            status_code: Some(status_code),
+            retry_after,
+            request_id,
+        },
+        _ => MotosanError::ProviderError {
+            message,
+            status_code: Some(status_code),
+            retry_after,
+            request_id,
+        },
     }
 }
 
@@ -319,6 +344,24 @@ pub(crate) fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
     let raw = headers.get("retry-after")?.to_str().ok()?.trim();
     let seconds = raw.parse::<u64>().ok()?;
     Some(Duration::from_secs(seconds))
+}
+
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+pub(crate) fn extract_request_id(headers: &HeaderMap) -> Option<String> {
+    ["request-id", "x-request-id"].iter().find_map(|name| {
+        headers
+            .get(*name)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
+    })
 }
 
 #[cfg(any(
@@ -452,5 +495,80 @@ mod validate_tests {
     fn any_provider_accepts_plain_text() {
         let p = TextOnlyProvider;
         assert!(p.validate_request(&req_text_only()).is_ok());
+    }
+}
+
+#[cfg(test)]
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+mod http_error_metadata_tests {
+    use super::*;
+    use reqwest::header::{HeaderMap, HeaderName};
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                HeaderName::from_bytes(name.as_bytes()).expect("header name"),
+                value.parse().expect("header value"),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn extract_request_id_prefers_request_id_then_x_request_id() {
+        let both = headers(&[("x-request-id", "xrid"), ("request-id", "rid")]);
+        assert_eq!(extract_request_id(&both).as_deref(), Some("rid"));
+        let fallback = headers(&[("x-request-id", "xrid")]);
+        assert_eq!(extract_request_id(&fallback).as_deref(), Some("xrid"));
+        assert_eq!(extract_request_id(&HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn map_http_error_populates_metadata_from_headers() {
+        let map = headers(&[("retry-after", "7"), ("request-id", "req_123")]);
+        let err = map_http_error(
+            429,
+            "too many".to_string(),
+            parse_retry_after(&map),
+            extract_request_id(&map),
+        );
+        assert!(matches!(err, MotosanError::RateLimit { .. }));
+        assert_eq!(err.status_code(), Some(429));
+        assert_eq!(err.retry_after(), Some(Duration::from_secs(7)));
+        assert_eq!(err.request_id(), Some("req_123"));
+        assert_eq!(err.to_string(), "rate limit error: too many");
+    }
+
+    #[test]
+    fn map_http_error_maps_status_to_variant() {
+        assert!(matches!(
+            map_http_error(401, "m".into(), None, None),
+            MotosanError::Auth { .. }
+        ));
+        assert!(matches!(
+            map_http_error(400, "m".into(), None, None),
+            MotosanError::InvalidRequest { .. }
+        ));
+        assert!(matches!(
+            map_http_error(429, "m".into(), None, None),
+            MotosanError::RateLimit { .. }
+        ));
+        assert!(matches!(
+            map_http_error(500, "m".into(), None, None),
+            MotosanError::ProviderError { .. }
+        ));
+        assert_eq!(
+            map_http_error(500, "m".into(), None, None).status_code(),
+            Some(500)
+        );
     }
 }

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -315,7 +315,7 @@ mod cli_terminal_tests {
     feature = "chatgpt-codex",
 ))]
 pub(crate) fn is_retryable_status(status_code: u16) -> bool {
-    status_code == 429 || status_code >= 500
+    status_code == 408 || status_code == 409 || status_code == 429 || status_code >= 500
 }
 
 #[cfg(any(
@@ -340,10 +340,31 @@ pub(crate) fn is_retryable_network_error(error: &reqwest::Error) -> bool {
     feature = "gemini-code-assist",
     feature = "chatgpt-codex",
 ))]
+pub(crate) const RETRY_AFTER_CAP: Duration = Duration::from_secs(60);
+
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
 pub(crate) fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
     let raw = headers.get("retry-after")?.to_str().ok()?.trim();
-    let seconds = raw.parse::<u64>().ok()?;
-    Some(Duration::from_secs(seconds))
+    let uncapped = if let Ok(seconds) = raw.parse::<f64>() {
+        if !seconds.is_finite() || seconds < 0.0 {
+            return None;
+        }
+        Duration::from_secs_f64(seconds.min(RETRY_AFTER_CAP.as_secs_f64()))
+    } else {
+        // RFC 7231 HTTP-date form (e.g. "Fri, 31 Dec 1999 23:59:59 GMT").
+        let when = chrono::DateTime::parse_from_rfc2822(raw).ok()?;
+        let remaining = when.signed_duration_since(chrono::Utc::now());
+        Duration::from_secs(remaining.num_seconds().max(0) as u64)
+    };
+    Some(uncapped.min(RETRY_AFTER_CAP))
 }
 
 #[cfg(any(
@@ -378,6 +399,7 @@ pub(crate) async fn sleep_before_retry(
     attempt: u32,
     retry_after: Option<Duration>,
 ) {
+    // retry_after arrives pre-capped to RETRY_AFTER_CAP by parse_retry_after.
     let delay = if policy.respect_retry_after {
         retry_after.unwrap_or_else(|| policy.delay_for_attempt(attempt))
     } else {
@@ -385,6 +407,109 @@ pub(crate) async fn sleep_before_retry(
     };
 
     tokio::time::sleep(delay).await;
+}
+
+#[cfg(test)]
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+mod retry_after_tests {
+    use super::{is_retryable_status, parse_retry_after, RETRY_AFTER_CAP};
+    use reqwest::header::{HeaderMap, HeaderValue};
+    use std::time::Duration;
+
+    fn headers_with_retry_after(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "retry-after",
+            HeaderValue::from_str(value).expect("ascii header value"),
+        );
+        headers
+    }
+
+    #[test]
+    fn integer_seconds_parse() {
+        let headers = headers_with_retry_after("5");
+        assert_eq!(parse_retry_after(&headers), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn integer_seconds_above_cap_clamp_to_cap() {
+        let headers = headers_with_retry_after("120");
+        assert_eq!(parse_retry_after(&headers), Some(RETRY_AFTER_CAP));
+    }
+
+    #[test]
+    fn decimal_seconds_parse() {
+        let headers = headers_with_retry_after("1.5");
+        assert_eq!(
+            parse_retry_after(&headers),
+            Some(Duration::from_millis(1500))
+        );
+    }
+
+    #[test]
+    fn negative_numeric_value_returns_none() {
+        let headers = headers_with_retry_after("-1");
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn http_date_near_future_parses_to_remaining_seconds() {
+        // Fixed offset from now via chrono arithmetic - no wall-clock strings.
+        let when = chrono::Utc::now() + chrono::Duration::seconds(30);
+        let headers = headers_with_retry_after(&when.to_rfc2822());
+        let delay = parse_retry_after(&headers).expect("http-date should parse");
+        // signed_duration_since truncates and the test itself takes time,
+        // so allow a small window below 30s.
+        assert!(
+            (28..=30).contains(&delay.as_secs()),
+            "expected ~30s, got {delay:?}"
+        );
+    }
+
+    #[test]
+    fn http_date_in_past_clamps_to_zero() {
+        let when = chrono::Utc::now() - chrono::Duration::seconds(100);
+        let headers = headers_with_retry_after(&when.to_rfc2822());
+        assert_eq!(parse_retry_after(&headers), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn http_date_far_future_clamps_to_cap() {
+        let when = chrono::Utc::now() + chrono::Duration::seconds(300);
+        let headers = headers_with_retry_after(&when.to_rfc2822());
+        assert_eq!(parse_retry_after(&headers), Some(RETRY_AFTER_CAP));
+    }
+
+    #[test]
+    fn garbage_value_returns_none() {
+        let headers = headers_with_retry_after("soon");
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn missing_header_returns_none() {
+        assert_eq!(parse_retry_after(&HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn retryable_status_set_is_408_409_429_and_5xx() {
+        assert!(is_retryable_status(408));
+        assert!(is_retryable_status(409));
+        assert!(is_retryable_status(429));
+        assert!(is_retryable_status(500));
+        assert!(is_retryable_status(503));
+        assert!(!is_retryable_status(400));
+        assert!(!is_retryable_status(404));
+        assert!(!is_retryable_status(200));
+    }
 }
 
 #[cfg(feature = "anthropic")]

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -1,8 +1,8 @@
 use crate::error::MotosanError;
 use crate::models::DEFAULT_OLLAMA_MODEL;
 use crate::providers::{
-    extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
-    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
+    map_http_error, parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -265,6 +265,7 @@ impl ProviderImpl for OllamaProvider {
 
             let status = response.status();
             let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
 
             if !status.is_success() {
                 if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
@@ -274,13 +275,23 @@ impl ProviderImpl for OllamaProvider {
                 }
                 let error_payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
                 let message = extract_error_message(&error_payload, "ollama request failed");
-                return Err(map_http_error(status.as_u16(), message));
+                return Err(map_http_error(
+                    status.as_u16(),
+                    message,
+                    retry_after,
+                    request_id,
+                ));
             }
 
             payload = response
                 .json()
                 .await
-                .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+                .map_err(|error| MotosanError::ProviderError {
+                    message: error.to_string(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                })?;
             break;
         }
 
@@ -371,6 +382,7 @@ impl ProviderImpl for OllamaProvider {
             }
 
             let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
             if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
                 attempt += 1;
                 sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
@@ -383,7 +395,12 @@ impl ProviderImpl for OllamaProvider {
                 .and_then(|bytes| serde_json::from_slice::<Value>(bytes).ok())
             {
                 let message = extract_error_message(&payload, "ollama stream request failed");
-                return Err(map_http_error(status.as_u16(), message));
+                return Err(map_http_error(
+                    status.as_u16(),
+                    message,
+                    retry_after,
+                    request_id.clone(),
+                ));
             }
 
             let message = body_bytes
@@ -391,7 +408,12 @@ impl ProviderImpl for OllamaProvider {
                 .map(|bytes| String::from_utf8_lossy(bytes).trim().to_string())
                 .filter(|message| !message.is_empty())
                 .unwrap_or_else(|| "ollama stream request failed".to_string());
-            return Err(map_http_error(status.as_u16(), message));
+            return Err(map_http_error(
+                status.as_u16(),
+                message,
+                retry_after,
+                request_id,
+            ));
         };
 
         // NDJSON parsing: each line is a separate JSON object

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -1,8 +1,8 @@
 use crate::error::MotosanError;
 use crate::models::DEFAULT_OPENAI_MODEL;
 use crate::providers::{
-    extract_error_message, is_retryable_network_error, is_retryable_status, map_http_error,
-    parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
+    map_http_error, parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -251,15 +251,30 @@ impl OpenAIProvider {
             .map_err(|error| MotosanError::Network(error.to_string()))?;
 
         let status = response.status();
-        let payload: Value = response
-            .json()
-            .await
-            .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+        let retry_after = parse_retry_after(response.headers());
+        let request_id = extract_request_id(response.headers());
 
         if !status.is_success() {
-            let message = extract_error_message(&payload, "openai responses request failed");
-            return Err(map_http_error(status.as_u16(), message));
+            let error_payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
+            let message = extract_error_message(&error_payload, "openai responses request failed");
+            return Err(map_http_error(
+                status.as_u16(),
+                message,
+                retry_after,
+                request_id,
+            ));
         }
+
+        let payload: Value =
+            response
+                .json()
+                .await
+                .map_err(|error| MotosanError::ProviderError {
+                    message: error.to_string(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                })?;
 
         let content = Self::extract_responses_text(&payload);
         let model = payload
@@ -501,6 +516,7 @@ impl ProviderImpl for OpenAIProvider {
 
             let status = response.status();
             let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
 
             if self.responses_fallback && status.as_u16() == 404 {
                 return self.chat_via_responses(&fallback_request).await;
@@ -510,7 +526,12 @@ impl ProviderImpl for OpenAIProvider {
                 payload = response
                     .json()
                     .await
-                    .map_err(|error| MotosanError::ProviderError(error.to_string()))?;
+                    .map_err(|error| MotosanError::ProviderError {
+                        message: error.to_string(),
+                        status_code: None,
+                        retry_after: None,
+                        request_id: None,
+                    })?;
                 break;
             }
 
@@ -522,7 +543,12 @@ impl ProviderImpl for OpenAIProvider {
 
             let error_payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
             let message = extract_error_message(&error_payload, "openai request failed");
-            return Err(map_http_error(status.as_u16(), message));
+            return Err(map_http_error(
+                status.as_u16(),
+                message,
+                retry_after,
+                request_id,
+            ));
         }
 
         let content = Self::extract_chat_content(&payload);
@@ -620,6 +646,7 @@ impl ProviderImpl for OpenAIProvider {
             }
 
             let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
             if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
                 attempt += 1;
                 sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
@@ -631,7 +658,12 @@ impl ProviderImpl for OpenAIProvider {
                 .await
                 .unwrap_or_else(|_| json!({"error": {"message": "openai stream request failed"}}));
             let message = extract_error_message(&current_payload, "openai stream request failed");
-            return Err(map_http_error(status.as_u16(), message));
+            return Err(map_http_error(
+                status.as_u16(),
+                message,
+                retry_after,
+                request_id,
+            ));
         };
 
         let raw_stream = response.bytes_stream().eventsource();

--- a/sdks/rust/src/retry.rs
+++ b/sdks/rust/src/retry.rs
@@ -1,12 +1,33 @@
+use std::fmt;
+use std::sync::Arc;
 use std::time::Duration;
 
-#[derive(Debug, Clone)]
+/// Why a retry is happening. Passed to `RetryPolicy::on_retry`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetryCause {
+    /// Retryable HTTP status code received from the provider.
+    Status(u16),
+    /// Retryable transport/network error (message from the HTTP client).
+    Network(String),
+}
+
+/// Fired via `RetryPolicy::on_retry` before each retry sleep.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetryEvent {
+    pub attempt: u32,
+    pub delay: Duration,
+    pub cause: RetryCause,
+}
+
+#[derive(Clone)]
 pub struct RetryPolicy {
     pub max_retries: u32,
     pub base_delay_ms: u64,
     pub max_delay_ms: u64,
     pub jitter: bool,
     pub respect_retry_after: bool,
+    /// Observability hook: called once before each retry sleep.
+    pub on_retry: Option<Arc<dyn Fn(RetryEvent) + Send + Sync>>,
 }
 
 impl RetryPolicy {
@@ -39,20 +60,49 @@ impl RetryPolicy {
         self
     }
 
+    pub fn on_retry(mut self, on_retry: impl Fn(RetryEvent) + Send + Sync + 'static) -> Self {
+        self.on_retry = Some(Arc::new(on_retry));
+        self
+    }
+
+    /// Full-jitter backoff: uniform in [0, min(base * 2^(attempt-1), max_delay)].
     pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
+        self.delay_for_attempt_with_rng(attempt, &mut fastrand::Rng::new())
+    }
+
+    /// Injectable-RNG variant so tests can seed the jitter deterministically.
+    pub(crate) fn delay_for_attempt_with_rng(
+        &self,
+        attempt: u32,
+        rng: &mut fastrand::Rng,
+    ) -> Duration {
         let exponent = attempt.saturating_sub(1).min(31);
         let exp_factor = 1_u64 << exponent;
-        let mut delay_ms = self.base_delay_ms.saturating_mul(exp_factor);
-        delay_ms = delay_ms.min(self.max_delay_ms);
+        let exp_delay_ms = self
+            .base_delay_ms
+            .saturating_mul(exp_factor)
+            .min(self.max_delay_ms);
 
-        if self.jitter {
-            let jitter_seed = attempt as u64 * 1_103_515_245 + 12_345;
-            let jitter_percent = jitter_seed % 100;
-            let jittered = delay_ms + (delay_ms.saturating_mul(jitter_percent) / 100);
-            delay_ms = jittered.min(self.max_delay_ms);
-        }
+        let delay_ms = if self.jitter {
+            rng.u64(0..=exp_delay_ms)
+        } else {
+            exp_delay_ms
+        };
 
         Duration::from_millis(delay_ms)
+    }
+}
+
+impl fmt::Debug for RetryPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RetryPolicy")
+            .field("max_retries", &self.max_retries)
+            .field("base_delay_ms", &self.base_delay_ms)
+            .field("max_delay_ms", &self.max_delay_ms)
+            .field("jitter", &self.jitter)
+            .field("respect_retry_after", &self.respect_retry_after)
+            .field("on_retry", &self.on_retry.is_some())
+            .finish()
     }
 }
 
@@ -64,6 +114,73 @@ impl Default for RetryPolicy {
             max_delay_ms: 2_000,
             jitter: true,
             respect_retry_after: true,
+            on_retry: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exp_delay_ms(policy: &RetryPolicy, attempt: u32) -> u64 {
+        let exp_factor = 1_u64 << attempt.saturating_sub(1).min(31);
+        policy
+            .base_delay_ms
+            .saturating_mul(exp_factor)
+            .min(policy.max_delay_ms)
+    }
+
+    #[test]
+    fn full_jitter_is_bounded_by_exponential_delay() {
+        let policy = RetryPolicy::new();
+        let mut rng = fastrand::Rng::with_seed(42);
+        for attempt in 1..=8 {
+            let bound = exp_delay_ms(&policy, attempt);
+            for _ in 0..200 {
+                let delay = policy.delay_for_attempt_with_rng(attempt, &mut rng);
+                assert!(
+                    delay <= Duration::from_millis(bound),
+                    "attempt {attempt}: {delay:?} exceeds {bound}ms"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn full_jitter_varies_and_is_seed_deterministic() {
+        let policy = RetryPolicy::new();
+        let mut a = fastrand::Rng::with_seed(7);
+        let mut b = fastrand::Rng::with_seed(7);
+        let draws_a: Vec<Duration> = (0..32)
+            .map(|_| policy.delay_for_attempt_with_rng(4, &mut a))
+            .collect();
+        let draws_b: Vec<Duration> = (0..32)
+            .map(|_| policy.delay_for_attempt_with_rng(4, &mut b))
+            .collect();
+        assert_eq!(draws_a, draws_b, "same seed must produce same delays");
+        assert!(
+            draws_a.iter().any(|d| d != &draws_a[0]),
+            "full jitter must vary across draws: {draws_a:?}"
+        );
+    }
+
+    #[test]
+    fn jitter_disabled_is_exact_exponential() {
+        let policy = RetryPolicy::new().jitter(false);
+        assert_eq!(policy.delay_for_attempt(1), Duration::from_millis(100));
+        assert_eq!(policy.delay_for_attempt(2), Duration::from_millis(200));
+        assert_eq!(policy.delay_for_attempt(3), Duration::from_millis(400));
+        assert_eq!(policy.delay_for_attempt(4), Duration::from_millis(800));
+        assert_eq!(policy.delay_for_attempt(5), Duration::from_millis(1600));
+        assert_eq!(policy.delay_for_attempt(6), Duration::from_millis(2000));
+        assert_eq!(policy.delay_for_attempt(99), Duration::from_millis(2000));
+    }
+
+    #[test]
+    fn debug_skips_on_retry_closure() {
+        let with_hook = RetryPolicy::new().on_retry(|_evt| {});
+        assert!(format!("{with_hook:?}").contains("on_retry: true"));
+        assert!(format!("{:?}", RetryPolicy::new()).contains("on_retry: false"));
     }
 }

--- a/sdks/rust/tests/anthropic_chat.rs
+++ b/sdks/rust/tests/anthropic_chat.rs
@@ -158,7 +158,7 @@ async fn anthropic_setup_token_401_includes_actionable_hint() {
         .build();
     let err = provider.chat(request).await.expect_err("should fail");
 
-    assert!(matches!(err, MotosanError::Auth(_)));
+    assert!(matches!(err, MotosanError::Auth { .. }));
     assert!(format!("{err}").contains("oauth-2025-04-20"));
     mock.assert_async().await;
 }

--- a/sdks/rust/tests/chatgpt_codex.rs
+++ b/sdks/rust/tests/chatgpt_codex.rs
@@ -175,5 +175,5 @@ async fn stream_401_returns_auth_error() {
         Err(e) => e,
         Ok(_) => panic!("expected error"),
     };
-    assert!(matches!(err, MotosanError::Auth(_)), "got {err:?}");
+    assert!(matches!(err, MotosanError::Auth { .. }), "got {err:?}");
 }

--- a/sdks/rust/tests/error_mapping.rs
+++ b/sdks/rust/tests/error_mapping.rs
@@ -33,13 +33,15 @@ async fn anthropic_maps_401_429_500() {
         .chat(sample_request())
         .await
         .expect_err("401 should fail");
-    assert!(matches!(err, MotosanError::Auth(_)));
+    assert!(matches!(err, MotosanError::Auth { .. }));
     unauthorized.assert_async().await;
 
     server.reset();
     let rate_limited = server
         .mock("POST", "/v1/messages")
         .with_status(429)
+        .with_header("retry-after", "7")
+        .with_header("request-id", "req_abc")
         .with_body(json!({"error": {"message": "too many"}}).to_string())
         .create_async()
         .await;
@@ -47,7 +49,11 @@ async fn anthropic_maps_401_429_500() {
         .chat(sample_request())
         .await
         .expect_err("429 should fail");
-    assert!(matches!(err, MotosanError::RateLimit(_)));
+    assert!(matches!(err, MotosanError::RateLimit { .. }));
+    assert_eq!(err.status_code(), Some(429));
+    assert_eq!(err.retry_after(), Some(std::time::Duration::from_secs(7)));
+    assert_eq!(err.request_id(), Some("req_abc"));
+    assert_eq!(err.to_string(), "rate limit error: too many");
     rate_limited.assert_async().await;
 
     server.reset();
@@ -61,7 +67,7 @@ async fn anthropic_maps_401_429_500() {
         .chat(sample_request())
         .await
         .expect_err("500 should fail");
-    assert!(matches!(err, MotosanError::ProviderError(_)));
+    assert!(matches!(err, MotosanError::ProviderError { .. }));
     provider_error.assert_async().await;
 }
 
@@ -83,7 +89,7 @@ async fn openai_maps_401_429_500() {
         .chat(sample_request())
         .await
         .expect_err("401 should fail");
-    assert!(matches!(err, MotosanError::Auth(_)));
+    assert!(matches!(err, MotosanError::Auth { .. }));
     unauthorized.assert_async().await;
 
     server.reset();
@@ -97,7 +103,7 @@ async fn openai_maps_401_429_500() {
         .chat(sample_request())
         .await
         .expect_err("429 should fail");
-    assert!(matches!(err, MotosanError::RateLimit(_)));
+    assert!(matches!(err, MotosanError::RateLimit { .. }));
     rate_limited.assert_async().await;
 
     server.reset();
@@ -111,7 +117,7 @@ async fn openai_maps_401_429_500() {
         .chat(sample_request())
         .await
         .expect_err("500 should fail");
-    assert!(matches!(err, MotosanError::ProviderError(_)));
+    assert!(matches!(err, MotosanError::ProviderError { .. }));
     provider_error.assert_async().await;
 }
 
@@ -137,7 +143,7 @@ async fn minimax_maps_401_429_500() {
         .chat(sample_request())
         .await
         .expect_err("401 should fail");
-    assert!(matches!(err, MotosanError::Auth(_)));
+    assert!(matches!(err, MotosanError::Auth { .. }));
     unauthorized.assert_async().await;
 
     server.reset();
@@ -151,7 +157,7 @@ async fn minimax_maps_401_429_500() {
         .chat(sample_request())
         .await
         .expect_err("429 should fail");
-    assert!(matches!(err, MotosanError::RateLimit(_)));
+    assert!(matches!(err, MotosanError::RateLimit { .. }));
     rate_limited.assert_async().await;
 
     server.reset();
@@ -165,6 +171,6 @@ async fn minimax_maps_401_429_500() {
         .chat(sample_request())
         .await
         .expect_err("500 should fail");
-    assert!(matches!(err, MotosanError::ProviderError(_)));
+    assert!(matches!(err, MotosanError::ProviderError { .. }));
     provider_error.assert_async().await;
 }

--- a/sdks/rust/tests/gemini_code_assist.rs
+++ b/sdks/rust/tests/gemini_code_assist.rs
@@ -207,7 +207,7 @@ async fn chat_401_returns_auth_error() {
         .unwrap_err();
 
     assert!(
-        matches!(err, MotosanError::Auth(_)),
+        matches!(err, MotosanError::Auth { .. }),
         "expected Auth, got {err:?}"
     );
 }
@@ -452,5 +452,5 @@ async fn stream_401_returns_auth_error() {
         Err(e) => e,
         Ok(_) => panic!("expected error"),
     };
-    assert!(matches!(err, MotosanError::Auth(_)));
+    assert!(matches!(err, MotosanError::Auth { .. }));
 }

--- a/sdks/rust/tests/gemini_provider.rs
+++ b/sdks/rust/tests/gemini_provider.rs
@@ -253,7 +253,7 @@ async fn chat_401_returns_auth_error() {
         .await
         .unwrap_err();
     assert!(
-        matches!(err, MotosanError::Auth(_)),
+        matches!(err, MotosanError::Auth { .. }),
         "expected Auth, got {err:?}"
     );
 }
@@ -279,7 +279,7 @@ async fn chat_400_returns_invalid_request() {
         .await
         .unwrap_err();
     assert!(
-        matches!(err, MotosanError::InvalidRequest(_)),
+        matches!(err, MotosanError::InvalidRequest { .. }),
         "expected InvalidRequest, got {err:?}"
     );
 }
@@ -305,7 +305,7 @@ async fn chat_500_returns_provider_error() {
         .await
         .unwrap_err();
     assert!(
-        matches!(err, MotosanError::ProviderError(_)),
+        matches!(err, MotosanError::ProviderError { .. }),
         "expected ProviderError, got {err:?}"
     );
 }
@@ -400,7 +400,7 @@ async fn chat_exhausts_retries_on_persistent_500() {
         )
         .await
         .unwrap_err();
-    assert!(matches!(err, MotosanError::ProviderError(_)));
+    assert!(matches!(err, MotosanError::ProviderError { .. }));
 }
 
 // ---------------------------------------------------------------------------
@@ -627,7 +627,7 @@ async fn stream_401_returns_auth_error() {
         Ok(_) => panic!("expected Auth error, got Ok"),
     };
     assert!(
-        matches!(err, MotosanError::Auth(_)),
+        matches!(err, MotosanError::Auth { .. }),
         "expected Auth, got {err:?}"
     );
 }

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -299,7 +299,7 @@ async fn openai_stream_maps_structured_error_payload() {
         .build();
 
     let result = provider.stream(request).await;
-    assert!(matches!(result, Err(MotosanError::Auth(_))));
+    assert!(matches!(result, Err(MotosanError::Auth { .. })));
     mock.assert_async().await;
 }
 
@@ -371,6 +371,50 @@ async fn openai_chat_can_fallback_to_responses_api_on_404() {
     assert_eq!(response.content, "fallback response");
     assert_eq!(response.usage.input_tokens, 5);
     assert_eq!(response.usage.output_tokens, 3);
+    responses_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_responses_fallback_non_json_error_preserves_http_metadata() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(404)
+        .with_body(json!({"error": {"message": "not found"}}).to_string())
+        .create_async()
+        .await;
+
+    let responses_mock = server
+        .mock("POST", "/v1/responses")
+        .match_header("authorization", "Bearer test-key")
+        .with_status(503)
+        .with_header("retry-after", "7")
+        .with_header("request-id", "resp_req")
+        .with_body("upstream unavailable")
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None)
+        .with_chat_url(format!("{}/v1/chat/completions", server.url()))
+        .with_responses_url(format!("{}/v1/responses", server.url()))
+        .with_responses_fallback(true);
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let err = provider
+        .chat(request)
+        .await
+        .expect_err("non-JSON Responses API 503 should fail");
+    assert!(matches!(err, MotosanError::ProviderError { .. }));
+    assert_eq!(err.status_code(), Some(503));
+    assert_eq!(err.retry_after(), Some(std::time::Duration::from_secs(7)));
+    assert_eq!(err.request_id(), Some("resp_req"));
+    assert_eq!(
+        err.to_string(),
+        "provider error: openai responses request failed"
+    );
     responses_mock.assert_async().await;
 }
 

--- a/sdks/rust/tests/openai_retry.rs
+++ b/sdks/rust/tests/openai_retry.rs
@@ -127,7 +127,7 @@ async fn openai_chat_does_not_retry_on_400() {
         )
         .await;
 
-    assert!(matches!(result, Err(MotosanError::InvalidRequest(_))));
+    assert!(matches!(result, Err(MotosanError::InvalidRequest { .. })));
     bad_request.assert_async().await;
 }
 


### PR DESCRIPTION
Summary:
- Task 2: Converts Rust HTTP-mapped MotosanError variants to structured metadata and propagates Retry-After/request-id through HTTP providers, including non-JSON Responses API fallback metadata coverage.
- Task 3: Hardens Retry-After parsing with 60s cap, decimal seconds, HTTP-date support, and 408/409 retry classification.
- Task 4: Adds full-jitter RetryPolicy delays plus RetryEvent/RetryCause/on_retry surface; the hook remains inert until PR-R2 send_with_retry.

M2 PR-R1: docs/superpowers/plans/2026-07-15-stream-retry-m2-implementation.md

BREAKING: Rust MotosanError enum shape changes; RetryPolicy gains on_retry. Display strings are unchanged; version bump happens in PR-REL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)