### PR TITLE
feat(python): structured errors + RetryPolicy + attribute-based classification (M2)

### DIFF
--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -8,7 +8,7 @@ from dataclasses import replace
 from enum import StrEnum
 from typing import Any
 
-from motosan_ai.error import ConfigError, NetworkError, ProviderError, RateLimitError
+from motosan_ai.error import ConfigError, MotosanError, NetworkError, ProviderError, RateLimitError
 from motosan_ai.providers import (
     AnthropicProvider,
     ChatGptCodexProvider,
@@ -19,6 +19,7 @@ from motosan_ai.providers import (
     MinimaxProvider,
     OpenAIProvider,
 )
+from motosan_ai.retry import RetryPolicy
 from motosan_ai.think_stripper import ThinkStripper
 from motosan_ai.types import ChatRequest, ChatResponse, Message, StreamEvent, Tool
 
@@ -72,11 +73,15 @@ class Client:
         ollama_keep_alive: str | None = None,
         ollama_num_ctx: int | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> None:
         provider_value = Provider(provider)
         self.provider = provider_value
         self.model = model
-        self._max_retries = max_retries
+        self._retry_policy = (
+            retry_policy if retry_policy is not None else RetryPolicy(max_retries=max_retries)
+        )
+        self._max_retries = self._retry_policy.max_retries
 
         if provider_value == Provider.gemini_code_assist:
             if not access_token:
@@ -152,9 +157,14 @@ class Client:
         api_key: str | None = None,
         model: str | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> Client:
         return cls(
-            provider=Provider.anthropic, api_key=api_key, model=model, max_retries=max_retries
+            provider=Provider.anthropic,
+            api_key=api_key,
+            model=model,
+            max_retries=max_retries,
+            retry_policy=retry_policy,
         )
 
     @classmethod
@@ -163,8 +173,15 @@ class Client:
         api_key: str | None = None,
         model: str | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> Client:
-        return cls(provider=Provider.openai, api_key=api_key, model=model, max_retries=max_retries)
+        return cls(
+            provider=Provider.openai,
+            api_key=api_key,
+            model=model,
+            max_retries=max_retries,
+            retry_policy=retry_policy,
+        )
 
     @classmethod
     def gemini(
@@ -173,6 +190,7 @@ class Client:
         model: str | None = None,
         base_url: str | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> Client:
         return cls(
             provider=Provider.gemini,
@@ -180,6 +198,7 @@ class Client:
             model=model,
             base_url=base_url,
             max_retries=max_retries,
+            retry_policy=retry_policy,
         )
 
     @classmethod
@@ -190,6 +209,7 @@ class Client:
         model: str | None = None,
         base_url: str | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> Client:
         return cls(
             provider=Provider.gemini_code_assist,
@@ -198,6 +218,7 @@ class Client:
             model=model,
             base_url=base_url,
             max_retries=max_retries,
+            retry_policy=retry_policy,
         )
 
     @classmethod
@@ -209,6 +230,7 @@ class Client:
         base_url: str | None = None,
         reasoning_effort: str | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> Client:
         return cls(
             provider=Provider.openai_chatgpt,
@@ -218,6 +240,7 @@ class Client:
             base_url=base_url,
             reasoning_effort=reasoning_effort,
             max_retries=max_retries,
+            retry_policy=retry_policy,
         )
 
     @classmethod
@@ -227,6 +250,7 @@ class Client:
         model: str | None = None,
         base_url: str | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> Client:
         return cls(
             provider=Provider.minimax,
@@ -234,6 +258,7 @@ class Client:
             model=model,
             base_url=base_url,
             max_retries=max_retries,
+            retry_policy=retry_policy,
         )
 
     @classmethod
@@ -242,12 +267,14 @@ class Client:
         binary_path: str | None = None,
         model: str | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> Client:
         return cls(
             provider=Provider.codex_cli,
             binary_path=binary_path,
             model=model,
             max_retries=max_retries,
+            retry_policy=retry_policy,
         )
 
     @classmethod
@@ -256,12 +283,14 @@ class Client:
         binary_path: str | None = None,
         model: str | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> Client:
         return cls(
             provider=Provider.gemini_cli,
             binary_path=binary_path,
             model=model,
             max_retries=max_retries,
+            retry_policy=retry_policy,
         )
 
     @classmethod
@@ -275,6 +304,7 @@ class Client:
         keep_alive: str | None = None,
         num_ctx: int | None = None,
         max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
     ) -> Client:
         return cls(
             provider=Provider.ollama,
@@ -285,6 +315,7 @@ class Client:
             ollama_keep_alive=keep_alive,
             ollama_num_ctx=num_ctx,
             max_retries=max_retries,
+            retry_policy=retry_policy,
         )
 
     @staticmethod
@@ -328,12 +359,12 @@ class Client:
         if request.model is None and self.model is not None:
             request = replace(request, model=self.model)
 
-        if self._max_retries > 0:
+        if self._retry_policy.max_retries > 0:
             from motosan_ai.retry import with_retry
 
             return await with_retry(
                 lambda: self._provider.chat(request),
-                max_retries=self._max_retries,
+                policy=self._retry_policy,
             )
         return await self._provider.chat(request)
 
@@ -366,8 +397,9 @@ class Client:
         if request.model is None and self.model is not None:
             request = replace(request, model=self.model)
 
-        last_error: RateLimitError | None = None
-        max_attempts = self._max_retries + 1 if self._max_retries > 0 else 1
+        policy = self._retry_policy
+        last_error: MotosanError | None = None
+        max_attempts = policy.max_retries + 1 if policy.max_retries > 0 else 1
         for attempt in range(max_attempts):
             yielded = False
             try:
@@ -388,7 +420,12 @@ class Client:
                         yield event
                 return
             except (RateLimitError, NetworkError, ProviderError) as e:
-                from motosan_ai.retry import RetryPolicy, _is_retryable, compute_delay
+                from motosan_ai.retry import (
+                    RetryEvent,
+                    _is_retryable,
+                    compute_delay,
+                    retry_cause,
+                )
 
                 # F1: once the stream has emitted any event, a mid-stream error
                 # must propagate verbatim — retrying would replay a partially
@@ -397,17 +434,17 @@ class Client:
                 if yielded or not _is_retryable(e):
                     raise
                 last_error = e
-                if attempt >= self._max_retries:
+                if attempt >= policy.max_retries:
                     break
-                wait = compute_delay(
-                    RetryPolicy(max_retries=self._max_retries),
-                    attempt + 1,
-                    e.retry_after,
-                )
+                wait = compute_delay(policy, attempt + 1, e.retry_after)
+                if policy.on_retry is not None:
+                    policy.on_retry(
+                        RetryEvent(attempt=attempt + 1, delay=wait, cause=retry_cause(e))
+                    )
                 logger.warning(
                     "Retryable stream error (attempt %d/%d), retrying in %.1fs: %s",
                     attempt + 1,
-                    self._max_retries,
+                    policy.max_retries,
                     wait,
                     type(e).__name__,
                 )

--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -388,12 +388,7 @@ class Client:
                         yield event
                 return
             except (RateLimitError, NetworkError, ProviderError) as e:
-                from motosan_ai.retry import (
-                    DEFAULT_INITIAL_BACKOFF,
-                    DEFAULT_MAX_BACKOFF,
-                    _is_retryable,
-                    _parse_retry_after,
-                )
+                from motosan_ai.retry import RetryPolicy, _is_retryable, compute_delay
 
                 # F1: once the stream has emitted any event, a mid-stream error
                 # must propagate verbatim — retrying would replay a partially
@@ -404,12 +399,10 @@ class Client:
                 last_error = e
                 if attempt >= self._max_retries:
                     break
-                retry_after = _parse_retry_after(str(e))
-                wait = min(
-                    retry_after
-                    if retry_after is not None
-                    else DEFAULT_INITIAL_BACKOFF * (2**attempt),
-                    DEFAULT_MAX_BACKOFF,
+                wait = compute_delay(
+                    RetryPolicy(max_retries=self._max_retries),
+                    attempt + 1,
+                    e.retry_after,
                 )
                 logger.warning(
                     "Retryable stream error (attempt %d/%d), retrying in %.1fs: %s",

--- a/sdks/python/motosan_ai/error.py
+++ b/sdks/python/motosan_ai/error.py
@@ -1,5 +1,16 @@
 class MotosanError(Exception):
-    pass
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        status_code: int | None = None,
+        retry_after: float | None = None,
+        request_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.retry_after = retry_after
+        self.request_id = request_id
 
 
 class AuthError(MotosanError):

--- a/sdks/python/motosan_ai/providers/anthropic.py
+++ b/sdks/python/motosan_ai/providers/anthropic.py
@@ -9,6 +9,7 @@ import httpx
 from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
+from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
     ChatRequest,
     ChatResponse,
@@ -42,6 +43,15 @@ _STOP_REASON_MAP = {
     "stop": StopReason.stop,
     "stop_sequence": StopReason.stop_sequence,
 }
+
+
+def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, Any]:
+    retry_after = None
+    request_id = None
+    if headers is not None:
+        retry_after = parse_retry_after_header(headers.get("retry-after"))
+        request_id = headers.get("request-id") or headers.get("x-request-id")
+    return {"status_code": status, "retry_after": retry_after, "request_id": request_id}
 
 
 def _with_cache_control(block: dict[str, Any]) -> dict[str, Any]:
@@ -296,12 +306,15 @@ class AnthropicProvider(BaseProvider):
         return message
 
     @staticmethod
-    def _map_http_error(status: int, message: str) -> Exception:
+    def _map_http_error(
+        status: int, message: str, headers: httpx.Headers | None = None
+    ) -> Exception:
+        metadata = _http_error_kwargs(status, headers)
         if status == 401:
-            return AuthError(message)
+            return AuthError(message, **metadata)
         if status == 429:
-            return RateLimitError(message)
-        return ProviderError(message)
+            return RateLimitError(message, **metadata)
+        return ProviderError(message, **metadata)
 
     @staticmethod
     def _has_mcp(request: ChatRequest) -> bool:
@@ -339,7 +352,7 @@ class AnthropicProvider(BaseProvider):
 
         if not resp.is_success:
             message = self._response_error_message(resp.status_code, resp.headers, resp.text)
-            raise self._map_http_error(resp.status_code, message)
+            raise self._map_http_error(resp.status_code, message, resp.headers)
 
         payload = resp.json()
         return self._parse_response(payload)
@@ -399,7 +412,7 @@ class AnthropicProvider(BaseProvider):
                 message = self._response_error_message(
                     resp.status_code, resp.headers, error_body.decode()
                 )
-                raise self._map_http_error(resp.status_code, message)
+                raise self._map_http_error(resp.status_code, message, resp.headers)
 
             async for line in resp.aiter_lines():
                 if not line.startswith("data: "):

--- a/sdks/python/motosan_ai/providers/chatgpt_codex.py
+++ b/sdks/python/motosan_ai/providers/chatgpt_codex.py
@@ -16,6 +16,7 @@ from motosan_ai.error import (
     StreamError,
 )
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
+from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
     ChatRequest,
     ChatResponse,
@@ -28,6 +29,15 @@ from motosan_ai.types import (
 _DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/codex/responses"
 _DEFAULT_MODEL = "gpt-5.5"
 _ORIGINATOR = "codex_cli_rs"
+
+
+def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, Any]:
+    retry_after = None
+    request_id = None
+    if headers is not None:
+        retry_after = parse_retry_after_header(headers.get("retry-after"))
+        request_id = headers.get("request-id") or headers.get("x-request-id")
+    return {"status_code": status, "retry_after": retry_after, "request_id": request_id}
 
 
 @dataclass
@@ -324,12 +334,15 @@ class ChatGptCodexProvider(BaseProvider):
         return body
 
     @staticmethod
-    def _map_http_error(status: int, message: str) -> Exception:
+    def _map_http_error(
+        status: int, message: str, headers: httpx.Headers | None = None
+    ) -> Exception:
+        metadata = _http_error_kwargs(status, headers)
         if status == 401:
-            return AuthError(message)
+            return AuthError(message, **metadata)
         if status == 429:
-            return RateLimitError(message)
-        return ProviderError(message)
+            return RateLimitError(message, **metadata)
+        return ProviderError(message, **metadata)
 
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:
         self.validate_request(request)
@@ -351,7 +364,7 @@ class ChatGptCodexProvider(BaseProvider):
                 retry_after = resp.headers.get("retry-after")
                 if retry_after:
                     message = f"Retry-After: {retry_after}\n{message}"
-                raise self._map_http_error(resp.status_code, message)
+                raise self._map_http_error(resp.status_code, message, resp.headers)
 
             state = _ChatGptCodexAdapterState()
             try:

--- a/sdks/python/motosan_ai/providers/gemini.py
+++ b/sdks/python/motosan_ai/providers/gemini.py
@@ -9,6 +9,7 @@ import httpx
 
 from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
+from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
     ChatRequest,
     ChatResponse,
@@ -26,6 +27,15 @@ from motosan_ai.types import (
 _DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 _DEFAULT_MODEL = "gemini-2.5-flash"
 _DEFAULT_MAX_TOKENS = 8192
+
+
+def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, Any]:
+    retry_after = None
+    request_id = None
+    if headers is not None:
+        retry_after = parse_retry_after_header(headers.get("retry-after"))
+        request_id = headers.get("request-id") or headers.get("x-request-id")
+    return {"status_code": status, "retry_after": retry_after, "request_id": request_id}
 
 
 def _gen_tool_call_id() -> str:
@@ -202,12 +212,15 @@ class GeminiProvider(BaseProvider):
         return message
 
     @staticmethod
-    def _map_http_error(status: int, message: str) -> Exception:
+    def _map_http_error(
+        status: int, message: str, headers: httpx.Headers | None = None
+    ) -> Exception:
+        metadata = _http_error_kwargs(status, headers)
         if status == 401:
-            return AuthError(message)
+            return AuthError(message, **metadata)
         if status == 429:
-            return RateLimitError(message)
-        return ProviderError(message)
+            return RateLimitError(message, **metadata)
+        return ProviderError(message, **metadata)
 
     async def chat(self, request: ChatRequest) -> ChatResponse:
         self.validate_request(request)
@@ -219,7 +232,7 @@ class GeminiProvider(BaseProvider):
             raise NetworkError(str(exc)) from exc
         if not resp.is_success:
             message = self._response_error_message(resp.status_code, resp.headers, resp.text)
-            raise self._map_http_error(resp.status_code, message)
+            raise self._map_http_error(resp.status_code, message, resp.headers)
         return self._parse_response(resp.json(), request)
 
     def _parse_response(self, payload: dict[str, Any], request: ChatRequest) -> ChatResponse:
@@ -270,7 +283,7 @@ class GeminiProvider(BaseProvider):
             message = self._response_error_message(
                 resp.status_code, resp.headers, error_body.decode()
             )
-            raise self._map_http_error(resp.status_code, message)
+            raise self._map_http_error(resp.status_code, message, resp.headers)
 
         try:
             async for line in resp.aiter_lines():

--- a/sdks/python/motosan_ai/providers/gemini_code_assist.py
+++ b/sdks/python/motosan_ai/providers/gemini_code_assist.py
@@ -13,6 +13,7 @@ from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
 from motosan_ai.providers.gemini import build_gemini_body
+from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import ChatRequest, ChatResponse, StopReason, StreamEvent, Usage
 
 _DEFAULT_BASE_URL = "https://cloudcode-pa.googleapis.com"
@@ -24,6 +25,15 @@ _CLIENT_METADATA = (
 )
 _REQUEST_COUNTER = count()
 _TOOL_CALL_COUNTER = count()
+
+
+def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, Any]:
+    retry_after = None
+    request_id = None
+    if headers is not None:
+        retry_after = parse_retry_after_header(headers.get("retry-after"))
+        request_id = headers.get("request-id") or headers.get("x-request-id")
+    return {"status_code": status, "retry_after": retry_after, "request_id": request_id}
 
 
 def _gen_request_id() -> str:
@@ -186,12 +196,15 @@ class GeminiCodeAssistProvider(BaseProvider):
         }
 
     @staticmethod
