### PR TITLE
feat(rust): one send_with_retry engine; migrate all six HTTP providers (M2)

### DIFF
--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -3,8 +3,8 @@ const DEFAULT_MAX_TOKENS: u32 = 8192;
 use crate::error::MotosanError;
 use crate::models::DEFAULT_ANTHROPIC_MODEL;
 use crate::providers::{
-    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
-    map_http_error, parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
+    ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -467,51 +467,21 @@ impl ProviderImpl for AnthropicProvider {
             || req.mcp_tool_configs.as_ref().is_some_and(|c| !c.is_empty());
         let body = AnthropicRequestBuilder::new(req, self.model.clone(), is_oauth).build();
         let adaptive_thinking = body["thinking"]["type"].as_str() == Some("adaptive");
-        let mut attempt = 0;
-        let payload: Value;
-        loop {
+        let response = send_with_retry(&self.retry_policy, || {
             let request = self
                 .http
                 .post(self.endpoint())
                 .header("anthropic-version", "2023-06-01")
                 .json(&body);
             let request = Self::apply_beta_header(request, has_mcp, is_oauth, adaptive_thinking);
-            let response = match self.apply_auth(request).send().await {
-                Ok(response) => response,
-                Err(error) => {
-                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
-                    {
-                        attempt += 1;
-                        sleep_before_retry(&self.retry_policy, attempt, None).await;
-                        continue;
-                    }
-                    return Err(MotosanError::Network(error.to_string()));
-                }
-            };
+            self.apply_auth(request)
+        })
+        .await?;
 
-            let status = response.status();
+        let status = response.status();
+        if !status.is_success() {
             let retry_after = parse_retry_after(response.headers());
             let request_id = extract_request_id(response.headers());
-
-            if status.is_success() {
-                payload = response
-                    .json()
-                    .await
-                    .map_err(|error| MotosanError::ProviderError {
-                        message: error.to_string(),
-                        status_code: None,
-                        retry_after: None,
-                        request_id: None,
-                    })?;
-                break;
-            }
-
-            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
-                attempt += 1;
-                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                continue;
-            }
-
             let error_payload: Value = response.json().await.unwrap_or(json!({}));
             let message = extract_error_message(&error_payload, "anthropic request failed");
             let message = Self::with_auth_hint(
@@ -526,6 +496,17 @@ impl ProviderImpl for AnthropicProvider {
                 request_id,
             ));
         }
+
+        let payload: Value =
+            response
+                .json()
+                .await
+                .map_err(|error| MotosanError::ProviderError {
+                    message: error.to_string(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                })?;
 
         let content_blocks = payload.get("content").and_then(Value::as_array);
 
@@ -811,40 +792,21 @@ impl ProviderImpl for AnthropicProvider {
                 .build()
         };
         let adaptive_thinking = body["thinking"]["type"].as_str() == Some("adaptive");
-        let mut attempt = 0;
-        let response = loop {
+        let response = send_with_retry(&self.retry_policy, || {
             let request = self
                 .http
                 .post(self.endpoint())
                 .header("anthropic-version", "2023-06-01")
                 .json(&body);
             let request = Self::apply_beta_header(request, has_mcp, is_oauth, adaptive_thinking);
-            let response = match self.apply_auth(request).send().await {
-                Ok(response) => response,
-                Err(error) => {
-                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
-                    {
-                        attempt += 1;
-                        sleep_before_retry(&self.retry_policy, attempt, None).await;
-                        continue;
-                    }
-                    return Err(MotosanError::Network(error.to_string()));
-                }
-            };
+            self.apply_auth(request)
+        })
+        .await?;
 
-            let status = response.status();
-            if status.is_success() {
-                break response;
-            }
-
+        let status = response.status();
+        if !status.is_success() {
             let retry_after = parse_retry_after(response.headers());
             let request_id = extract_request_id(response.headers());
-            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
-                attempt += 1;
-                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                continue;
-            }
-
             let message = response
                 .text()
                 .await
@@ -860,7 +822,7 @@ impl ProviderImpl for AnthropicProvider {
                 retry_after,
                 request_id,
             ));
-        };
+        }
 
         let raw_stream = response.bytes_stream().eventsource();
         let adapter = AnthropicStreamAdapter {

--- a/sdks/rust/src/providers/chatgpt_codex.rs
+++ b/sdks/rust/src/providers/chatgpt_codex.rs
@@ -1,7 +1,7 @@
 use crate::error::MotosanError;
 use crate::providers::{
-    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
-    map_http_error, parse_retry_after, sleep_before_retry, ProviderImpl,
+    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
+    ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::{collect_stream, BoxStream};
@@ -256,55 +256,35 @@ impl ProviderImpl for ChatGptCodexProvider {
         let url = self.url();
         let body = self.build_responses_body(&req);
 
-        let mut attempt = 0u32;
-        loop {
-            let result = self
-                .apply_auth(
-                    self.http
-                        .post(&url)
-                        .header("content-type", "application/json"),
-                )
-                .json(&body)
-                .send()
-                .await;
+        let response = send_with_retry(&self.retry_policy, || {
+            self.apply_auth(
+                self.http
+                    .post(&url)
+                    .header("content-type", "application/json"),
+            )
+            .json(&body)
+        })
+        .await?;
 
-            match result {
-                Err(e)
-                    if is_retryable_network_error(&e)
-                        && attempt < self.retry_policy.max_retries =>
-                {
-                    attempt += 1;
-                    sleep_before_retry(&self.retry_policy, attempt, None).await;
-                    continue;
-                }
-                Err(e) => return Err(MotosanError::Network(e.to_string())),
-                Ok(resp) => {
-                    let status = resp.status().as_u16();
-                    if status != 200 {
-                        let retry_after = parse_retry_after(resp.headers());
-                        let request_id = extract_request_id(resp.headers());
-                        let payload: Value = resp.json().await.unwrap_or(json!({}));
-                        let msg = extract_error_message(&payload, "ChatGPT-backend error");
-                        if is_retryable_status(status) && attempt < self.retry_policy.max_retries {
-                            attempt += 1;
-                            sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                            continue;
-                        }
-                        return Err(map_http_error(status, msg, retry_after, request_id));
-                    }
-                    let sse = resp.bytes_stream().eventsource();
-                    let adapter = ChatGptCodexStreamAdapter {
-                        inner: Box::pin(sse),
-                        pending: VecDeque::new(),
-                        item_to_call_id: HashMap::new(),
-                        seen_tool_ids: HashSet::new(),
-                        saw_tool_call: false,
-                        error: None,
-                    };
-                    return Ok(Box::pin(adapter));
-                }
-            }
+        let status = response.status().as_u16();
+        if status != 200 {
+            let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
+            let payload: Value = response.json().await.unwrap_or(json!({}));
+            let msg = extract_error_message(&payload, "ChatGPT-backend error");
+            return Err(map_http_error(status, msg, retry_after, request_id));
         }
+
+        let sse = response.bytes_stream().eventsource();
+        let adapter = ChatGptCodexStreamAdapter {
+            inner: Box::pin(sse),
+            pending: VecDeque::new(),
+            item_to_call_id: HashMap::new(),
+            seen_tool_ids: HashSet::new(),
+            saw_tool_call: false,
+            error: None,
+        };
+        Ok(Box::pin(adapter))
     }
 }
 

--- a/sdks/rust/src/providers/gemini.rs
+++ b/sdks/rust/src/providers/gemini.rs
@@ -3,8 +3,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::error::MotosanError;
 use crate::models::DEFAULT_GEMINI_MODEL;
 use crate::providers::{
-    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
-    map_http_error, parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
+    ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -321,104 +321,66 @@ impl ProviderImpl for GeminiProvider {
         let url = self.generate_url(&req);
         let body = Self::build_request(&req);
 
-        let mut attempt = 0u32;
-        loop {
-            let result = self
-                .apply_auth(
-                    self.http
-                        .post(&url)
-                        .header("content-type", "application/json"),
-                )
-                .json(&body)
-                .send()
-                .await;
+        let response = send_with_retry(&self.retry_policy, || {
+            self.apply_auth(
+                self.http
+                    .post(&url)
+                    .header("content-type", "application/json"),
+            )
+            .json(&body)
+        })
+        .await?;
 
-            match result {
-                Err(e)
-                    if is_retryable_network_error(&e)
-                        && attempt < self.retry_policy.max_retries =>
-                {
-                    attempt += 1;
-                    sleep_before_retry(&self.retry_policy, attempt, None).await;
-                    continue;
-                }
-                Err(e) => return Err(MotosanError::Network(e.to_string())),
-                Ok(resp) => {
-                    let status = resp.status().as_u16();
-                    if status != 200 {
-                        let retry_after = parse_retry_after(resp.headers());
-                        let request_id = extract_request_id(resp.headers());
-                        let payload: Value = resp.json().await.unwrap_or(json!({}));
-                        let msg = extract_error_message(&payload, "Gemini API error");
-                        if is_retryable_status(status) && attempt < self.retry_policy.max_retries {
-                            attempt += 1;
-                            sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                            continue;
-                        }
-                        return Err(map_http_error(status, msg, retry_after, request_id));
-                    }
-                    let payload: Value =
-                        resp.json().await.map_err(|e| MotosanError::ProviderError {
-                            message: format!("failed to parse Gemini response: {e}"),
-                            status_code: None,
-                            retry_after: None,
-                            request_id: None,
-                        })?;
-                    return Ok(Self::parse_response(&payload, &model));
-                }
-            }
+        let status = response.status().as_u16();
+        if status != 200 {
+            let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
+            let payload: Value = response.json().await.unwrap_or(json!({}));
+            let msg = extract_error_message(&payload, "Gemini API error");
+            return Err(map_http_error(status, msg, retry_after, request_id));
         }
+
+        let payload: Value = response
+            .json()
+            .await
+            .map_err(|e| MotosanError::ProviderError {
+                message: format!("failed to parse Gemini response: {e}"),
+                status_code: None,
+                retry_after: None,
+                request_id: None,
+            })?;
+        Ok(Self::parse_response(&payload, &model))
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
         let url = self.stream_url(&req);
         let body = Self::build_request(&req);
 
-        let mut attempt = 0u32;
-        loop {
-            let result = self
-                .apply_auth(
-                    self.http
-                        .post(&url)
-                        .header("content-type", "application/json"),
-                )
-                .json(&body)
-                .send()
-                .await;
+        let response = send_with_retry(&self.retry_policy, || {
+            self.apply_auth(
+                self.http
+                    .post(&url)
+                    .header("content-type", "application/json"),
+            )
+            .json(&body)
+        })
+        .await?;
 
-            match result {
-                Err(e)
-                    if is_retryable_network_error(&e)
-                        && attempt < self.retry_policy.max_retries =>
-                {
-                    attempt += 1;
-                    sleep_before_retry(&self.retry_policy, attempt, None).await;
-                    continue;
-                }
-                Err(e) => return Err(MotosanError::Network(e.to_string())),
-                Ok(resp) => {
-                    let status = resp.status().as_u16();
-                    if status != 200 {
-                        let retry_after = parse_retry_after(resp.headers());
-                        let request_id = extract_request_id(resp.headers());
-                        let payload: Value = resp.json().await.unwrap_or(json!({}));
-                        let msg = extract_error_message(&payload, "Gemini stream error");
-                        if is_retryable_status(status) && attempt < self.retry_policy.max_retries {
-                            attempt += 1;
-                            sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                            continue;
-                        }
-                        return Err(map_http_error(status, msg, retry_after, request_id));
-                    }
-                    let sse = resp.bytes_stream().eventsource();
-                    let adapter = GeminiStreamAdapter {
-                        inner: Box::pin(sse),
-                        pending: VecDeque::new(),
-                    };
-                    return Ok(Box::pin(adapter));
-                }
-            }
+        let status = response.status().as_u16();
+        if status != 200 {
+            let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
+            let payload: Value = response.json().await.unwrap_or(json!({}));
+            let msg = extract_error_message(&payload, "Gemini stream error");
+            return Err(map_http_error(status, msg, retry_after, request_id));
         }
+
+        let sse = response.bytes_stream().eventsource();
+        let adapter = GeminiStreamAdapter {
+            inner: Box::pin(sse),
+            pending: VecDeque::new(),
+        };
+        Ok(Box::pin(adapter))
     }
 }
 

--- a/sdks/rust/src/providers/gemini_code_assist.rs
+++ b/sdks/rust/src/providers/gemini_code_assist.rs
@@ -4,8 +4,8 @@ use crate::error::MotosanError;
 use crate::models::{DEFAULT_GEMINI_CODE_ASSIST_MODEL, GEMINI_CODE_ASSIST_BASE_URL};
 use crate::providers::gemini::GeminiProvider;
 use crate::providers::{
-    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
-    map_http_error, parse_retry_after, sleep_before_retry, ProviderImpl,
+    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
+    ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::{collect_stream, BoxStream};
@@ -122,52 +122,32 @@ impl ProviderImpl for GeminiCodeAssistProvider {
         let url = self.stream_url();
         let body = self.build_envelope(&req);
 
-        let mut attempt = 0u32;
-        loop {
-            let result = self
-                .apply_auth(
-                    self.http
-                        .post(&url)
-                        .header("content-type", "application/json"),
-                )
-                .json(&body)
-                .send()
-                .await;
+        let response = send_with_retry(&self.retry_policy, || {
+            self.apply_auth(
+                self.http
+                    .post(&url)
+                    .header("content-type", "application/json"),
+            )
+            .json(&body)
+        })
+        .await?;
 
-            match result {
-                Err(e)
-                    if is_retryable_network_error(&e)
-                        && attempt < self.retry_policy.max_retries =>
-                {
-                    attempt += 1;
-                    sleep_before_retry(&self.retry_policy, attempt, None).await;
-                    continue;
-                }
-                Err(e) => return Err(MotosanError::Network(e.to_string())),
-                Ok(resp) => {
-                    let status = resp.status().as_u16();
-                    if status != 200 {
-                        let retry_after = parse_retry_after(resp.headers());
-                        let request_id = extract_request_id(resp.headers());
-                        let payload: Value = resp.json().await.unwrap_or(json!({}));
-                        let msg = extract_error_message(&payload, "Gemini Code Assist error");
-                        if is_retryable_status(status) && attempt < self.retry_policy.max_retries {
-                            attempt += 1;
-                            sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                            continue;
-                        }
-                        return Err(map_http_error(status, msg, retry_after, request_id));
-                    }
-                    let sse = resp.bytes_stream().eventsource();
-                    let adapter = CodeAssistStreamAdapter {
-                        inner: Box::pin(sse),
-                        pending: VecDeque::new(),
-                        seen_tool_ids: std::collections::HashSet::new(),
-                    };
-                    return Ok(Box::pin(adapter));
-                }
-            }
+        let status = response.status().as_u16();
+        if status != 200 {
+            let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
+            let payload: Value = response.json().await.unwrap_or(json!({}));
+            let msg = extract_error_message(&payload, "Gemini Code Assist error");
+            return Err(map_http_error(status, msg, retry_after, request_id));
         }
+
+        let sse = response.bytes_stream().eventsource();
+        let adapter = CodeAssistStreamAdapter {
+            inner: Box::pin(sse),
+            pending: VecDeque::new(),
+            seen_tool_ids: std::collections::HashSet::new(),
+        };
+        Ok(Box::pin(adapter))
     }
 }
 

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -394,30 +394,6 @@ pub(crate) fn extract_request_id(headers: &HeaderMap) -> Option<String> {
     feature = "gemini-code-assist",
     feature = "chatgpt-codex",
 ))]
-pub(crate) async fn sleep_before_retry(
-    policy: &RetryPolicy,
-    attempt: u32,
-    retry_after: Option<Duration>,
-) {
-    // retry_after arrives pre-capped to RETRY_AFTER_CAP by parse_retry_after.
-    let delay = if policy.respect_retry_after {
-        retry_after.unwrap_or_else(|| policy.delay_for_attempt(attempt))
-    } else {
-        policy.delay_for_attempt(attempt)
-    };
-
-    tokio::time::sleep(delay).await;
-}
-
-#[cfg(any(
-    feature = "anthropic",
-    feature = "openai",
-    feature = "minimax",
-    feature = "ollama_native",
-    feature = "gemini",
-    feature = "gemini-code-assist",
-    feature = "chatgpt-codex",
-))]
 async fn observe_and_sleep(
     policy: &RetryPolicy,
     attempt: u32,

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -8,7 +8,7 @@ use crate::error::MotosanError;
     feature = "gemini-code-assist",
     feature = "chatgpt-codex",
 ))]
