### PR TITLE
feat(typescript): M2 request-id, full jitter, one retry path (Tasks 10–12)

### DIFF
--- a/sdks/typescript/src/error.ts
+++ b/sdks/typescript/src/error.ts
@@ -1,6 +1,7 @@
 export class MotosanError extends Error {
   status?: number
   retryAfterMs?: number
+  requestId?: string
 }
 export class AuthError extends MotosanError {}
 export class RateLimitError extends MotosanError {}
@@ -39,6 +40,7 @@ export function mapHttpError(
   status: number,
   message: string,
   retryAfter?: string | null,
+  requestId?: string | null,
 ): MotosanError {
   const error =
     status === 401
@@ -53,17 +55,21 @@ export function mapHttpError(
   if (retryAfterMs !== undefined) {
     error.retryAfterMs = retryAfterMs
   }
+  if (requestId) {
+    error.requestId = requestId
+  }
   return error
 }
 
 /**
  * Determine if an HTTP status code is retryable.
- * Retryable statuses: 429 (rate limit) or >= 500 (server error).
+ * Retryable statuses: 408 (request timeout), 409 (conflict),
+ * 429 (rate limit), or >= 500 (server error).
  *
- * Mirrors Rust `is_retryable_status`.
+ * Mirrors Rust `is_retryable_status`. See specs/retry.md.
  */
 export function isRetryableStatus(status: number): boolean {
-  return status === 429 || status >= 500
+  return status === 408 || status === 409 || status === 429 || status >= 500
 }
 
 /**
@@ -101,11 +107,18 @@ export function isRetryableNetworkError(error: unknown): boolean {
   return false
 }
 
+/** Cap applied to any parsed Retry-After value (specs/retry.md: RETRY_AFTER_CAP_SECS = 60). */
+export const RETRY_AFTER_CAP_MS = 60_000
+
 /**
- * Parse the Retry-After header value (integer seconds) into milliseconds.
+ * Parse the Retry-After header value into milliseconds.
  *
- * Returns undefined if the header is null, empty, or contains a non-integer value.
- * Mirrors Rust `parse_retry_after`: trim, parse as u64 seconds, convert to ms.
+ * Accepts both RFC 7231 forms:
+ * - delay-seconds (e.g. "30") -> seconds * 1000
+ * - HTTP-date (e.g. "Wed, 15 Jul 2026 12:00:30 GMT") -> date minus now
+ *
+ * The result is clamped to [0, RETRY_AFTER_CAP_MS]. Returns undefined if the
+ * header is null, empty, or unparseable. Mirrors Rust `parse_retry_after`.
  */
 export function parseRetryAfter(headerValue: string | null): number | undefined {
   if (headerValue === null) {
@@ -113,11 +126,24 @@ export function parseRetryAfter(headerValue: string | null): number | undefined 
   }
 
   const trimmed = headerValue.trim()
-  if (!/^\d+$/.test(trimmed)) {
-    return undefined
+
+  // delay-seconds form
+  if (/^\d+$/.test(trimmed)) {
+    return Math.min(Number(trimmed) * 1000, RETRY_AFTER_CAP_MS)
   }
 
-  return Number(trimmed) * 1000
+  // HTTP-date form. Every RFC 7231 date contains letters (month name, "GMT");
+  // requiring one keeps numeric junk like "-5" or "30.5" out of Date.parse,
+  // which would otherwise interpret them as calendar dates (Node parses
+  // "-5" as a valid date). Matches Rust rfc2822 / Python parsedate behavior.
+  if (!/[A-Za-z]/.test(trimmed)) {
+    return undefined
+  }
+  const parsedMs = Date.parse(trimmed)
+  if (Number.isNaN(parsedMs)) {
+    return undefined
+  }
+  return Math.max(0, Math.min(parsedMs - Date.now(), RETRY_AFTER_CAP_MS))
 }
 
 /**

--- a/sdks/typescript/src/http/fetch.ts
+++ b/sdks/typescript/src/http/fetch.ts
@@ -13,10 +13,13 @@ async function throwMappedError(response: Response): Promise<never> {
     payload = text
   }
   const message = extractErrorMessage(payload, `HTTP ${response.status}`)
+  const requestId =
+    response.headers?.get('request-id') ?? response.headers?.get('x-request-id') ?? null
   throw mapHttpError(
     response.status,
     message,
     response.headers?.get('retry-after') ?? null,
+    requestId,
   )
 }
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -13,6 +13,7 @@ export * from './providers/gemini.js'
 export { ChatGptCodexProvider, DEFAULT_CHATGPT_CODEX_URL } from './providers/chatgpt_codex.js'
 
 export { RetryPolicy } from './retry.js'
+export type { RetryPolicyOptions, RetryEvent } from './retry.js'
 export { ThinkStripper, stripThink } from './think_stripper.js'
 export {
   DEFAULT_ANTHROPIC_MODEL,

--- a/sdks/typescript/src/providers/anthropic.ts
+++ b/sdks/typescript/src/providers/anthropic.ts
@@ -1,14 +1,9 @@
-import {
-  isRetryableNetworkError,
-  isRetryableStatus,
-  ProviderError,
-  StreamError,
-} from '../error.js'
+import { ProviderError, StreamError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { DEFAULT_ANTHROPIC_MODEL } from '../models.js'
 import { parseSse } from '../http/sse.js'
 import { fullCaps, type ProviderCapabilities } from '../provider.js'
-import { RetryPolicy, withRetry, type RetryClassification } from '../retry.js'
+import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import { serializeAnthropicRequest } from '../serialize/anthropic.js'
 import {
   doneEvent,
@@ -142,21 +137,6 @@ interface StreamState {
   stopReason?: StopReason
 }
 
-function classifyHttpError(result: unknown): RetryClassification {
-  if (result instanceof Error) {
-    const error = result as { status?: number; retryAfterMs?: number }
-    const status = error.status
-    if (
-      (status !== undefined && isRetryableStatus(status)) ||
-      isRetryableNetworkError(result)
-    ) {
-      return { retryable: true, retryAfterMs: error.retryAfterMs }
-    }
-    throw result
-  }
-  return { retryable: false }
-}
-
 export class AnthropicProvider {
   private readonly model: string
   private readonly baseUrl: string
@@ -218,7 +198,7 @@ export class AnthropicProvider {
     const payload = await withRetry(
       this.retryPolicy,
       async () => postJson<any>(`${this.baseUrl}/v1/messages`, headers, body),
-      classifyHttpError,
+      classifyForRetry,
     )
 
     const blocks: any[] = Array.isArray(payload?.content) ? payload.content : []
@@ -265,28 +245,15 @@ export class AnthropicProvider {
     }
     const body = isSetupToken(this.apiKey) ? withOAuthSystemIdentity(serialized) : serialized
     const headers = this.requestHeaders(request, body)
-    let attempt = 0
-    let responseBody: ReadableStream<Uint8Array>
-    while (true) {
-      try {
-        responseBody = await postStream(`${this.baseUrl}/v1/messages`, headers, body)
-        break
-      } catch (error) {
-        const status = (error as { status?: number }).status
-        const retryable =
-          (status !== undefined && isRetryableStatus(status)) ||
-          isRetryableNetworkError(error)
-        if (!retryable || attempt >= this.retryPolicy.maxRetries) {
-          throw error
-        }
-        attempt += 1
-        const retryAfterMs = (error as { retryAfterMs?: number }).retryAfterMs
-        const delay = this.retryPolicy.respectRetryAfter
-          ? retryAfterMs ?? this.retryPolicy.delayForAttempt(attempt)
-          : this.retryPolicy.delayForAttempt(attempt)
-        await new Promise((resolve) => setTimeout(resolve, delay))
-      }
-    }
+    // Retry ONLY the initial fetch. parseSse below runs outside withRetry, so
+    // nothing is retried after the first emitted event (pinned by
+    // tests/retry-integration.test.ts "does not retry after the response body
+    // has been returned").
+    const responseBody = await withRetry(
+      this.retryPolicy,
+      async () => postStream(`${this.baseUrl}/v1/messages`, headers, body),
+      classifyForRetry,
+    )
 
     const state: StreamState = {}
 

--- a/sdks/typescript/src/providers/chatgpt_codex.ts
+++ b/sdks/typescript/src/providers/chatgpt_codex.ts
@@ -8,12 +8,12 @@
  * the Python mid-stream `StreamError` raise).
  */
 
-import { StreamError, isRetryableNetworkError, isRetryableStatus } from '../error.js'
+import { StreamError } from '../error.js'
 import { postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_CHATGPT_CODEX_MODEL } from '../models.js'
 import { textOnly, type ProviderCapabilities } from '../provider.js'
-import { RetryPolicy } from '../retry.js'
+import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import {
   collectStream,
   doneEvent,
@@ -222,28 +222,13 @@ export class ChatGptCodexProvider {
     const body = this.buildResponsesBody(request, model)
     const headers = this.headers()
 
-    // Retry ONLY the initial fetch (mirrors anthropic.ts:259-288 / ollama.ts:300-321).
-    let attempt = 0
-    let responseBody: ReadableStream<Uint8Array>
-    while (true) {
-      try {
-        responseBody = await postStream(this.baseUrl, headers, body)
-        break
-      } catch (error) {
-        const status = (error as { status?: number }).status
-        const retryable =
-          (status !== undefined && isRetryableStatus(status)) || isRetryableNetworkError(error)
-        if (!retryable || attempt >= this.retryPolicy.maxRetries) {
-          throw error
-        }
-        attempt += 1
-        const retryAfterMs = (error as { retryAfterMs?: number }).retryAfterMs
-        const delay = this.retryPolicy.respectRetryAfter
-          ? retryAfterMs ?? this.retryPolicy.delayForAttempt(attempt)
-          : this.retryPolicy.delayForAttempt(attempt)
-        await new Promise((resolve) => setTimeout(resolve, delay))
-      }
-    }
+    // Retry ONLY the initial fetch via the shared engine (same guard as the
+    // other providers: nothing is retried after the first emitted event).
+    const responseBody = await withRetry(
+      this.retryPolicy,
+      async () => postStream(this.baseUrl, headers, body),
+      classifyForRetry,
+    )
 
     // Only `sawToolCall` drives the terminal stop_reason (parity with Rust/Python,
     // which also track a seen-ids set that is write-only — dropped here per plan R1).

--- a/sdks/typescript/src/providers/gemini.ts
+++ b/sdks/typescript/src/providers/gemini.ts
@@ -1,9 +1,8 @@
-import { isRetryableNetworkError, isRetryableStatus } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_GEMINI_MODEL } from '../models.js'
 import { withImage, type ProviderCapabilities } from '../provider.js'
-import { RetryPolicy, withRetry, type RetryClassification } from '../retry.js'
+import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import { serializeGeminiRequest } from '../serialize/gemini.js'
 import {
   BoxStream,
@@ -42,26 +41,6 @@ function mapFinishReason(reason: string, hasToolCalls: boolean): StopReason {
   return hasToolCalls ? 'tool_use' : 'other'
 }
 
-/**
- * Copied verbatim from providers/openai.ts:38-51 (the existing per-provider
- * duplication pattern). The mapped HTTP error already carries `.status`
- * (error.ts:51, set inside http/fetch.ts:41 throwMappedError) and
- * `.retryAfterMs` (error.ts:54), so this works unchanged.
- */
-function classifyHttpError(result: unknown): RetryClassification {
-  if (result instanceof Error) {
-    const error = result as { status?: number; retryAfterMs?: number }
-    const status = error.status
-    if (
-      (status !== undefined && isRetryableStatus(status)) ||
-      isRetryableNetworkError(result)
-    ) {
-      return { retryable: true, retryAfterMs: error.retryAfterMs }
-    }
-    throw result
-  }
-  return { retryable: false }
-}
 
 /**
  * Gemini provider over the generativelanguage REST API (generateContent +
@@ -119,7 +98,7 @@ export class GeminiProvider {
     const payload = await withRetry(
       this.retryPolicy,
       async () => postJson<any>(url, this.headers(), body),
-      classifyHttpError,
+      classifyForRetry,
     )
 
     return this.parseResponse(payload, model)
@@ -178,31 +157,13 @@ export class GeminiProvider {
     const url = this.streamUrl(model)
     const body = serializeGeminiRequest(request, model)
 
-    // Retry ONLY the initial postStream fetch (manual status-aware loop,
-    // mirrors openai.ts:326-351). Once the body is obtained, parseSse drives
-    // with NO mid-stream retry (gemini.rs:372-413).
-    let attempt = 0
-    let responseBody: ReadableStream<Uint8Array>
-    while (true) {
-      try {
-        responseBody = await postStream(url, this.headers(), body)
-        break
-      } catch (error) {
-        const status = (error as { status?: number }).status
-        const retryable =
-          (status !== undefined && isRetryableStatus(status)) ||
-          isRetryableNetworkError(error)
-        if (!retryable || attempt >= this.retryPolicy.maxRetries) {
-          throw error
-        }
-        attempt += 1
-        const retryAfterMs = (error as { retryAfterMs?: number }).retryAfterMs
-        const delay = this.retryPolicy.respectRetryAfter
-          ? retryAfterMs ?? this.retryPolicy.delayForAttempt(attempt)
-          : this.retryPolicy.delayForAttempt(attempt)
-        await new Promise((resolve) => setTimeout(resolve, delay))
-      }
-    }
+    // Retry ONLY the initial postStream fetch via the shared engine. Once the
+    // body is obtained, parseSse drives with NO mid-stream retry (gemini.rs:372-413).
+    const responseBody = await withRetry(
+      this.retryPolicy,
+      async () => postStream(url, this.headers(), body),
+      classifyForRetry,
+    )
 
     // Drive parseSse. Gemini sends NO [DONE]; each data: line is a full
     // GenerateContentResponse chunk. Termination is finishReason-driven (emit

--- a/sdks/typescript/src/providers/ollama.ts
+++ b/sdks/typescript/src/providers/ollama.ts
@@ -1,9 +1,8 @@
-import { isRetryableNetworkError, isRetryableStatus } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseNdjson } from '../http/ndjson.js'
 import { DEFAULT_OLLAMA_MODEL } from '../models.js'
 import { textOnly, type ProviderCapabilities } from '../provider.js'
-import { RetryPolicy, withRetry, type RetryClassification } from '../retry.js'
+import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import {
   doneEvent,
   textEvent,
@@ -14,21 +13,6 @@ import {
 } from '../stream.js'
 import type { ChatRequest, ChatResponse, StopReason, ToolCall } from '../types.js'
 
-/** Same classify shape as providers/openai.ts:38-51 / providers/minimax.ts. */
-function classifyHttpError(result: unknown): RetryClassification {
-  if (result instanceof Error) {
-    const error = result as { status?: number; retryAfterMs?: number }
-    const status = error.status
-    if (
-      (status !== undefined && isRetryableStatus(status)) ||
-      isRetryableNetworkError(result)
-    ) {
-      return { retryable: true, retryAfterMs: error.retryAfterMs }
-    }
-    throw result
-  }
-  return { retryable: false }
-}
 
 /**
  * A native-API tool call before id-defaulting. Mirrors Rust ToolCall but
@@ -239,7 +223,7 @@ export class OllamaProvider {
     const payload = await withRetry(
       this.retryPolicy,
       async () => postJson<any>(this.endpoint(), {}, body),
-      classifyHttpError,
+      classifyForRetry,
     )
 
     const message = payload?.message
@@ -296,29 +280,12 @@ export class OllamaProvider {
   private async *streamImpl(req: ChatRequest) {
     const body = this.buildRequestBody(req, true)
 
-    // Retry ONLY the initial postStream fetch (mirrors openai.ts:326-351).
-    let attempt = 0
-    let responseBody: ReadableStream<Uint8Array>
-    while (true) {
-      try {
-        responseBody = await postStream(this.endpoint(), {}, body)
-        break
-      } catch (error) {
-        const status = (error as { status?: number }).status
-        const retryable =
-          (status !== undefined && isRetryableStatus(status)) ||
-          isRetryableNetworkError(error)
-        if (!retryable || attempt >= this.retryPolicy.maxRetries) {
-          throw error
-        }
-        attempt += 1
-        const retryAfterMs = (error as { retryAfterMs?: number }).retryAfterMs
-        const delay = this.retryPolicy.respectRetryAfter
-          ? retryAfterMs ?? this.retryPolicy.delayForAttempt(attempt)
-          : this.retryPolicy.delayForAttempt(attempt)
-        await new Promise((resolve) => setTimeout(resolve, delay))
-      }
-    }
+    // Retry ONLY the initial postStream fetch via the shared engine.
+    const responseBody = await withRetry(
+      this.retryPolicy,
+      async () => postStream(this.endpoint(), {}, body),
+      classifyForRetry,
+    )
 
     // Adapter over parseNdjson: decide termination on done:true.
     try {

--- a/sdks/typescript/src/providers/openai.ts
+++ b/sdks/typescript/src/providers/openai.ts
@@ -1,9 +1,8 @@
-import { isRetryableNetworkError, isRetryableStatus } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_OPENAI_MODEL } from '../models.js'
 import { withImage, type ProviderCapabilities } from '../provider.js'
-import { RetryPolicy, withRetry, type RetryClassification } from '../retry.js'
+import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import { serializeOpenAiRequest } from '../serialize/openai.js'
 import {
   doneEvent,
@@ -33,21 +32,6 @@ const FINISH_REASON_MAP: Record<string, StopReason> = {
   stop: 'stop',
   length: 'max_tokens',
   tool_calls: 'tool_use',
-}
-
-function classifyHttpError(result: unknown): RetryClassification {
-  if (result instanceof Error) {
-    const error = result as { status?: number; retryAfterMs?: number }
-    const status = error.status
-    if (
-      (status !== undefined && isRetryableStatus(status)) ||
-      isRetryableNetworkError(result)
-    ) {
-      return { retryable: true, retryAfterMs: error.retryAfterMs }
-    }
-    throw result
-  }
-  return { retryable: false }
 }
 
 export class OpenAIProvider {
@@ -223,7 +207,11 @@ export class OpenAIProvider {
       }
     }
 
-    const payload = await postJson<any>(this.responsesUrl, this.headers(), body)
+    const payload = await withRetry(
+      this.retryPolicy,
+      async () => postJson<any>(this.responsesUrl, this.headers(), body),
+      classifyForRetry,
+    )
     const content = this.extractResponsesText(payload)
     const responseModel =
       typeof payload?.model === 'string' ? payload.model : DEFAULT_OPENAI_MODEL
@@ -259,7 +247,7 @@ export class OpenAIProvider {
       payload = await withRetry(
         this.retryPolicy,
         async () => postJson<any>(this.chatUrl, this.headers(), body),
-        classifyHttpError,
+        classifyForRetry,
       )
     } catch (error) {
       if (
@@ -323,32 +311,12 @@ export class OpenAIProvider {
     const body = serializeOpenAiRequest(request, resolvedModel)
     body.stream = true
 
-    let attempt = 0
-    let responseBody: ReadableStream<Uint8Array>
-    while (true) {
-      try {
-        responseBody = await postStream(
-          this.chatUrl,
-          this.headers(),
-          body,
-        )
-        break
-      } catch (error) {
-        const status = (error as { status?: number }).status
-        const retryable =
-          (status !== undefined && isRetryableStatus(status)) ||
-          isRetryableNetworkError(error)
-        if (!retryable || attempt >= this.retryPolicy.maxRetries) {
-          throw error
-        }
-        attempt += 1
-        const retryAfterMs = (error as { retryAfterMs?: number }).retryAfterMs
-        const delay = this.retryPolicy.respectRetryAfter
-          ? retryAfterMs ?? this.retryPolicy.delayForAttempt(attempt)
-          : this.retryPolicy.delayForAttempt(attempt)
-        await new Promise((resolve) => setTimeout(resolve, delay))
-      }
-    }
+    // Retry ONLY the initial fetch; no retry after the first emitted event.
+    const responseBody = await withRetry(
+      this.retryPolicy,
+      async () => postStream(this.chatUrl, this.headers(), body),
+      classifyForRetry,
+    )
 
     // Per-index tool-call tracking (only one tool open at a time for collectStream).
     const toolBuffer: Map<number, { id: string; name: string }> = new Map()

--- a/sdks/typescript/src/retry.ts
+++ b/sdks/typescript/src/retry.ts
@@ -1,9 +1,19 @@
+/** Fired via RetryPolicy.onRetry before each retry sleep (D7). */
+export interface RetryEvent {
+  attempt: number
+  delayMs: number
+  cause: string
+}
+
 export interface RetryPolicyOptions {
   maxRetries?: number
   baseDelayMs?: number
   maxDelayMs?: number
   jitter?: boolean
   respectRetryAfter?: boolean
+  /** Injectable RNG in [0, 1) for full jitter. Defaults to Math.random. */
+  random?: () => number
+  onRetry?: (evt: RetryEvent) => void
 }
 
 export interface RetryClassification {
@@ -23,6 +33,8 @@ export class RetryPolicy {
   maxDelayMs: number
   jitter: boolean
   respectRetryAfter: boolean
+  random: () => number
+  onRetry?: (evt: RetryEvent) => void
 
   constructor(opts?: RetryPolicyOptions) {
     this.maxRetries = opts?.maxRetries ?? DEFAULT_MAX_RETRIES
@@ -31,6 +43,8 @@ export class RetryPolicy {
     this.jitter = opts?.jitter ?? DEFAULT_JITTER
     this.respectRetryAfter =
       opts?.respectRetryAfter ?? DEFAULT_RESPECT_RETRY_AFTER
+    this.random = opts?.random ?? Math.random
+    this.onRetry = opts?.onRetry
   }
 
   static default(): RetryPolicy {
@@ -62,19 +76,26 @@ export class RetryPolicy {
     return this
   }
 
+  withRandom(random: () => number): this {
+    this.random = random
+    return this
+  }
+
+  withOnRetry(onRetry: (evt: RetryEvent) => void): this {
+    this.onRetry = onRetry
+    return this
+  }
+
   delayForAttempt(attempt: number): number {
     const exponent = Math.min(Math.max(attempt - 1, 0), 31)
-    const expFactor = 2 ** exponent
-    let delayMs = Math.min(this.baseDelayMs * expFactor, this.maxDelayMs)
+    const expDelay = Math.min(this.baseDelayMs * 2 ** exponent, this.maxDelayMs)
 
-    if (this.jitter) {
-      const jitterSeed = attempt * 1_103_515_245 + 12_345
-      const jitterPercent = jitterSeed % 100
-      const jittered = delayMs + Math.floor((delayMs * jitterPercent) / 100)
-      delayMs = Math.min(jittered, this.maxDelayMs)
+    if (!this.jitter) {
+      return expDelay
     }
 
-    return delayMs
+    // Full jitter (specs/retry.md): uniform in [0, expDelay).
+    return this.random() * expDelay
   }
 }
 
@@ -93,9 +114,16 @@ export async function withRetry<T>(
 
       if (attempt < policy.maxRetries && retryable) {
         attempt += 1
+        // Retry-After (capped upstream in parseRetryAfter) is used VERBATIM — no jitter.
         const delay = policy.respectRetryAfter
           ? retryAfterMs ?? policy.delayForAttempt(attempt)
           : policy.delayForAttempt(attempt)
+
+        policy.onRetry?.({
+          attempt,
+          delayMs: delay,
+          cause: error instanceof Error ? error.message : String(error),
+        })
 
         await new Promise((resolve) => setTimeout(resolve, delay))
         continue

--- a/sdks/typescript/src/retry.ts
+++ b/sdks/typescript/src/retry.ts
@@ -1,3 +1,5 @@
+import { isRetryableNetworkError, isRetryableStatus } from './error.js'
+
 /** Fired via RetryPolicy.onRetry before each retry sleep (D7). */
 export interface RetryEvent {
   attempt: number
@@ -132,4 +134,29 @@ export async function withRetry<T>(
       throw error
     }
   }
+}
+
+/**
+ * Shared retry classification for every provider request path (chat and the
+ * pre-first-event stream fetch). Replaces the four per-provider
+ * classifyHttpError copies. Accepts a thrown value (usually a mapHttpError
+ * Error carrying `.status` / `.retryAfterMs`) or a bare numeric HTTP status.
+ * Pure — never throws; withRetry rethrows the original error on
+ * `{ retryable: false }`.
+ */
+export function classifyForRetry(errOrStatus: unknown): RetryClassification {
+  if (typeof errOrStatus === 'number') {
+    return { retryable: isRetryableStatus(errOrStatus) }
+  }
+  if (errOrStatus instanceof Error) {
+    const error = errOrStatus as { status?: number; retryAfterMs?: number }
+    const status = error.status
+    if (
+      (status !== undefined && isRetryableStatus(status)) ||
+      isRetryableNetworkError(errOrStatus)
+    ) {
+      return { retryable: true, retryAfterMs: error.retryAfterMs }
+    }
+  }
+  return { retryable: false }
 }

--- a/sdks/typescript/tests/error.test.ts
+++ b/sdks/typescript/tests/error.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   StreamReadTimeoutError,
   UnsupportedFeatureError,
@@ -6,6 +6,8 @@ import {
   isRetryableNetworkError,
   parseRetryAfter,
   extractErrorMessage,
+  mapHttpError,
+  RETRY_AFTER_CAP_MS,
 } from '../src/error.js'
 
 describe('StreamReadTimeoutError', () => {
@@ -40,7 +42,12 @@ describe('isRetryableStatus', () => {
     expect(isRetryableStatus(599)).toBe(true)
   })
 
-  it('returns false for 401, 400, 404, 4xx (except 429)', () => {
+  it('returns true for 408 (request timeout) and 409 (conflict)', () => {
+    expect(isRetryableStatus(408)).toBe(true)
+    expect(isRetryableStatus(409)).toBe(true)
+  })
+
+  it('returns false for 401, 400, 404, 4xx (except 408/409/429)', () => {
     expect(isRetryableStatus(401)).toBe(false)
     expect(isRetryableStatus(400)).toBe(false)
     expect(isRetryableStatus(404)).toBe(false)
@@ -126,9 +133,58 @@ describe('parseRetryAfter', () => {
     expect(result).toBe(0)
   })
 
-  it('handles large numbers', () => {
+  it('caps integer seconds above 60 at RETRY_AFTER_CAP_MS', () => {
     const result = parseRetryAfter('3600')
-    expect(result).toBe(3600000) // 1 hour in milliseconds
+    expect(result).toBe(RETRY_AFTER_CAP_MS) // 1 hour requested, capped to 60s
+  })
+})
+
+describe('parseRetryAfter HTTP-date form (RFC 7231)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('parses a future HTTP-date into a millisecond delay', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-15T12:00:00Z'))
+    const future = new Date(Date.now() + 30_000).toUTCString() // Wed, 15 Jul 2026 12:00:30 GMT
+    expect(parseRetryAfter(future)).toBe(30_000)
+  })
+
+  it('clamps a past HTTP-date to 0', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-15T12:00:00Z'))
+    const past = new Date(Date.now() - 45_000).toUTCString()
+    expect(parseRetryAfter(past)).toBe(0)
+  })
+
+  it('caps an HTTP-date more than 60s ahead at RETRY_AFTER_CAP_MS', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-15T12:00:00Z'))
+    const farFuture = new Date(Date.now() + 120_000).toUTCString()
+    expect(parseRetryAfter(farFuture)).toBe(RETRY_AFTER_CAP_MS)
+  })
+
+  it('exports RETRY_AFTER_CAP_MS as 60000', () => {
+    expect(RETRY_AFTER_CAP_MS).toBe(60_000)
+  })
+
+  it('returns undefined for strings that are neither integer nor date', () => {
+    expect(parseRetryAfter('not-a-date')).toBeUndefined()
+  })
+})
+
+describe('mapHttpError requestId', () => {
+  it('populates requestId when provided', () => {
+    const error = mapHttpError(429, 'rate limited', '2', 'req_abc123')
+    expect(error.requestId).toBe('req_abc123')
+    expect(error.status).toBe(429)
+    expect(error.retryAfterMs).toBe(2000)
+  })
+
+  it('leaves requestId undefined when absent or null', () => {
+    expect(mapHttpError(500, 'server error').requestId).toBeUndefined()
+    expect(mapHttpError(500, 'server error', null, null).requestId).toBeUndefined()
   })
 })
 

--- a/sdks/typescript/tests/http-fetch.test.ts
+++ b/sdks/typescript/tests/http-fetch.test.ts
@@ -84,6 +84,34 @@ describe('http/fetch', () => {
       ).rejects.toThrow(ProviderError)
     })
 
+    it('attaches requestId from the request-id response header', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 429,
+        text: vi.fn().mockResolvedValue(JSON.stringify({ error: { message: 'rate limited' } })),
+        headers: new Headers({ 'request-id': 'req_primary', 'x-request-id': 'req_fallback' }),
+      }
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse))
+
+      await expect(
+        postJson('https://api.test.com/v1/messages', {}, { test: true }),
+      ).rejects.toMatchObject({ requestId: 'req_primary' })
+    })
+
+    it('falls back to the x-request-id header when request-id is absent', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        text: vi.fn().mockResolvedValue('oops'),
+        headers: new Headers({ 'x-request-id': 'req_fallback' }),
+      }
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse))
+
+      await expect(
+        postJson('https://api.test.com/v1/messages', {}, { test: true }),
+      ).rejects.toMatchObject({ requestId: 'req_fallback' })
+    })
+
     it('falls back to "HTTP <status>" when the body has no error message', async () => {
       const mockResponse = {
         ok: false,

--- a/sdks/typescript/tests/providers-openai-responses.test.ts
+++ b/sdks/typescript/tests/providers-openai-responses.test.ts
@@ -250,17 +250,44 @@ describe('OpenAI Responses-API fallback', () => {
     expect(String(mockFetch.mock.calls[1][0])).toBe('https://custom.openai.test/responses')
   })
 
-  it('does not retry the single Responses fallback call', async () => {
+  it('retries the Responses fallback call on a retryable 5xx then succeeds (shared path)', async () => {
     provider
       .withRetryPolicy(new RetryPolicy({ maxRetries: 3, baseDelayMs: 1, jitter: false }))
       .withResponsesFallback(true)
     mockFetch
       .mockResolvedValueOnce(jsonResponse(404, {}))
       .mockResolvedValueOnce(jsonResponse(500, { error: { message: 'Responses unavailable' } }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          output_text: 'recovered',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+      )
+
+    const response = await provider.chat({ messages: [{ role: 'user', content: 'test' }] })
+
+    expect(response.content).toBe('recovered')
+    // 3 total fetches: the triggering 404 on chat/completions, then the
+    // Responses call's 500 -> 200 retry through the shared withRetry engine
+    // (the two Responses-endpoint fetches are the retried pair).
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(String(mockFetch.mock.calls[1][0])).toBe(DEFAULT_OPENAI_RESPONSES_URL)
+    expect(String(mockFetch.mock.calls[2][0])).toBe(DEFAULT_OPENAI_RESPONSES_URL)
+  })
+
+  it('does not retry a non-retryable 404 in the Responses fallback path', async () => {
+    provider
+      .withRetryPolicy(new RetryPolicy({ maxRetries: 3, baseDelayMs: 1, jitter: false }))
+      .withResponsesFallback(true)
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(404, {}))
+      .mockResolvedValueOnce(jsonResponse(404, { error: { message: 'Responses not found' } }))
 
     await expect(provider.chat({ messages: [{ role: 'user', content: 'test' }] })).rejects.toThrow(
-      'Responses unavailable',
+      'Responses not found',
     )
+    // 2 total fetches: chat/completions 404 triggers the fallback, and the
+    // Responses 404 is non-retryable so withRetry rethrows without a retry.
     expect(mockFetch).toHaveBeenCalledTimes(2)
   })
 

--- a/sdks/typescript/tests/retry-integration.test.ts
+++ b/sdks/typescript/tests/retry-integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { InvalidRequestError, mapHttpError } from '../src/error.js'
 import { AnthropicProvider } from '../src/providers/anthropic.js'
+import { ChatGptCodexProvider } from '../src/providers/chatgpt_codex.js'
 import { MinimaxProvider } from '../src/providers/minimax.js'
 import { OpenAIProvider } from '../src/providers/openai.js'
 import { RetryPolicy } from '../src/retry.js'
@@ -349,6 +350,31 @@ describe('retry provider integration', () => {
     for await (const event of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
       events.push(event)
     }
+    expect(calls).toBe(2)
+    expect(events.filter((e) => !e.done).map((e) => e.content)).toContain('stream ok')
+  })
+
+  it('ChatGPT-Codex stream retries a 503 then succeeds before the first event (shared path)', async () => {
+    let calls = 0
+    const sse =
+      'data: {"type":"response.output_text.delta","delta":"stream ok"}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1
+        return calls === 1
+          ? new Response(JSON.stringify({ error: { message: 'overloaded' } }), { status: 503 })
+          : new Response(sse, { status: 200, headers: { 'content-type': 'text/event-stream' } })
+      }),
+    )
+
+    const provider = new ChatGptCodexProvider('tok', 'acct').withRetryPolicy(immediateRetryPolicy())
+    const events: StreamEvent[] = []
+    for await (const event of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+      events.push(event)
+    }
+
     expect(calls).toBe(2)
     expect(events.filter((e) => !e.done).map((e) => e.content)).toContain('stream ok')
   })

--- a/sdks/typescript/tests/retry.test.ts
+++ b/sdks/typescript/tests/retry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { isRetryableNetworkError, isRetryableStatus, parseRetryAfter } from '../src/error.js'
-import { RetryPolicy, withRetry, type RetryEvent } from '../src/retry.js'
+import { classifyForRetry, RetryPolicy, withRetry, type RetryEvent } from '../src/retry.js'
 
 function retryableByStatusOrNetwork(err: unknown) {
   const status = (err as { status?: number })?.status
@@ -365,5 +365,35 @@ describe('withRetry onRetry', () => {
 
     await expect(withRetry(policy, op, () => ({ retryable: false }))).rejects.toThrow('fatal')
     expect(events).toEqual([])
+  })
+})
+
+describe('classifyForRetry', () => {
+  it('classifies retryable-status errors and carries retryAfterMs', () => {
+    const err = new Error('rate limited') as Error & { status?: number; retryAfterMs?: number }
+    err.status = 429
+    err.retryAfterMs = 1500
+    expect(classifyForRetry(err)).toEqual({ retryable: true, retryAfterMs: 1500 })
+  })
+
+  it('returns retryable:false for non-retryable statuses without throwing', () => {
+    const err = new Error('bad request') as Error & { status?: number }
+    err.status = 400
+    expect(classifyForRetry(err)).toEqual({ retryable: false })
+  })
+
+  it('classifies retryable network errors', () => {
+    const err = new Error('refused') as Error & { code?: string }
+    err.code = 'ECONNREFUSED'
+    expect(classifyForRetry(err).retryable).toBe(true)
+  })
+
+  it('accepts a bare numeric status', () => {
+    expect(classifyForRetry(503)).toEqual({ retryable: true })
+    expect(classifyForRetry(404)).toEqual({ retryable: false })
+  })
+
+  it('treats non-Error, non-number values as not retryable', () => {
+    expect(classifyForRetry('boom')).toEqual({ retryable: false })
   })
 })

--- a/sdks/typescript/tests/retry.test.ts
+++ b/sdks/typescript/tests/retry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { isRetryableNetworkError, isRetryableStatus, parseRetryAfter } from '../src/error.js'
-import { RetryPolicy, withRetry } from '../src/retry.js'
+import { RetryPolicy, withRetry, type RetryEvent } from '../src/retry.js'
 
 function retryableByStatusOrNetwork(err: unknown) {
   const status = (err as { status?: number })?.status
@@ -67,39 +67,45 @@ describe('RetryPolicy.delayForAttempt', () => {
   })
 })
 