-    def _map_http_error(status: int, message: str) -> Exception:
+    def _map_http_error(
+        status: int, message: str, headers: httpx.Headers | None = None
+    ) -> Exception:
+        metadata = _http_error_kwargs(status, headers)
         if status == 401:
-            return AuthError(message)
+            return AuthError(message, **metadata)
         if status == 429:
-            return RateLimitError(message)
-        return ProviderError(message)
+            return RateLimitError(message, **metadata)
+        return ProviderError(message, **metadata)
 
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:
         self.validate_request(request)
@@ -209,7 +222,7 @@ class GeminiCodeAssistProvider(BaseProvider):
         try:
             if not resp.is_success:
                 error_body = await resp.aread()
-                raise self._map_http_error(resp.status_code, error_body.decode())
+                raise self._map_http_error(resp.status_code, error_body.decode(), resp.headers)
 
             state = _CodeAssistAdapterState()
             try:

--- a/sdks/python/motosan_ai/providers/minimax.py
+++ b/sdks/python/motosan_ai/providers/minimax.py
@@ -15,6 +15,7 @@ from motosan_ai.error import (
     StreamError,
 )
 from motosan_ai.provider_base import ProviderCapabilities
+from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
     ChatRequest,
     ChatResponse,
@@ -25,6 +26,15 @@ from motosan_ai.types import (
     ToolCall,
     Usage,
 )