-use crate::retry::RetryPolicy;
+use crate::retry::{RetryCause, RetryEvent, RetryPolicy};
 use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, ContentBlock, ProviderCapabilities};
 #[cfg(any(
@@ -407,6 +407,85 @@ pub(crate) async fn sleep_before_retry(
     };
 
     tokio::time::sleep(delay).await;
+}
+
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+async fn observe_and_sleep(
+    policy: &RetryPolicy,
+    attempt: u32,
+    retry_after: Option<Duration>,
+    cause: RetryCause,
+) {
+    // Compute once so the observer sees the exact delay that is slept.
+    let delay = if policy.respect_retry_after {
+        retry_after.unwrap_or_else(|| policy.delay_for_attempt(attempt))
+    } else {
+        policy.delay_for_attempt(attempt)
+    };
+    if let Some(on_retry) = policy.on_retry.as_deref() {
+        on_retry(RetryEvent {
+            attempt,
+            delay,
+            cause,
+        });
+    }
+    tokio::time::sleep(delay).await;
+}
+
+/// One retry engine for every HTTP provider (normative contract: specs/retry.md).
+///
+/// Returns success and terminal non-success responses with the body untouched,
+/// leaving caller-side parsing and provider-specific error shaping intact.
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+pub(crate) async fn send_with_retry(
+    policy: &RetryPolicy,
+    build: impl Fn() -> reqwest::RequestBuilder,
+) -> Result<reqwest::Response, MotosanError> {
+    let mut attempt: u32 = 0;
+    loop {
+        let response = match build().send().await {
+            Ok(response) => response,
+            Err(error) => {
+                if attempt < policy.max_retries && is_retryable_network_error(&error) {
+                    attempt += 1;
+                    let cause = RetryCause::Network(error.to_string());
+                    observe_and_sleep(policy, attempt, None, cause).await;
+                    continue;
+                }
+                return Err(MotosanError::Network(error.to_string()));
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success()
+            && attempt < policy.max_retries
+            && is_retryable_status(status.as_u16())
+        {
+            let retry_after = parse_retry_after(response.headers());
+            attempt += 1;
+            let cause = RetryCause::Status(status.as_u16());
+            observe_and_sleep(policy, attempt, retry_after, cause).await;
+            continue;
+        }
+
+        return Ok(response);
+    }
 }
 
 #[cfg(test)]

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -1,8 +1,8 @@
 use crate::error::MotosanError;
 use crate::models::DEFAULT_OLLAMA_MODEL;
 use crate::providers::{
-    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
-    map_http_error, parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
+    ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -246,44 +246,28 @@ impl OllamaProvider {
 impl ProviderImpl for OllamaProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let body = self.build_request_body(&req, false);
-        let mut attempt = 0;
-        let payload: Value;
 
-        loop {
-            let response = match self.http.post(self.endpoint()).json(&body).send().await {
-                Ok(response) => response,
-                Err(error) => {
-                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
-                    {
-                        attempt += 1;
-                        sleep_before_retry(&self.retry_policy, attempt, None).await;
-                        continue;
-                    }
-                    return Err(MotosanError::Network(error.to_string()));
-                }
-            };
+        let response = send_with_retry(&self.retry_policy, || {
+            self.http.post(self.endpoint()).json(&body)
+        })
+        .await?;
 
-            let status = response.status();
+        let status = response.status();
+        if !status.is_success() {
             let retry_after = parse_retry_after(response.headers());
             let request_id = extract_request_id(response.headers());
+            let error_payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
+            let message = extract_error_message(&error_payload, "ollama request failed");
+            return Err(map_http_error(
+                status.as_u16(),
+                message,
+                retry_after,
+                request_id,
+            ));
+        }
 
-            if !status.is_success() {
-                if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
-                    attempt += 1;
-                    sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                    continue;
-                }
-                let error_payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
-                let message = extract_error_message(&error_payload, "ollama request failed");
-                return Err(map_http_error(
-                    status.as_u16(),
-                    message,
-                    retry_after,
-                    request_id,
-                ));
-            }
-
-            payload = response
+        let payload: Value =
+            response
                 .json()
                 .await
                 .map_err(|error| MotosanError::ProviderError {
@@ -292,8 +276,6 @@ impl ProviderImpl for OllamaProvider {
                     retry_after: None,
                     request_id: None,
                 })?;
-            break;
-        }
 
         let message = payload.get("message");
 
@@ -360,35 +342,16 @@ impl ProviderImpl for OllamaProvider {
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream, MotosanError> {
         let body = self.build_request_body(&req, true);
-        let mut attempt = 0;
 
-        let response = loop {
-            let response = match self.http.post(self.endpoint()).json(&body).send().await {
-                Ok(response) => response,
-                Err(error) => {
-                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
-                    {
-                        attempt += 1;
-                        sleep_before_retry(&self.retry_policy, attempt, None).await;
-                        continue;
-                    }
-                    return Err(MotosanError::Network(error.to_string()));
-                }
-            };
+        let response = send_with_retry(&self.retry_policy, || {
+            self.http.post(self.endpoint()).json(&body)
+        })
+        .await?;
 
-            let status = response.status();
-            if status.is_success() {
-                break response;
-            }
-
+        let status = response.status();
+        if !status.is_success() {
             let retry_after = parse_retry_after(response.headers());
             let request_id = extract_request_id(response.headers());
-            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
-                attempt += 1;
-                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                continue;
-            }
-
             let body_bytes = response.bytes().await.ok();
             if let Some(payload) = body_bytes
                 .as_deref()
@@ -414,7 +377,7 @@ impl ProviderImpl for OllamaProvider {
                 retry_after,
                 request_id,
             ));
-        };
+        }
 
         // NDJSON parsing: each line is a separate JSON object
         let byte_stream = response.bytes_stream();

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -1,8 +1,8 @@
 use crate::error::MotosanError;
 use crate::models::DEFAULT_OPENAI_MODEL;
 use crate::providers::{
-    extract_error_message, extract_request_id, is_retryable_network_error, is_retryable_status,
-    map_http_error, parse_retry_after, sleep_before_retry, ChatResponseBuilder, ProviderImpl,
+    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
+    ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -244,17 +244,15 @@ impl OpenAIProvider {
             }
         }
 
-        let response = self
-            .apply_auth(self.http.post(&self.responses_url).json(&body))
-            .send()
-            .await
-            .map_err(|error| MotosanError::Network(error.to_string()))?;
+        let response = send_with_retry(&self.retry_policy, || {
+            self.apply_auth(self.http.post(&self.responses_url).json(&body))
+        })
+        .await?;
 
         let status = response.status();
-        let retry_after = parse_retry_after(response.headers());
-        let request_id = extract_request_id(response.headers());
-
         if !status.is_success() {
+            let retry_after = parse_retry_after(response.headers());
+            let request_id = extract_request_id(response.headers());
             let error_payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
             let message = extract_error_message(&error_payload, "openai responses request failed");
             return Err(map_http_error(
@@ -494,53 +492,21 @@ impl ProviderImpl for OpenAIProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let fallback_request = req.clone();
         let body = OpenAIRequestBuilder::new(req, self.model.clone()).build();
-        let mut attempt = 0;
-        let payload: Value;
-        loop {
-            let response = match self
-                .apply_auth(self.http.post(&self.chat_url).json(&body))
-                .send()
-                .await
-            {
-                Ok(response) => response,
-                Err(error) => {
-                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
-                    {
-                        attempt += 1;
-                        sleep_before_retry(&self.retry_policy, attempt, None).await;
-                        continue;
-                    }
-                    return Err(MotosanError::Network(error.to_string()));
-                }
-            };
 
-            let status = response.status();
+        let response = send_with_retry(&self.retry_policy, || {
+            self.apply_auth(self.http.post(&self.chat_url).json(&body))
+        })
+        .await?;
+
+        let status = response.status();
+
+        if self.responses_fallback && status.as_u16() == 404 {
+            return self.chat_via_responses(&fallback_request).await;
+        }
+
+        if !status.is_success() {
             let retry_after = parse_retry_after(response.headers());
             let request_id = extract_request_id(response.headers());
-
-            if self.responses_fallback && status.as_u16() == 404 {
-                return self.chat_via_responses(&fallback_request).await;
-            }
-
-            if status.is_success() {
-                payload = response
-                    .json()
-                    .await
-                    .map_err(|error| MotosanError::ProviderError {
-                        message: error.to_string(),
-                        status_code: None,
-                        retry_after: None,
-                        request_id: None,
-                    })?;
-                break;
-            }
-
-            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
-                attempt += 1;
-                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                continue;
-            }
-
             let error_payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
             let message = extract_error_message(&error_payload, "openai request failed");
             return Err(map_http_error(
@@ -550,6 +516,17 @@ impl ProviderImpl for OpenAIProvider {
                 request_id,
             ));
         }
+
+        let payload: Value =
+            response
+                .json()
+                .await
+                .map_err(|error| MotosanError::ProviderError {
+                    message: error.to_string(),
+                    status_code: None,
+                    retry_after: None,
+                    request_id: None,
+                })?;
 
         let content = Self::extract_chat_content(&payload);
 
@@ -621,38 +598,16 @@ impl ProviderImpl for OpenAIProvider {
         let body = OpenAIRequestBuilder::new(req, self.model.clone())
             .stream(true)
             .build();
-        let mut attempt = 0;
-        let response = loop {
-            let response = match self
-                .apply_auth(self.http.post(&self.chat_url).json(&body))
-                .send()
-                .await
-            {
-                Ok(response) => response,
-                Err(error) => {
-                    if attempt < self.retry_policy.max_retries && is_retryable_network_error(&error)
-                    {
-                        attempt += 1;
-                        sleep_before_retry(&self.retry_policy, attempt, None).await;
-                        continue;
-                    }
-                    return Err(MotosanError::Network(error.to_string()));
-                }
-            };
 
-            let status = response.status();
-            if status.is_success() {
-                break response;
-            }
+        let response = send_with_retry(&self.retry_policy, || {
+            self.apply_auth(self.http.post(&self.chat_url).json(&body))
+        })
+        .await?;
 
+        let status = response.status();
+        if !status.is_success() {
             let retry_after = parse_retry_after(response.headers());
             let request_id = extract_request_id(response.headers());
-            if attempt < self.retry_policy.max_retries && is_retryable_status(status.as_u16()) {
-                attempt += 1;
-                sleep_before_retry(&self.retry_policy, attempt, retry_after).await;
-                continue;
-            }
-
             let current_payload: Value = response
                 .json()
                 .await
@@ -664,7 +619,7 @@ impl ProviderImpl for OpenAIProvider {
                 retry_after,
                 request_id,
             ));
-        };
+        }
 
         let raw_stream = response.bytes_stream().eventsource();
         let adapter = OpenAIStreamAdapter {

--- a/sdks/rust/tests/chatgpt_codex.rs
+++ b/sdks/rust/tests/chatgpt_codex.rs
@@ -177,3 +177,62 @@ async fn stream_401_returns_auth_error() {
     };
     assert!(matches!(err, MotosanError::Auth { .. }), "got {err:?}");
 }
+
+#[tokio::test]
+async fn stream_fires_on_retry_via_shared_engine() {
+    use motosan_ai::retry::RetryCause;
+    use std::sync::{Arc, Mutex};
+
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", Matcher::Any)
+        .with_status(503)
+        .with_body(r#"{"error":{"message":"overloaded"}}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    server
+        .mock("POST", Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(FIXTURE)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let seen: Arc<Mutex<Vec<(u32, u16)>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+    let mut policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    policy.on_retry = Some(Arc::new(move |evt| {
+        let status = match evt.cause {
+            RetryCause::Status(code) => code,
+            RetryCause::Network(_) => 0,
+        };
+        sink.lock().unwrap().push((evt.attempt, status));
+    }));
+
+    let provider =
+        ChatGptCodexProvider::new("oauth-token", "acct-123", "gpt-5.5", Some(server.url()))
+            .with_retry_policy(policy);
+    let mut stream = provider
+        .stream(
+            ChatRequest::builder()
+                .messages(vec![Message::user("hi")])
+                .build(),
+        )
+        .await
+        .unwrap();
+    let mut text = String::new();
+    while let Some(item) = stream.next().await {
+        let ev = item.expect("stream item should not fail");
+        if ev.event_type == StreamEventType::Text {
+            text.push_str(&ev.content);
+        }
+    }
+    assert_eq!(text, EXPECTED_TEXT);
+    assert_eq!(*seen.lock().unwrap(), vec![(1, 503)]);
+}

--- a/sdks/rust/tests/gemini_code_assist.rs
+++ b/sdks/rust/tests/gemini_code_assist.rs
@@ -454,3 +454,51 @@ async fn stream_401_returns_auth_error() {
     };
     assert!(matches!(err, MotosanError::Auth { .. }));
 }
+
+#[tokio::test]
+async fn chat_fires_on_retry_via_shared_engine() {
+    use motosan_ai::retry::RetryCause;
+    use std::sync::{Arc, Mutex};
+
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", Matcher::Regex("streamGenerateContent".into()))
+        .with_status(503)
+        .with_body(r#"{"error":{"message":"overloaded"}}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    server
+        .mock("POST", Matcher::Regex("streamGenerateContent".into()))
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_text("recovered", Some("STOP")))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let seen: Arc<Mutex<Vec<(u32, u16)>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+    let mut policy = fast_retry();
+    policy.on_retry = Some(Arc::new(move |evt| {
+        let status = match evt.cause {
+            RetryCause::Status(code) => code,
+            RetryCause::Network(_) => 0,
+        };
+        sink.lock().unwrap().push((evt.attempt, status));
+    }));
+
+    let provider =
+        GeminiCodeAssistProvider::new("ya29.fake", "my-project", None, Some(server.url()))
+            .with_retry_policy(policy);
+    let resp = provider
+        .chat(
+            ChatRequest::builder()
+                .messages(vec![Message::user("hi")])
+                .build(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.content, "recovered");
+    assert_eq!(*seen.lock().unwrap(), vec![(1, 503)]);
+}

--- a/sdks/rust/tests/gemini_provider.rs
+++ b/sdks/rust/tests/gemini_provider.rs
@@ -665,3 +665,49 @@ async fn stream_retries_500_then_succeeds() {
     let resp = motosan_ai::stream::collect_stream(stream).await.unwrap();
     assert_eq!(resp.content, "Hi!");
 }
+
+#[tokio::test]
+async fn chat_fires_on_retry_via_shared_engine() {
+    use motosan_ai::retry::RetryCause;
+    use std::sync::{Arc, Mutex};
+
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", Matcher::Regex("generateContent".into()))
+        .with_status(503)
+        .with_body(r#"{"error":{"message":"overloaded"}}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    server
+        .mock("POST", Matcher::Regex("generateContent".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(ok_body("recovered"))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let seen: Arc<Mutex<Vec<(u32, u16)>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+    let mut policy = fast_retry();
+    policy.on_retry = Some(Arc::new(move |evt| {
+        let status = match evt.cause {
+            RetryCause::Status(code) => code,
+            RetryCause::Network(_) => 0,
+        };
+        sink.lock().unwrap().push((evt.attempt, status));
+    }));
+
+    let provider = GeminiProvider::new("key", None, Some(server.url())).with_retry_policy(policy);
+    let resp = provider
+        .chat(
+            ChatRequest::builder()
+                .messages(vec![Message::user("hi")])
+                .build(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.content, "recovered");
+    assert_eq!(*seen.lock().unwrap(), vec![(1, 503)]);
+}

--- a/sdks/rust/tests/ollama_native_provider.rs
+++ b/sdks/rust/tests/ollama_native_provider.rs
@@ -520,3 +520,59 @@ async fn ollama_native_chat_retries_non_json_5xx_then_succeeds() {
     error_mock.assert_async().await;
     success_mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn ollama_native_chat_fires_on_retry_via_shared_engine() {
+    use motosan_ai::retry::RetryCause;
+    use std::sync::{Arc, Mutex};
+
+    let mut server = mockito::Server::new_async().await;
+    let error_mock = server
+        .mock("POST", "/api/chat")
+        .with_status(503)
+        .with_body(r#"{"error":{"message":"overloaded"}}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let success_mock = server
+        .mock("POST", "/api/chat")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": "recovered"},
+                "done": true
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let seen: Arc<Mutex<Vec<(u32, u16)>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+    let mut policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    policy.on_retry = Some(Arc::new(move |evt| {
+        let status = match evt.cause {
+            RetryCause::Status(code) => code,
+            RetryCause::Network(_) => 0,
+        };
+        sink.lock().unwrap().push((evt.attempt, status));
+    }));
+
+    let provider = build_provider(server.url()).with_retry_policy(policy);
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let response = provider.chat(request).await.expect("retry then succeed");
+    assert_eq!(response.content, "recovered");
+    assert_eq!(*seen.lock().unwrap(), vec![(1, 503)]);
+    error_mock.assert_async().await;
+    success_mock.assert_async().await;
+}

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -4,7 +4,8 @@ use mockito::Matcher;
 use motosan_ai::providers::openai::{OpenAIAuthStyle, OpenAIProvider};
 use motosan_ai::providers::ProviderImpl;
 use motosan_ai::{
-    ChatRequest, Message, MotosanError, StopReason, StreamEventType, Tool, DEFAULT_OPENAI_MODEL,
+    ChatRequest, Message, MotosanError, RetryPolicy, StopReason, StreamEventType, Tool,
+    DEFAULT_OPENAI_MODEL,
 };
 use serde_json::json;
 use tokio_stream::StreamExt;
@@ -398,6 +399,7 @@ async fn openai_responses_fallback_non_json_error_preserves_http_metadata() {
     let provider = OpenAIProvider::new("test-key", None)
         .with_chat_url(format!("{}/v1/chat/completions", server.url()))
         .with_responses_url(format!("{}/v1/responses", server.url()))
+        .with_retry_policy(RetryPolicy::new().max_retries(0))
         .with_responses_fallback(true);
     let request = ChatRequest::builder()
         .message(Message::user("hello"))

--- a/sdks/rust/tests/openai_retry.rs
+++ b/sdks/rust/tests/openai_retry.rs
@@ -2,8 +2,10 @@
 
 use motosan_ai::providers::openai::OpenAIProvider;
 use motosan_ai::providers::ProviderImpl;
+use motosan_ai::retry::{RetryCause, RetryEvent};
 use motosan_ai::{ChatRequest, Message, MotosanError, RetryPolicy};
 use serde_json::json;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio_stream::StreamExt;
 
@@ -272,5 +274,62 @@ async fn openai_chat_retries_502_with_non_json_body() {
 
     assert_eq!(response.content, "recovered");
     bad_gateway.assert_async().await;
+    success.assert_async().await;
+}
+
+#[tokio::test]
+async fn openai_chat_fires_on_retry_observer_on_503_then_200() {
+    let mut server = mockito::Server::new_async().await;
+    let unavailable = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(503)
+        .with_body(json!({"error": {"message": "unavailable"}}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let success = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(
+            json!({
+                "model": "gpt-5.3-codex",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let events: Arc<Mutex<Vec<RetryEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&events);
+    let mut policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    policy.on_retry = Some(Arc::new(move |event: RetryEvent| {
+        sink.lock().unwrap().push(event);
+    }));
+    let provider = OpenAIProvider::new("test-key", None)
+        .with_chat_url(format!("{}/v1/chat/completions", server.url()))
+        .with_retry_policy(policy);
+
+    let response = provider
+        .chat(
+            ChatRequest::builder()
+                .message(Message::user("hello"))
+                .build(),
+        )
+        .await
+        .expect("should retry once and succeed");
+
+    assert_eq!(response.content, "ok");
+    let events = events.lock().unwrap();
+    assert_eq!(events.len(), 1, "on_retry must fire exactly once");
+    assert_eq!(events[0].attempt, 1);
+    assert!(matches!(events[0].cause, RetryCause::Status(503)));
+    unavailable.assert_async().await;
     success.assert_async().await;
 }

--- a/sdks/rust/tests/openai_retry.rs
+++ b/sdks/rust/tests/openai_retry.rs
@@ -326,10 +326,12 @@ async fn openai_chat_fires_on_retry_observer_on_503_then_200() {
         .expect("should retry once and succeed");
 
     assert_eq!(response.content, "ok");
-    let events = events.lock().unwrap();
-    assert_eq!(events.len(), 1, "on_retry must fire exactly once");
-    assert_eq!(events[0].attempt, 1);
-    assert!(matches!(events[0].cause, RetryCause::Status(503)));
+    // Drain the recorded events into a local before any `.await` so the
+    // MutexGuard is not held across an await point (clippy::await_holding_lock).
+    let recorded: Vec<RetryEvent> = std::mem::take(&mut *events.lock().unwrap());
+    assert_eq!(recorded.len(), 1, "on_retry must fire exactly once");
+    assert_eq!(recorded[0].attempt, 1);
+    assert!(matches!(recorded[0].cause, RetryCause::Status(503)));
     unavailable.assert_async().await;
     success.assert_async().await;
 }


### PR DESCRIPTION
## Summary
- Add one Rust `send_with_retry` engine and make it the sole production `on_retry` firing site.
- Route Anthropic, OpenAI chat/stream, OpenAI Responses fallback, Ollama native, Gemini, Gemini Code Assist, and ChatGPT Codex request retry through the shared engine.
- Preserve provider-side terminal error parsing with `retry_after`/`request_id` metadata, delete `sleep_before_retry`, and add shared-engine observer tests.

## Verification
- `cargo fmt && cargo clippy --all-features -- -D warnings && cargo test --all-features && cargo check --no-default-features`
- Pre-push gate passed: Python unit tests, Rust unit tests, Python live Anthropic tests, Rust live Anthropic tests.

M2 PR-R2: docs/superpowers/plans/2026-07-15-stream-retry-m2-implementation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)