-describe('RetryPolicy jitter (deterministic)', () => {
-  it('uses attempt-derived deterministic jitter by default', () => {
+describe('RetryPolicy full jitter', () => {
+  it('uses injectable random: delay = random() * expDelay', () => {
+    const policy = new RetryPolicy({ random: () => 0.5 })
+
+    expect(policy.delayForAttempt(1)).toBe(50)
+    expect(policy.delayForAttempt(2)).toBe(100)
+    expect(policy.delayForAttempt(3)).toBe(200)
+    expect(policy.delayForAttempt(6)).toBe(1000)
+  })
+
+  it('random extremes map to 0 and the full exponential delay', () => {
+    const floor = new RetryPolicy({ random: () => 0 })
+    const ceil = new RetryPolicy({ random: () => 1 })
+
+    expect(floor.delayForAttempt(3)).toBe(0)
+    expect(ceil.delayForAttempt(3)).toBe(400)
+    expect(ceil.delayForAttempt(6)).toBe(2000)
+  })
+
+  it('defaults random to Math.random and stays within [0, expDelay]', () => {
     const policy = RetryPolicy.default()
 
-    expect(policy.delayForAttempt(1)).toBe(190)
-    expect(policy.delayForAttempt(2)).toBe(270)
-    expect(policy.delayForAttempt(3)).toBe(720)
+    expect(policy.random).toBe(Math.random)
+    for (let i = 0; i < 200; i += 1) {
+      const first = policy.delayForAttempt(1)
+      expect(first).toBeGreaterThanOrEqual(0)
+      expect(first).toBeLessThanOrEqual(100)
+
+      const capped = policy.delayForAttempt(6)
+      expect(capped).toBeGreaterThanOrEqual(0)
+      expect(capped).toBeLessThanOrEqual(2000)
+    }
   })
 
-  it('same attempt always produces the same jittered delay', () => {
-    const policy = RetryPolicy.default()
-
-    expect(policy.delayForAttempt(2)).toBe(policy.delayForAttempt(2))
-  })
-
-  it('uses integer millisecond jitter like Rust for odd base delays', () => {
-    const policy = new RetryPolicy({ baseDelayMs: 101, maxDelayMs: 10_000 })
-
-    expect(policy.delayForAttempt(1)).toBe(191)
-    expect(policy.delayForAttempt(2)).toBe(272)
-  })
-
-  it('jitter can be disabled', () => {
-    const policy = new RetryPolicy({ jitter: false })
+  it('jitter=false returns the exact exponential delay and ignores random', () => {
+    const policy = new RetryPolicy({ jitter: false, random: () => 0.123 })
 
     expect(policy.delayForAttempt(1)).toBe(100)
     expect(policy.delayForAttempt(2)).toBe(200)
-  })
-
-  it('jittered delay respects maxDelayMs cap', () => {
-    const policy = RetryPolicy.default()
-
-    expect(policy.delayForAttempt(5)).toBeLessThanOrEqual(2000)
     expect(policy.delayForAttempt(6)).toBe(2000)
   })
 })
@@ -292,5 +298,72 @@ describe('withRetry with error.ts classification', () => {
 
     await expect(promise).resolves.toBe('success')
     expect(op).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('withRetry onRetry', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('fires before each sleep with attempt, delayMs, cause', async () => {
+    vi.useFakeTimers()
+    const events: RetryEvent[] = []
+    const policy = new RetryPolicy({
+      maxRetries: 3,
+      jitter: false,
+      onRetry: (evt) => events.push(evt),
+    })
+    const op = vi.fn(async (attempt: number) => {
+      if (attempt < 3) {
+        const err = new Error(`boom-${attempt}`) as Error & { status?: number }
+        err.status = 503
+        throw err
+      }
+      return 'ok'
+    })
+    const classify = (err: unknown) => ({
+      retryable: (err as { status?: number }).status === 503,
+    })
+
+    const promise = withRetry(policy, op, classify)
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toBe('ok')
+    expect(events).toEqual([
+      { attempt: 1, delayMs: 100, cause: 'boom-1' },
+      { attempt: 2, delayMs: 200, cause: 'boom-2' },
+    ])
+  })
+
+  it('reports verbatim retryAfterMs as delayMs even with jitter enabled', async () => {
+    vi.useFakeTimers()
+    const events: RetryEvent[] = []
+    const policy = new RetryPolicy({ onRetry: (evt) => events.push(evt) })
+    const op = vi.fn(async (attempt: number) => {
+      if (attempt === 1) {
+        throw new Error('throttled')
+      }
+      return 'ok'
+    })
+    const classify = () => ({ retryable: true, retryAfterMs: 500 })
+
+    const promise = withRetry(policy, op, classify)
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toBe('ok')
+    expect(events).toEqual([{ attempt: 1, delayMs: 500, cause: 'throttled' }])
+  })
+
+  it('does not fire for non-retryable errors', async () => {
+    const events: RetryEvent[] = []
+    const policy = new RetryPolicy({ onRetry: (evt) => events.push(evt) })
+    const op = vi.fn(async () => {
+      throw new Error('fatal')
+    })
+
+    await expect(withRetry(policy, op, () => ({ retryable: false }))).rejects.toThrow('fatal')
+    expect(events).toEqual([])
   })
 })


### PR DESCRIPTION
## M2 — TypeScript: request-id, full jitter, one retry path (Tasks 10–12)

Implements the TypeScript half of the M2 retry contract (`specs/retry.md`),
routing every provider request through the single `withRetry` engine.

### Task 10 — `request-id` on errors, Retry-After HTTP-date + 60s cap, retry 408/409
- `MotosanError.requestId?: string`; `mapHttpError(...)` gains a `requestId` arg,
  populated in `http/fetch.ts` from `request-id` then `x-request-id`.
- `isRetryableStatus` now returns `true` for **408/409** (plus 429 / ≥500).
- `parseRetryAfter` accepts both RFC 7231 forms (delay-seconds **and** HTTP-date),
  clamps to `[0, RETRY_AFTER_CAP_MS]` (`60_000`); past dates clamp to 0.

### Task 11 — full-jitter backoff + `onRetry` hook
- Replaces the deterministic LCG jitter with **full jitter** (`random() * expDelay`),
  `random` injectable via `RetryPolicyOptions.random` (default `Math.random`).
- Adds `RetryPolicy.onRetry(RetryEvent)`, fired before each sleep (never on the
  terminal failure). Retry-After delays stay **verbatim** (no jitter).

### Task 12 — route all provider requests through shared `withRetry`
- New `classifyForRetry` in `retry.ts` replaces the **four** per-provider
  `classifyHttpError` copies and the **five** hand-rolled `while (true)` stream loops
  (anthropic / openai / gemini / ollama / chatgpt_codex).
- OpenAI's previously-unretried `chatViaResponses` fallback now routes through the
  shared engine too.
- `grep -rn "classifyHttpError|isRetryableStatus|isRetryableNetworkError|delayForAttempt|while (true)" src/providers/ src/client.ts` → **no matches**.

### Behavior preserved
- Streaming still retries **only the initial fetch** — SSE/NDJSON parsing runs
  outside `withRetry`, so nothing retries after the first emitted event.
- The M1 retry-integration regression tests are **unchanged** (one additive
  ChatGPT-Codex 503→200 test + its import were appended; no existing assertion touched).

### Verification (the exact `ci-typescript` gate, run locally)
- `npm run typecheck` → exit 0
- `npm run build` → exit 0
- `npm test` → 571 passed | 9 skipped
- `npm pack --dry-run` → exit 0

Does not touch Rust/Python. No merge/tag/publish intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