+
+
+def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, Any]:
+    retry_after = None
+    request_id = None
+    if headers is not None:
+        retry_after = parse_retry_after_header(headers.get("retry-after"))
+        request_id = headers.get("request-id") or headers.get("x-request-id")
+    return {"status_code": status, "retry_after": retry_after, "request_id": request_id}
 
 
 class MinimaxProvider:
@@ -97,14 +107,17 @@ class MinimaxProvider:
             body["tool_choice"] = {"type": "function", "function": {"name": choice.name}}
 
     @staticmethod
-    def _raise_for_status(status_code: int, message: str) -> None:
+    def _raise_for_status(
+        status_code: int, message: str, headers: httpx.Headers | None = None
+    ) -> None:
+        metadata = _http_error_kwargs(status_code, headers)
         if status_code == 401:
-            raise AuthError(message)
+            raise AuthError(message, **metadata)
         if status_code == 429:
-            raise RateLimitError(message)
+            raise RateLimitError(message, **metadata)
         if status_code == 400:
-            raise InvalidRequestError(message)
-        raise ProviderError(message)
+            raise InvalidRequestError(message, **metadata)
+        raise ProviderError(message, **metadata)
 
     async def chat(self, request: ChatRequest) -> ChatResponse:
         body: dict[str, Any] = {
@@ -152,7 +165,7 @@ class MinimaxProvider:
             retry_after = response.headers.get("retry-after")
             if retry_after:
                 message = f"Retry-After: {retry_after}\n{message}"
-            self._raise_for_status(response.status_code, message)
+            self._raise_for_status(response.status_code, message, response.headers)
 
         payload = response.json() if response.content else {}
 
@@ -226,7 +239,7 @@ class MinimaxProvider:
                     retry_after = response.headers.get("retry-after")
                     if retry_after:
                         message = f"Retry-After: {retry_after}\n{message}"
-                    self._raise_for_status(response.status_code, message)
+                    self._raise_for_status(response.status_code, message, response.headers)
 
                 async for line in response.aiter_lines():
                     if not line.startswith("data:"):

--- a/sdks/python/motosan_ai/providers/ollama.py
+++ b/sdks/python/motosan_ai/providers/ollama.py
@@ -9,6 +9,7 @@ import httpx
 
 from motosan_ai.error import NetworkError, ProviderError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
+from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
     ChatRequest,
     ChatResponse,
@@ -19,6 +20,15 @@ from motosan_ai.types import (
     ToolCall,
     Usage,
 )
+
+
+def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, Any]:
+    retry_after = None
+    request_id = None
+    if headers is not None:
+        retry_after = parse_retry_after_header(headers.get("retry-after"))
+        request_id = headers.get("request-id") or headers.get("x-request-id")
+    return {"status_code": status, "retry_after": retry_after, "request_id": request_id}
 
 
 class OllamaProvider:
@@ -109,7 +119,10 @@ class OllamaProvider:
             raise NetworkError(str(exc)) from exc
 
         if resp.status_code >= 400:
-            raise ProviderError(f"Ollama error {resp.status_code}: {resp.text}")
+            raise ProviderError(
+                f"Ollama error {resp.status_code}: {resp.text}",
+                **_http_error_kwargs(resp.status_code, resp.headers),
+            )
 
         data = resp.json()
         msg = data.get("message") or {}
@@ -159,7 +172,8 @@ class OllamaProvider:
                 if resp.status_code >= 400:
                     text = await resp.aread()
                     raise ProviderError(
-                        f"Ollama error {resp.status_code}: {text.decode('utf-8', errors='ignore')}"
+                        f"Ollama error {resp.status_code}: {text.decode('utf-8', errors='ignore')}",
+                        **_http_error_kwargs(resp.status_code, resp.headers),
                     )
 
                 async for line in resp.aiter_lines():

--- a/sdks/python/motosan_ai/providers/openai.py
+++ b/sdks/python/motosan_ai/providers/openai.py
@@ -8,6 +8,7 @@ import httpx
 
 from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
+from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
     ChatRequest,
     ChatResponse,
@@ -30,6 +31,15 @@ _FINISH_REASON_TO_STOP = {
     "length": StopReason.max_tokens,
     "tool_calls": StopReason.tool_use,
 }
+
+
+def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, Any]:
+    retry_after = None
+    request_id = None
+    if headers is not None:
+        retry_after = parse_retry_after_header(headers.get("retry-after"))
+        request_id = headers.get("request-id") or headers.get("x-request-id")
+    return {"status_code": status, "retry_after": retry_after, "request_id": request_id}
 
 
 class OpenAIProvider:
@@ -154,12 +164,15 @@ class OpenAIProvider:
         return body
 
     @staticmethod
-    def _map_http_error(status: int, message: str) -> Exception:
+    def _map_http_error(
+        status: int, message: str, headers: httpx.Headers | None = None
+    ) -> Exception:
+        metadata = _http_error_kwargs(status, headers)
         if status == 401:
-            return AuthError(message)
+            return AuthError(message, **metadata)
         if status == 429:
-            return RateLimitError(message)
-        return ProviderError(message)
+            return RateLimitError(message, **metadata)
+        return ProviderError(message, **metadata)
 
     @staticmethod
     def _response_error_message(status: int, headers: httpx.Headers, text: str) -> str:
@@ -178,7 +191,7 @@ class OpenAIProvider:
 
         if not resp.is_success:
             message = self._response_error_message(resp.status_code, resp.headers, resp.text)
-            raise self._map_http_error(resp.status_code, message)
+            raise self._map_http_error(resp.status_code, message, resp.headers)
 
         payload = resp.json()
         choice = (payload.get("choices") or [{}])[0]
@@ -226,7 +239,7 @@ class OpenAIProvider:
                 message = self._response_error_message(
                     resp.status_code, resp.headers, error_body.decode()
                 )
-                raise self._map_http_error(resp.status_code, message)
+                raise self._map_http_error(resp.status_code, message, resp.headers)
 
             # Per-index tool-call tracking (mirrors TS providers/openai.ts):
             # index -> (id, name); only one tool call is open at a time.

--- a/sdks/python/motosan_ai/retry.py
+++ b/sdks/python/motosan_ai/retry.py
@@ -1,23 +1,23 @@
-"""Retry logic with exponential backoff for transient errors.
+"""Retry engine with full-jitter exponential backoff.
 
-Aligned with Rust SDK behavior:
-- Retries on RateLimitError (429) and ProviderError (5xx)
-- Retries on NetworkError (timeout, connection)
-- Exponential backoff: 100ms, 200ms, 400ms... capped at 2s
-- Respects Retry-After header
+- Classification is attribute-based: RateLimitError, NetworkError, and
+  ProviderError with status 408/409/5xx retry.
+- Backoff is full jitter: uniform(0, min(base_delay * 2**(attempt-1), max_delay)).
+- error.retry_after is used verbatim with no jitter and a 60s hard cap.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import re
+import random
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import TypeVar
 
-from motosan_ai.error import NetworkError, ProviderError, RateLimitError
+from motosan_ai.error import MotosanError, NetworkError, ProviderError, RateLimitError
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +27,6 @@ DEFAULT_MAX_RETRIES = 3
 DEFAULT_INITIAL_BACKOFF = 0.1  # seconds (aligned with Rust: 100ms)
 DEFAULT_MAX_BACKOFF = 2.0  # seconds (aligned with Rust: 2000ms)
 RETRY_AFTER_CAP_SECS = 60.0
-
-# 5xx status codes in error messages
-_STATUS_5XX_RE = re.compile(r"\b5\d{2}\b")
 
 
 def parse_retry_after_header(value: str | None) -> float | None:
@@ -58,26 +55,60 @@ def parse_retry_after_header(value: str | None) -> float | None:
     return min(max(seconds, 0.0), RETRY_AFTER_CAP_SECS)
 
 
-def _parse_retry_after(error_message: str) -> float | None:
-    """Try to extract Retry-After seconds from error message."""
-    match = re.search(r"[Rr]etry[- ][Aa]fter[:\s]+(\d+\.?\d*)", error_message)
-    if match:
-        return float(match.group(1))
-    return None
+@dataclass
+class RetryEvent:
+    """Passed to RetryPolicy.on_retry before each retry sleep."""
+
+    attempt: int
+    delay: float
+    cause: str
+
+
+@dataclass
+class RetryPolicy:
+    """Cross-SDK retry policy."""
+
+    max_retries: int = DEFAULT_MAX_RETRIES
+    base_delay: float = DEFAULT_INITIAL_BACKOFF
+    max_delay: float = DEFAULT_MAX_BACKOFF
+    jitter: bool = True
+    respect_retry_after: bool = True
+    on_retry: Callable[[RetryEvent], None] | None = None
 
 
 def _is_retryable(error: Exception) -> bool:
-    """Check if an error is retryable (aligned with Rust is_retryable_status + is_retryable_network_error)."""
+    """Check whether an error is retryable using structured metadata."""
     if isinstance(error, RateLimitError):
         return True
     if isinstance(error, NetworkError):
         return True
     if isinstance(error, ProviderError):
-        # Retry on 5xx errors (server errors)
-        msg = str(error)
-        if _STATUS_5XX_RE.search(msg):
-            return True
+        status_code = error.status_code or 0
+        return error.status_code in {408, 409} or status_code >= 500
     return False
+
+
+def retry_cause(error: Exception) -> str:
+    """Render a stable RetryEvent cause tag."""
+    if isinstance(error, NetworkError):
+        return f"network:{error}"
+    status_code = getattr(error, "status_code", None)
+    if status_code is not None:
+        return f"status:{status_code}"
+    return type(error).__name__
+
+
+def compute_delay(
+    policy: RetryPolicy,
+    attempt: int,
+    retry_after: float | None = None,
+    rng: Callable[[], float] = random.random,
+) -> float:
+    """Compute seconds to sleep before retry number attempt, which is 1-based."""
+    if policy.respect_retry_after and retry_after is not None:
+        return min(retry_after, RETRY_AFTER_CAP_SECS)
+    exp_delay = min(policy.base_delay * (2 ** (attempt - 1)), policy.max_delay)
+    return rng() * exp_delay if policy.jitter else exp_delay
 
 
 async def with_retry(
@@ -85,32 +116,41 @@ async def with_retry(
     max_retries: int = DEFAULT_MAX_RETRIES,
     initial_backoff: float = DEFAULT_INITIAL_BACKOFF,
     max_backoff: float = DEFAULT_MAX_BACKOFF,
+    *,
+    policy: RetryPolicy | None = None,
+    rng: Callable[[], float] = random.random,
 ) -> T:
     """Execute fn with retry on transient errors.
 
-    Retries on: RateLimitError (429), NetworkError, ProviderError (5xx).
-    Backoff: initial_backoff * 2^attempt capped at max_backoff.
-    Uses Retry-After header value if present in the error message.
+    The legacy positional params remain in their original order. When policy is
+    provided, policy values take precedence over the legacy params.
     """
+    if policy is None:
+        policy = RetryPolicy(
+            max_retries=max_retries,
+            base_delay=initial_backoff,
+            max_delay=max_backoff,
+        )
+
     last_error: Exception | None = None
-    for attempt in range(max_retries + 1):
+    for attempt in range(policy.max_retries + 1):
         try:
             return await fn()
         except Exception as e:
             if not _is_retryable(e):
                 raise
             last_error = e
-            if attempt >= max_retries:
+            if attempt >= policy.max_retries:
                 break
-            retry_after = _parse_retry_after(str(e))
-            if retry_after is not None:
-                wait = min(retry_after, max_backoff)
-            else:
-                wait = min(initial_backoff * (2**attempt), max_backoff)
+            retry_number = attempt + 1
+            retry_after = e.retry_after if isinstance(e, MotosanError) else None
+            wait = compute_delay(policy, retry_number, retry_after, rng)
+            if policy.on_retry is not None:
+                policy.on_retry(RetryEvent(attempt=retry_number, delay=wait, cause=retry_cause(e)))
             logger.warning(
-                "Retryable error (attempt %d/%d), retrying in %.1fs: %s",
-                attempt + 1,
-                max_retries,
+                "Retryable error (attempt %d/%d), retrying in %.2fs: %s",
+                retry_number,
+                policy.max_retries,
                 wait,
                 type(e).__name__,
             )

--- a/sdks/python/motosan_ai/retry.py
+++ b/sdks/python/motosan_ai/retry.py
@@ -84,7 +84,7 @@ def _is_retryable(error: Exception) -> bool:
         return True
     if isinstance(error, ProviderError):
         status_code = error.status_code or 0
-        return error.status_code in {408, 409} or status_code >= 500
+        return error.status_code in {408, 409, 429} or status_code >= 500
     return False
 
 

--- a/sdks/python/motosan_ai/retry.py
+++ b/sdks/python/motosan_ai/retry.py
@@ -13,6 +13,8 @@ import asyncio
 import logging
 import re
 from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import TypeVar
 
 from motosan_ai.error import NetworkError, ProviderError, RateLimitError
@@ -24,9 +26,36 @@ T = TypeVar("T")
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_INITIAL_BACKOFF = 0.1  # seconds (aligned with Rust: 100ms)
 DEFAULT_MAX_BACKOFF = 2.0  # seconds (aligned with Rust: 2000ms)
+RETRY_AFTER_CAP_SECS = 60.0
 
 # 5xx status codes in error messages
 _STATUS_5XX_RE = re.compile(r"\b5\d{2}\b")
+
+
+def parse_retry_after_header(value: str | None) -> float | None:
+    """Parse a Retry-After header as capped seconds."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        seconds = float(stripped)
+    except ValueError:
+        pass
+    else:
+        if seconds < 0:
+            return None
+        return min(seconds, RETRY_AFTER_CAP_SECS)
+
+    try:
+        retry_at = parsedate_to_datetime(stripped)
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=UTC)
+    seconds = (retry_at - datetime.now(UTC)).total_seconds()
+    return min(max(seconds, 0.0), RETRY_AFTER_CAP_SECS)
 
 
 def _parse_retry_after(error_message: str) -> float | None:

--- a/sdks/python/tests/test_anthropic_validation.py
+++ b/sdks/python/tests/test_anthropic_validation.py
@@ -5,7 +5,6 @@ import respx
 from motosan_ai.error import InvalidRequestError, ProviderError, RateLimitError
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.providers.anthropic import AnthropicProvider
-from motosan_ai.retry import _parse_retry_after
 from motosan_ai.types import ChatRequest, Message
 
 
@@ -62,7 +61,7 @@ async def test_retry_after_header_is_preserved_in_error_message(provider):
     )
     with pytest.raises(RateLimitError) as exc:
         await provider.chat(ChatRequest(messages=[Message.user("hi")]))
-    assert _parse_retry_after(str(exc.value)) == 2.0
+    assert exc.value.retry_after == 2.0
 
 
 @respx.mock

--- a/sdks/python/tests/test_client_retry_policy.py
+++ b/sdks/python/tests/test_client_retry_policy.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from motosan_ai import Client, Provider
+from motosan_ai.error import ProviderError
+from motosan_ai.retry import RetryEvent, RetryPolicy
+from motosan_ai.types import ChatRequest, Message, StreamEvent
+
+_OK_JSON = {
+    "model": "claude-sonnet-4-6",
+    "stop_reason": "end_turn",
+    "usage": {"input_tokens": 1, "output_tokens": 1},
+    "content": [{"type": "text", "text": "ok"}],
+}
+
+_FAST = {"max_retries": 1, "base_delay": 0.001, "max_delay": 0.002}
+
+
+def _sse_lines(*events: dict) -> str:
+    return "\n".join(f"data: {json.dumps(e)}" for e in events) + "\n"
+
+
+def test_legacy_max_retries_builds_default_policy(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    client = Client(provider=Provider.anthropic, max_retries=2)
+
+    assert client._retry_policy.max_retries == 2
+
+
+def test_explicit_retry_policy_wins_over_max_retries(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    client = Client(
+        provider=Provider.anthropic, max_retries=5, retry_policy=RetryPolicy(max_retries=0)
+    )
+
+    assert client._retry_policy.max_retries == 0
+
+
+def test_classmethod_constructor_accepts_retry_policy(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    client = Client.anthropic(retry_policy=RetryPolicy(max_retries=7))
+
+    assert client._retry_policy.max_retries == 7
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_chat_retry_policy_retries_once_then_succeeds(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    route = respx.post("https://api.anthropic.com/v1/messages").mock(
+        side_effect=[
+            httpx.Response(500, json={"error": {"message": "overloaded"}}),
+            httpx.Response(200, json=_OK_JSON),
+        ]
+    )
+    client = Client(provider=Provider.anthropic, retry_policy=RetryPolicy(**_FAST))
+
+    resp = await client.chat([Message.user("hi")])
+
+    assert resp.content == "ok"
+    assert route.call_count == 2
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_on_retry_fires_through_client_chat_path(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        side_effect=[
+            httpx.Response(429, json={"error": {"message": "slow down"}}),
+            httpx.Response(200, json=_OK_JSON),
+        ]
+    )
+    events: list[RetryEvent] = []
+    policy = RetryPolicy(on_retry=events.append, **_FAST)
+    client = Client(provider=Provider.anthropic, retry_policy=policy)
+
+    resp = await client.chat([Message.user("hi")])
+
+    assert resp.content == "ok"
+    assert len(events) == 1
+    assert events[0].attempt == 1
+    assert events[0].cause == "status:429"
+    assert 0.0 <= events[0].delay <= 0.002
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_retry_policy_retries_before_first_event(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    sse = _sse_lines(
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+        {"type": "message_stop"},
+    )
+    route = respx.post("https://api.anthropic.com/v1/messages").mock(
+        side_effect=[
+            httpx.Response(500, json={"error": {"message": "overloaded"}}),
+            httpx.Response(200, text=sse, headers={"content-type": "text/event-stream"}),
+        ]
+    )
+    observed: list[RetryEvent] = []
+    policy = RetryPolicy(on_retry=observed.append, **_FAST)
+    client = Client(provider=Provider.anthropic, retry_policy=policy)
+
+    out = [ev async for ev in client.stream([Message.user("hi")])]
+
+    assert any(ev.content == "hi" for ev in out)
+    assert route.call_count == 2
+    assert len(observed) == 1
+    assert observed[0].attempt == 1
+    assert observed[0].cause == "status:500"
+
+
+class _CountingProvider:
+    """Provider stub that records how many times stream() was invoked."""
+
+    def __init__(self, make_gen):
+        self._make_gen = make_gen
+        self.stream_calls = 0
+
+    async def stream(self, request):
+        self.stream_calls += 1
+        async for event in self._make_gen():
+            yield event
+
+
+@pytest.mark.asyncio
+async def test_stream_policy_refuses_retry_after_first_event(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    async def gen():
+        yield StreamEvent(content="partial", done=False)
+        raise ProviderError("HTTP 503: overloaded", status_code=503)
+
+    client = Client(
+        provider=Provider.anthropic,
+        retry_policy=RetryPolicy(max_retries=3, base_delay=0.001),
+    )
+    provider = _CountingProvider(gen)
+    client._provider = provider
+    req = ChatRequest(messages=[Message.user("hi")])
+
+    with pytest.raises(ProviderError):
+        async for _ in client.stream_with(req):
+            pass
+    assert provider.stream_calls == 1

--- a/sdks/python/tests/test_client_stream_with.py
+++ b/sdks/python/tests/test_client_stream_with.py
@@ -113,7 +113,7 @@ async def test_stream_with_does_not_retry_provider_error_after_yield(monkeypatch
 
     async def gen():
         yield StreamEvent(content="partial", done=False)
-        raise ProviderError("503 server error")  # retryable BY CLASS, but mid-stream
+        raise ProviderError("HTTP 503: server error", status_code=503)  # retryable, but mid-stream
 
     client = Client(provider=Provider.anthropic, max_retries=3)
     provider = _CountingProvider(gen)

--- a/sdks/python/tests/test_errors.py
+++ b/sdks/python/tests/test_errors.py
@@ -1,10 +1,25 @@
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+
+import httpx
 import pytest
+import respx
 
-from motosan_ai.error import AuthError, InvalidRequestError, ProviderError, RateLimitError
+from motosan_ai.error import (
+    AuthError,
+    InvalidRequestError,
+    MotosanError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    StreamError,
+)
+from motosan_ai.providers.anthropic import AnthropicProvider
 from motosan_ai.providers.minimax import MinimaxProvider
+from motosan_ai.types import ChatRequest, Message
 
 
-def test_error_mapping():
+def test_minimax_error_mapping():
     with pytest.raises(AuthError):
         MinimaxProvider._raise_for_status(401, "unauthorized")
     with pytest.raises(RateLimitError):
@@ -13,3 +28,101 @@ def test_error_mapping():
         MinimaxProvider._raise_for_status(400, "bad")
     with pytest.raises(ProviderError):
         MinimaxProvider._raise_for_status(500, "oops")
+
+
+def test_error_attributes_are_stored_without_changing_str():
+    err = MotosanError(
+        "HTTP 429: slow down",
+        status_code=429,
+        retry_after=1.5,
+        request_id="req_abc",
+    )
+
+    assert str(err) == "HTTP 429: slow down"
+    assert err.status_code == 429
+    assert err.retry_after == 1.5
+    assert err.request_id == "req_abc"
+
+
+def test_error_metadata_defaults_to_none():
+    err = MotosanError("boom")
+
+    assert err.status_code is None
+    assert err.retry_after is None
+    assert err.request_id is None
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [AuthError, RateLimitError, InvalidRequestError, ProviderError, NetworkError, StreamError],
+)
+def test_error_subclasses_accept_metadata_kwargs(error_cls):
+    err = error_cls("boom", status_code=503, retry_after=2.0, request_id="req_123")
+
+    assert str(err) == "boom"
+    assert err.status_code == 503
+    assert err.retry_after == 2.0
+    assert err.request_id == "req_123"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_anthropic_429_populates_http_metadata():
+    provider = AnthropicProvider("test-key", base_url="https://mock.anthropic.com")
+    respx.post("https://mock.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(
+            429,
+            headers={"retry-after": "120", "request-id": "req_abc"},
+            json={"error": {"message": "slow down"}},
+        )
+    )
+
+    with pytest.raises(RateLimitError) as exc:
+        await provider.chat(ChatRequest(messages=[Message.user("hi")]))
+
+    assert str(exc.value) == "Retry-After: 120\nHTTP 429: slow down"
+    assert exc.value.status_code == 429
+    assert exc.value.retry_after == 60.0
+    assert exc.value.request_id == "req_abc"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_anthropic_retry_after_http_date_populates_seconds():
+    provider = AnthropicProvider("test-key", base_url="https://mock.anthropic.com")
+    retry_at = datetime.now(timezone.utc) + timedelta(seconds=25)
+    respx.post("https://mock.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(
+            429,
+            headers={"retry-after": format_datetime(retry_at, usegmt=True)},
+            json={"error": {"message": "slow down"}},
+        )
+    )
+
+    with pytest.raises(RateLimitError) as exc:
+        await provider.chat(ChatRequest(messages=[Message.user("hi")]))
+
+    assert exc.value.status_code == 429
+    assert exc.value.retry_after is not None
+    assert 20.0 <= exc.value.retry_after <= 30.0
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_anthropic_500_populates_request_id_fallback():
+    provider = AnthropicProvider("test-key", base_url="https://mock.anthropic.com")
+    respx.post("https://mock.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(
+            500,
+            headers={"x-request-id": "req_xyz"},
+            json={"error": {"message": "backend blew up"}},
+        )
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        await provider.chat(ChatRequest(messages=[Message.user("hi")]))
+
+    assert str(exc.value) == "HTTP 500: backend blew up"
+    assert exc.value.status_code == 500
+    assert exc.value.retry_after is None
+    assert exc.value.request_id == "req_xyz"

--- a/sdks/python/tests/test_gemini_errors.py
+++ b/sdks/python/tests/test_gemini_errors.py
@@ -4,7 +4,6 @@ import respx
 
 from motosan_ai.error import AuthError, ProviderError, RateLimitError
 from motosan_ai.providers.gemini import GeminiProvider
-from motosan_ai.retry import _parse_retry_after
 from motosan_ai.types import ChatRequest, Message
 
 
@@ -61,7 +60,7 @@ async def test_retry_after_header_is_preserved_in_error_message(provider):
     )
     with pytest.raises(RateLimitError) as exc:
         await provider.chat(ChatRequest(messages=[Message.user("hi")]))
-    assert _parse_retry_after(str(exc.value)) == 1.5
+    assert exc.value.retry_after == 1.5
 
 
 @respx.mock

--- a/sdks/python/tests/test_retry.py
+++ b/sdks/python/tests/test_retry.py
@@ -1,46 +1,30 @@
+import random
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
 
 import pytest
 
-from motosan_ai.error import (
-    AuthError,
-    NetworkError,
-    ProviderError,
-    RateLimitError,
-)
+from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError
 from motosan_ai.retry import (
     RETRY_AFTER_CAP_SECS,
+    RetryEvent,
+    RetryPolicy,
     _is_retryable,
-    _parse_retry_after,
+    compute_delay,
     parse_retry_after_header,
     with_retry,
 )
 
 
-class TestParseRetryAfter:
-    def test_with_seconds(self):
-        assert _parse_retry_after("Rate limited. Retry-After: 5") == 5.0
-
-    def test_with_decimal(self):
-        assert _parse_retry_after("retry-after: 1.5") == 1.5
-
-    def test_no_match(self):
-        assert _parse_retry_after("some error") is None
-
-    def test_retry_after_dash_variant(self):
-        assert _parse_retry_after("Retry-After 10") == 10.0
-
-
 class TestParseRetryAfterHeader:
     def test_integer_seconds(self):
-        assert parse_retry_after_header("5") == 5.0
+        assert parse_retry_after_header("5") == pytest.approx(5.0)
 
     def test_decimal_seconds(self):
-        assert parse_retry_after_header("1.5") == 1.5
+        assert parse_retry_after_header("1.5") == pytest.approx(1.5)
 
     def test_caps_seconds(self):
-        assert parse_retry_after_header("120") == RETRY_AFTER_CAP_SECS
+        assert parse_retry_after_header("120") == pytest.approx(RETRY_AFTER_CAP_SECS)
 
     def test_negative_seconds_returns_none(self):
         assert parse_retry_after_header("-1") is None
@@ -56,7 +40,9 @@ class TestParseRetryAfterHeader:
     def test_past_http_date(self):
         retry_at = datetime.now(timezone.utc) - timedelta(seconds=25)
 
-        assert parse_retry_after_header(format_datetime(retry_at, usegmt=True)) == 0.0
+        assert parse_retry_after_header(format_datetime(retry_at, usegmt=True)) == pytest.approx(
+            0.0
+        )
 
     @pytest.mark.parametrize("value", [None, "", "not a date"])
     def test_none_empty_and_garbage_return_none(self, value):
@@ -64,29 +50,55 @@ class TestParseRetryAfterHeader:
 
 
 class TestIsRetryable:
-    def test_rate_limit_error(self):
-        assert _is_retryable(RateLimitError("429")) is True
-
-    def test_network_error(self):
+    def test_retryable_classes_and_statuses(self):
+        assert _is_retryable(RateLimitError("slow down", status_code=429)) is True
         assert _is_retryable(NetworkError("connection reset")) is True
+        assert _is_retryable(ProviderError("HTTP 500: boom", status_code=500)) is True
+        assert _is_retryable(ProviderError("HTTP 408: timeout", status_code=408)) is True
+        assert _is_retryable(ProviderError("HTTP 409: conflict", status_code=409)) is True
 
-    def test_provider_error_5xx(self):
-        assert _is_retryable(ProviderError("Error code: 500 - server error")) is True
-
-    def test_provider_error_502(self):
-        assert _is_retryable(ProviderError("502 Bad Gateway")) is True
-
-    def test_provider_error_503(self):
-        assert _is_retryable(ProviderError("503 Service Unavailable")) is True
-
-    def test_provider_error_4xx_not_retryable(self):
-        assert _is_retryable(ProviderError("Error code: 400 - bad request")) is False
-
-    def test_auth_error_not_retryable(self):
-        assert _is_retryable(AuthError("401 unauthorized")) is False
-
-    def test_value_error_not_retryable(self):
+    def test_not_retryable(self):
+        assert _is_retryable(ProviderError("HTTP 400: bad request", status_code=400)) is False
+        assert _is_retryable(AuthError("unauthorized", status_code=401)) is False
         assert _is_retryable(ValueError("bad")) is False
+
+    def test_provider_error_without_status_not_retryable(self):
+        assert _is_retryable(ProviderError("Error code: 500 - server error")) is False
+
+
+class TestComputeDelay:
+    def test_full_jitter_scales_rng_against_exponential_ceiling(self):
+        policy = RetryPolicy()
+
+        assert compute_delay(policy, 1, None, rng=lambda: 0.5) == pytest.approx(0.05)
+        assert compute_delay(policy, 2, None, rng=lambda: 0.5) == pytest.approx(0.1)
+        assert compute_delay(policy, 6, None, rng=lambda: 1.0) == pytest.approx(2.0)
+        assert compute_delay(policy, 3, None, rng=lambda: 0.0) == pytest.approx(0.0)
+
+    def test_seeded_rng_stays_within_bounds(self):
+        policy = RetryPolicy()
+        rng = random.Random(42).random
+
+        for attempt in (1, 2, 3, 6):
+            ceiling = min(0.1 * 2 ** (attempt - 1), 2.0)
+            assert 0.0 <= compute_delay(policy, attempt, None, rng=rng) <= ceiling
+
+    def test_no_jitter_is_pure_exponential(self):
+        policy = RetryPolicy(jitter=False)
+
+        assert compute_delay(policy, 1, None) == pytest.approx(0.1)
+        assert compute_delay(policy, 3, None) == pytest.approx(0.4)
+
+    def test_retry_after_verbatim_capped_at_60_not_max_delay(self):
+        policy = RetryPolicy()
+
+        assert compute_delay(policy, 1, 7.0, rng=lambda: 0.5) == pytest.approx(7.0)
+        assert compute_delay(policy, 1, 120.0) == pytest.approx(60.0)
+
+    def test_retry_after_ignored_when_respect_disabled(self):
+        policy = RetryPolicy(respect_retry_after=False, jitter=False)
+
+        assert compute_delay(policy, 1, 7.0) == pytest.approx(0.1)
 
 
 class TestWithRetry:
@@ -99,27 +111,27 @@ class TestWithRetry:
             calls += 1
             return "ok"
 
-        result = await with_retry(fn, max_retries=3)
-        assert result == "ok"
+        assert await with_retry(fn, max_retries=3) == "ok"
         assert calls == 1
 
     @pytest.mark.asyncio
-    async def test_retries_on_rate_limit(self):
+    async def test_retries_on_rate_limit_with_policy(self):
         calls = 0
 
         async def fn():
             nonlocal calls
             calls += 1
             if calls < 3:
-                raise RateLimitError("429")
+                raise RateLimitError("slow down", status_code=429)
             return "ok"
 
-        result = await with_retry(fn, max_retries=3, initial_backoff=0.001)
-        assert result == "ok"
+        policy = RetryPolicy(max_retries=3, base_delay=0.001)
+
+        assert await with_retry(fn, policy=policy) == "ok"
         assert calls == 3
 
     @pytest.mark.asyncio
-    async def test_retries_on_network_error(self):
+    async def test_legacy_positional_args_still_work(self):
         calls = 0
 
         async def fn():
@@ -129,103 +141,54 @@ class TestWithRetry:
                 raise NetworkError("connection reset")
             return "ok"
 
-        result = await with_retry(fn, max_retries=3, initial_backoff=0.001)
-        assert result == "ok"
+        assert await with_retry(fn, 3, 0.001, 2.0) == "ok"
         assert calls == 2
 
     @pytest.mark.asyncio
-    async def test_retries_on_5xx_provider_error(self):
+    async def test_does_not_retry_provider_error_without_status(self):
         calls = 0
 
         async def fn():
             nonlocal calls
             calls += 1
-            if calls < 2:
-                raise ProviderError("Error code: 500 - Internal Server Error")
-            return "ok"
-
-        result = await with_retry(fn, max_retries=3, initial_backoff=0.001)
-        assert result == "ok"
-        assert calls == 2
-
-    @pytest.mark.asyncio
-    async def test_does_not_retry_4xx_provider_error(self):
-        calls = 0
-
-        async def fn():
-            nonlocal calls
-            calls += 1
-            raise ProviderError("Error code: 400 - bad request")
+            raise ProviderError("Error code: 500 - server error")
 
         with pytest.raises(ProviderError):
             await with_retry(fn, max_retries=3, initial_backoff=0.001)
         assert calls == 1
 
     @pytest.mark.asyncio
-    async def test_does_not_retry_auth_error(self):
-        calls = 0
-
-        async def fn():
-            nonlocal calls
-            calls += 1
-            raise AuthError("401")
-
-        with pytest.raises(AuthError):
-            await with_retry(fn, max_retries=3, initial_backoff=0.001)
-        assert calls == 1
-
-    @pytest.mark.asyncio
     async def test_exhausts_retries(self):
-        async def fn():
-            raise RateLimitError("429")
-
-        with pytest.raises(RateLimitError):
-            await with_retry(fn, max_retries=2, initial_backoff=0.001)
-
-    @pytest.mark.asyncio
-    async def test_non_retryable_error_not_retried(self):
         calls = 0
 
         async def fn():
             nonlocal calls
             calls += 1
-            raise ValueError("bad")
+            raise ProviderError("HTTP 503: overloaded", status_code=503)
 
-        with pytest.raises(ValueError):
-            await with_retry(fn, max_retries=3, initial_backoff=0.001)
-        assert calls == 1
+        with pytest.raises(ProviderError):
+            await with_retry(fn, policy=RetryPolicy(max_retries=2, base_delay=0.001))
+        assert calls == 3
 
     @pytest.mark.asyncio
-    async def test_uses_retry_after_from_message(self):
+    async def test_uses_retry_after_attribute_verbatim(self):
         calls = 0
 
         async def fn():
             nonlocal calls
             calls += 1
             if calls == 1:
-                raise RateLimitError("Rate limited. Retry-After: 0.001")
+                raise RateLimitError("slow down", status_code=429, retry_after=0.001)
             return "ok"
 
-        result = await with_retry(fn, max_retries=2, initial_backoff=0.001, max_backoff=1.0)
-        assert result == "ok"
-        assert calls == 2
+        events: list[RetryEvent] = []
+        policy = RetryPolicy(max_retries=2, base_delay=0.05, on_retry=events.append)
+
+        assert await with_retry(fn, policy=policy) == "ok"
+        assert events[0].delay == pytest.approx(0.001)
 
     @pytest.mark.asyncio
-    async def test_max_retries_zero_does_not_retry(self):
-        calls = 0
-
-        async def fn():
-            nonlocal calls
-            calls += 1
-            raise RateLimitError("429")
-
-        with pytest.raises(RateLimitError):
-            await with_retry(fn, max_retries=0)
-        assert calls == 1
-
-    @pytest.mark.asyncio
-    async def test_mixed_errors_retries_then_succeeds(self):
-        """Network error then rate limit then success."""
+    async def test_on_retry_fires_before_each_sleep(self):
         calls = 0
 
         async def fn():
@@ -234,22 +197,44 @@ class TestWithRetry:
             if calls == 1:
                 raise NetworkError("timeout")
             if calls == 2:
-                raise RateLimitError("429")
+                raise RateLimitError("slow down", status_code=429)
             return "ok"
 
-        result = await with_retry(fn, max_retries=3, initial_backoff=0.001)
-        assert result == "ok"
-        assert calls == 3
+        events: list[RetryEvent] = []
+        policy = RetryPolicy(max_retries=3, base_delay=0.001, on_retry=events.append)
 
+        assert await with_retry(fn, policy=policy) == "ok"
+        assert [e.attempt for e in events] == [1, 2]
+        assert events[0].cause == "network:timeout"
+        assert events[1].cause == "status:429"
+        assert all(e.delay >= 0.0 for e in events)
 
-class TestProviderErrorHttpMessageFormat:
-    """Pins the message format providers must emit for retry classification."""
+    @pytest.mark.asyncio
+    async def test_injected_rng_drives_jitter(self):
+        calls = 0
 
-    def test_http_prefixed_502_is_retryable(self):
-        assert _is_retryable(ProviderError("HTTP 502: <html>bad gateway</html>")) is True
+        async def fn():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RateLimitError("slow down", status_code=429)
+            return "ok"
 
-    def test_retry_after_prefixed_message_is_retryable(self):
-        assert _is_retryable(ProviderError("Retry-After: 3\nHTTP 503: overloaded")) is True
+        events: list[RetryEvent] = []
+        policy = RetryPolicy(max_retries=1, base_delay=0.002, on_retry=events.append)
 
-    def test_retry_after_prefix_is_parsed(self):
-        assert _parse_retry_after("Retry-After: 3\nHTTP 503: overloaded") == 3.0
+        assert await with_retry(fn, policy=policy, rng=lambda: 0.5) == "ok"
+        assert events[0].delay == pytest.approx(0.001)
+
+    @pytest.mark.asyncio
+    async def test_max_retries_zero_does_not_retry(self):
+        calls = 0
+
+        async def fn():
+            nonlocal calls
+            calls += 1
+            raise RateLimitError("slow down", status_code=429)
+
+        with pytest.raises(RateLimitError):
+            await with_retry(fn, max_retries=0)
+        assert calls == 1

--- a/sdks/python/tests/test_retry.py
+++ b/sdks/python/tests/test_retry.py
@@ -1,3 +1,6 @@
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+
 import pytest
 
 from motosan_ai.error import (
@@ -6,7 +9,13 @@ from motosan_ai.error import (
     ProviderError,
     RateLimitError,
 )
-from motosan_ai.retry import _is_retryable, _parse_retry_after, with_retry
+from motosan_ai.retry import (
+    RETRY_AFTER_CAP_SECS,
+    _is_retryable,
+    _parse_retry_after,
+    parse_retry_after_header,
+    with_retry,
+)
 
 
 class TestParseRetryAfter:
@@ -21,6 +30,37 @@ class TestParseRetryAfter:
 
     def test_retry_after_dash_variant(self):
         assert _parse_retry_after("Retry-After 10") == 10.0
+
+
+class TestParseRetryAfterHeader:
+    def test_integer_seconds(self):
+        assert parse_retry_after_header("5") == 5.0
+
+    def test_decimal_seconds(self):
+        assert parse_retry_after_header("1.5") == 1.5
+
+    def test_caps_seconds(self):
+        assert parse_retry_after_header("120") == RETRY_AFTER_CAP_SECS
+
+    def test_negative_seconds_returns_none(self):
+        assert parse_retry_after_header("-1") is None
+
+    def test_future_http_date(self):
+        retry_at = datetime.now(timezone.utc) + timedelta(seconds=25)
+
+        parsed = parse_retry_after_header(format_datetime(retry_at, usegmt=True))
+
+        assert parsed is not None
+        assert 20.0 <= parsed <= 30.0
+
+    def test_past_http_date(self):
+        retry_at = datetime.now(timezone.utc) - timedelta(seconds=25)
+
+        assert parse_retry_after_header(format_datetime(retry_at, usegmt=True)) == 0.0
+
+    @pytest.mark.parametrize("value", [None, "", "not a date"])
+    def test_none_empty_and_garbage_return_none(self, value):
+        assert parse_retry_after_header(value) is None
 
 
 class TestIsRetryable:

--- a/sdks/python/tests/test_retry.py
+++ b/sdks/python/tests/test_retry.py
@@ -56,6 +56,7 @@ class TestIsRetryable:
         assert _is_retryable(ProviderError("HTTP 500: boom", status_code=500)) is True
         assert _is_retryable(ProviderError("HTTP 408: timeout", status_code=408)) is True
         assert _is_retryable(ProviderError("HTTP 409: conflict", status_code=409)) is True
+        assert _is_retryable(ProviderError("HTTP 429: slow down", status_code=429)) is True
 
     def test_not_retryable(self):
         assert _is_retryable(ProviderError("HTTP 400: bad request", status_code=400)) is False


### PR DESCRIPTION
Summary:
- Task 7: add structured Python error metadata and Retry-After header parsing, populated by HTTP providers.
- Task 8: add RetryPolicy/RetryEvent, full-jitter compute_delay, attribute-based retry classification, and legacy-compatible with_retry.
- Task 9: thread RetryPolicy through Client chat/stream paths with on_retry callbacks and the pre-first-event stream retry guard.
- Review fix: include structured ProviderError status_code=429 in the retryable status set.

M2 PR-P: docs/superpowers/plans/2026-07-15-stream-retry-m2-implementation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)