### PR TITLE
test(retry): M2 Task 13 — cross-SDK specs/retry.md conformance suites

### DIFF
--- a/sdks/python/tests/test_retry_conformance.py
+++ b/sdks/python/tests/test_retry_conformance.py
@@ -1,0 +1,115 @@
+"""Mirrors specs/retry.md — update BOTH or neither.
+
+Cross-SDK siblings assert the SAME tables:
+  sdks/rust/src/providers/mod.rs (mod retry_conformance)
+  sdks/typescript/tests/retry-conformance.test.ts
+A failure means the implementation drifted from specs/retry.md — fix the
+implementation (or the spec plus all three suites), never this file alone.
+"""
+
+import pytest
+
+from motosan_ai.error import (
+    AuthError,
+    InvalidRequestError,
+    MotosanError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+)
+from motosan_ai.retry import (
+    RetryPolicy,
+    _is_retryable,
+    compute_delay,
+    parse_retry_after_header,
+)
+
+RETRYABLE_STATUSES = [408, 409, 429, 500, 502, 503, 529, 599]
+NON_RETRYABLE_STATUSES = [400, 401, 403, 404, 422, 499]
+
+
+def error_for_status(status: int) -> MotosanError:
+    """Construct the exception map_http_error produces for this status (D1 mapping).
+
+    429 -> RateLimitError, so its retryability is exercised via isinstance,
+    matching real provider raise sites. (200/301 are not error statuses, so
+    Python's attribute-based table omits them; Rust/TS classify raw codes.)
+    """
+    message = f"HTTP {status}: boom"
+    if status == 401:
+        return AuthError(message, status_code=status)
+    if status == 429:
+        return RateLimitError(message, status_code=status)
+    if status == 400:
+        return InvalidRequestError(message, status_code=status)
+    return ProviderError(message, status_code=status)
+
+
+class TestClassificationTable:
+    @pytest.mark.parametrize("status", RETRYABLE_STATUSES)
+    def test_retryable(self, status):
+        assert _is_retryable(error_for_status(status)) is True
+
+    @pytest.mark.parametrize("status", NON_RETRYABLE_STATUSES)
+    def test_non_retryable(self, status):
+        assert _is_retryable(error_for_status(status)) is False
+
+    def test_network_error_is_retryable(self):
+        assert _is_retryable(NetworkError("connection reset")) is True
+
+    def test_message_text_is_ignored(self):
+        # D9: classification is attribute-based; "500" in the text no longer counts.
+        assert _is_retryable(ProviderError("Error code: 500 - server error")) is False
+
+    def test_plain_exception_not_retryable(self):
+        assert _is_retryable(ValueError("bad")) is False
+
+
+class TestParseRetryAfterHeader:
+    def test_integer_seconds(self):
+        assert parse_retry_after_header("5") == 5.0
+        assert parse_retry_after_header("0") == 0.0
+        assert parse_retry_after_header(" 7 ") == 7.0
+
+    def test_capped_at_60s(self):
+        assert parse_retry_after_header("61") == 60.0
+        assert parse_retry_after_header("86400") == 60.0
+
+    def test_http_date_clamped(self):
+        # Deterministic: past date clamps to 0; far-future date clamps to the cap.
+        assert parse_retry_after_header("Wed, 21 Oct 2015 07:28:00 GMT") == 0.0
+        assert parse_retry_after_header("Fri, 31 Dec 2100 23:59:59 GMT") == 60.0
+
+    def test_garbage_is_none(self):
+        # A negative integer is invalid, NOT clamp-to-0 (only past HTTP-dates clamp).
+        assert parse_retry_after_header(None) is None
+        assert parse_retry_after_header("") is None
+        assert parse_retry_after_header("soon") is None
+        assert parse_retry_after_header("-5") is None
+
+
+class TestPolicyMath:
+    def test_full_jitter_scales_capped_exp_delay_by_rng(self):
+        policy = RetryPolicy()  # base 0.1s, max 2.0s, jitter on
+        # compute_delay is a free function; RetryPolicy has no delay method.
+        assert compute_delay(policy, 1, rng=lambda: 0.5) == pytest.approx(0.05)
+        assert compute_delay(policy, 2, rng=lambda: 0.5) == pytest.approx(0.1)
+        assert compute_delay(policy, 3, rng=lambda: 0.5) == pytest.approx(0.2)
+        assert compute_delay(policy, 4, rng=lambda: 0.0) == 0.0
+        # attempt 6: uncapped exp = 0.1 * 2**5 = 3.2 -> capped at 2.0 BEFORE jitter.
+        assert compute_delay(policy, 6, rng=lambda: 1.0) == pytest.approx(2.0)
+
+    def test_jitter_disabled_is_pure_exponential(self):
+        policy = RetryPolicy(jitter=False)
+        assert compute_delay(policy, 1) == pytest.approx(0.1)
+        assert compute_delay(policy, 2) == pytest.approx(0.2)
+        assert compute_delay(policy, 5) == pytest.approx(1.6)
+        assert compute_delay(policy, 6) == pytest.approx(2.0)
+
+    def test_defaults_match_spec(self):
+        policy = RetryPolicy()
+        assert policy.max_retries == 3
+        assert policy.base_delay == 0.1
+        assert policy.max_delay == 2.0
+        assert policy.jitter is True
+        assert policy.respect_retry_after is True

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -752,3 +752,143 @@ mod http_error_metadata_tests {
         );
     }
 }
+
+// Mirrors specs/retry.md — update BOTH or neither.
+// Cross-SDK siblings assert the SAME tables:
+//   sdks/python/tests/test_retry_conformance.py
+//   sdks/typescript/tests/retry-conformance.test.ts
+// A failure means the implementation drifted from specs/retry.md — fix the
+// implementation (or the spec plus all three suites), never this file alone.
+// In-crate unit test (NOT tests/): is_retryable_status / parse_retry_after are
+// pub(crate) in this module and feature-gated, so an integration test could not
+// import them. Gated behind the same 7-feature cfg (default = []).
+#[cfg(test)]
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+mod retry_conformance {
+    use super::{is_retryable_status, parse_retry_after};
+    use crate::retry::RetryPolicy;
+    use reqwest::header::{HeaderMap, HeaderValue};
+    use std::time::Duration;
+
+    const RETRYABLE: [u16; 8] = [408, 409, 429, 500, 502, 503, 529, 599];
+    const NON_RETRYABLE: [u16; 8] = [200, 301, 400, 401, 403, 404, 422, 499];
+
+    /// parse_retry_after takes a &HeaderMap, so wrap the raw value in one.
+    fn retry_after(value: &str) -> Option<Duration> {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_str(value).unwrap());
+        parse_retry_after(&headers)
+    }
+
+    #[test]
+    fn classification_retryable_statuses() {
+        for status in RETRYABLE {
+            assert!(
+                is_retryable_status(status),
+                "specs/retry.md: {status} must be retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn classification_non_retryable_statuses() {
+        for status in NON_RETRYABLE {
+            assert!(
+                !is_retryable_status(status),
+                "specs/retry.md: {status} must NOT be retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn retry_after_integer_seconds() {
+        assert_eq!(retry_after("5"), Some(Duration::from_secs(5)));
+        assert_eq!(retry_after("0"), Some(Duration::ZERO));
+        assert_eq!(retry_after(" 7 "), Some(Duration::from_secs(7)));
+    }
+
+    #[test]
+    fn retry_after_capped_at_60s() {
+        assert_eq!(retry_after("61"), Some(Duration::from_secs(60)));
+        assert_eq!(retry_after("86400"), Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn retry_after_http_date_clamped() {
+        // Deterministic: past date clamps to 0; far-future date clamps to the 60s cap.
+        assert_eq!(
+            retry_after("Wed, 21 Oct 2015 07:28:00 GMT"),
+            Some(Duration::ZERO)
+        );
+        assert_eq!(
+            retry_after("Fri, 31 Dec 2100 23:59:59 GMT"),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn retry_after_garbage_is_none() {
+        // A negative integer is invalid, NOT clamp-to-0 (only past HTTP-dates clamp).
+        assert_eq!(retry_after(""), None);
+        assert_eq!(retry_after("soon"), None);
+        assert_eq!(retry_after("-5"), None);
+    }
+
+    #[test]
+    fn full_jitter_bounded_by_capped_exponential() {
+        // specs/retry.md § backoff: full jitter — uniform in
+        // [0, min(base * 2^(attempt-1), max_delay)]. The Rust RNG is &mut
+        // fastrand::Rng (no fractional-scale injection), so assert the ceiling
+        // over a seeded run instead of an exact scaled value.
+        let policy = RetryPolicy::default(); // base 100ms, max 2000ms, jitter on
+        let mut rng = fastrand::Rng::with_seed(42);
+        // ceilings for attempts 1..=7 (attempt 6+ capped at max_delay = 2000ms)
+        let ceilings_ms = [100u64, 200, 400, 800, 1600, 2000, 2000];
+        for (idx, &ceiling) in ceilings_ms.iter().enumerate() {
+            let attempt = (idx + 1) as u32;
+            for _ in 0..200 {
+                let delay = policy.delay_for_attempt_with_rng(attempt, &mut rng);
+                assert!(
+                    delay <= Duration::from_millis(ceiling),
+                    "specs/retry.md: attempt {attempt} delay {delay:?} exceeds {ceiling}ms ceiling"
+                );
+            }
+        }
+        // Full jitter must spread draws, not pin to the ceiling (seed-deterministic).
+        let mut rng = fastrand::Rng::with_seed(42);
+        let draws: Vec<Duration> = (0..64)
+            .map(|_| policy.delay_for_attempt_with_rng(3, &mut rng))
+            .collect();
+        assert!(
+            draws.iter().any(|d| d != &draws[0]),
+            "specs/retry.md: full jitter must vary across draws: {draws:?}"
+        );
+    }
+
+    #[test]
+    fn jitter_disabled_is_pure_exponential() {
+        let policy = RetryPolicy::default().jitter(false);
+        assert_eq!(policy.delay_for_attempt(1), Duration::from_millis(100));
+        assert_eq!(policy.delay_for_attempt(2), Duration::from_millis(200));
+        assert_eq!(policy.delay_for_attempt(5), Duration::from_millis(1600));
+        assert_eq!(policy.delay_for_attempt(6), Duration::from_millis(2000));
+    }
+
+    #[test]
+    fn defaults_match_spec() {
+        let policy = RetryPolicy::default();
+        assert_eq!(policy.max_retries, 3);
+        assert_eq!(policy.base_delay_ms, 100);
+        assert_eq!(policy.max_delay_ms, 2000);
+        assert!(policy.jitter);
+        assert!(policy.respect_retry_after);
+    }
+}

--- a/sdks/typescript/tests/retry-conformance.test.ts
+++ b/sdks/typescript/tests/retry-conformance.test.ts
@@ -1,0 +1,78 @@
+// Mirrors specs/retry.md — update BOTH or neither.
+// Cross-SDK siblings assert the SAME tables:
+//   sdks/rust/src/providers/mod.rs (mod retry_conformance)
+//   sdks/python/tests/test_retry_conformance.py
+// A failure means the implementation drifted from specs/retry.md — fix the
+// implementation (or the spec plus all three suites), never this file alone.
+import { describe, expect, it } from 'vitest'
+import { isRetryableStatus, parseRetryAfter } from '../src/error.js'
+import { RetryPolicy } from '../src/retry.js'
+
+const RETRYABLE = [408, 409, 429, 500, 502, 503, 529, 599]
+const NON_RETRYABLE = [200, 301, 400, 401, 403, 404, 422, 499]
+
+describe('specs/retry.md § classification', () => {
+  it.each(RETRYABLE)('status %i is retryable', (status) => {
+    expect(isRetryableStatus(status)).toBe(true)
+  })
+
+  it.each(NON_RETRYABLE)('status %i is NOT retryable', (status) => {
+    expect(isRetryableStatus(status)).toBe(false)
+  })
+})
+
+describe('specs/retry.md § Retry-After', () => {
+  it('parses integer seconds to milliseconds', () => {
+    expect(parseRetryAfter('5')).toBe(5000)
+    expect(parseRetryAfter('0')).toBe(0)
+    expect(parseRetryAfter(' 7 ')).toBe(7000)
+  })
+
+  it('caps at 60 seconds', () => {
+    expect(parseRetryAfter('61')).toBe(60_000)
+    expect(parseRetryAfter('86400')).toBe(60_000)
+  })
+
+  it('parses HTTP-date, clamped to [0, 60s]', () => {
+    // Deterministic: past date clamps to 0; far-future date clamps to the cap.
+    expect(parseRetryAfter('Wed, 21 Oct 2015 07:28:00 GMT')).toBe(0)
+    expect(parseRetryAfter('Fri, 31 Dec 2100 23:59:59 GMT')).toBe(60_000)
+  })
+
+  it('returns undefined for garbage', () => {
+    // A negative integer is invalid, NOT clamp-to-0 (only past HTTP-dates clamp).
+    expect(parseRetryAfter(null)).toBeUndefined()
+    expect(parseRetryAfter('')).toBeUndefined()
+    expect(parseRetryAfter('soon')).toBeUndefined()
+    expect(parseRetryAfter('-5')).toBeUndefined()
+  })
+})
+
+describe('specs/retry.md § backoff (full jitter)', () => {
+  it('scales the capped exponential delay by the injected random()', () => {
+    const half = new RetryPolicy({ random: () => 0.5 }) // base 100, max 2000
+    expect(half.delayForAttempt(1)).toBe(50)
+    expect(half.delayForAttempt(2)).toBe(100)
+    expect(half.delayForAttempt(3)).toBe(200)
+    expect(new RetryPolicy({ random: () => 0 }).delayForAttempt(4)).toBe(0)
+    // attempt 6: uncapped exp = 100 * 2^5 = 3200 → capped at 2000 BEFORE jitter.
+    expect(new RetryPolicy({ random: () => 1 }).delayForAttempt(6)).toBe(2000)
+  })
+
+  it('jitter=false is pure exponential and ignores random', () => {
+    const policy = new RetryPolicy({ jitter: false, random: () => 0.123 })
+    expect(policy.delayForAttempt(1)).toBe(100)
+    expect(policy.delayForAttempt(2)).toBe(200)
+    expect(policy.delayForAttempt(5)).toBe(1600)
+    expect(policy.delayForAttempt(6)).toBe(2000)
+  })
+
+  it('defaults match spec', () => {
+    const policy = RetryPolicy.default()
+    expect(policy.maxRetries).toBe(3)
+    expect(policy.baseDelayMs).toBe(100)
+    expect(policy.maxDelayMs).toBe(2000)
+    expect(policy.jitter).toBe(true)
+    expect(policy.respectRetryAfter).toBe(true)
+  })
+})


### PR DESCRIPTION
## M2 — Task 13: cross-SDK `specs/retry.md` conformance suites

One table-driven suite per SDK that pins the normative retry contract, so future
drift in any SDK fails loudly against `specs/retry.md`.

### What each suite asserts (identical tables across all three)
- **Classification** — `408/409/429/≥500` retryable; `200/301/400/401/403/404/422/499` not.
- **Retry-After** — integer seconds + RFC 7231 HTTP-date; clamped to `[0, 60s]`; a
  negative integer → none; only a *past* HTTP-date clamps to 0.
- **Backoff** — full jitter bounded by `min(base·2^(n-1), max_delay)` with injected RNG;
  `jitter=false` is pure exponential; spec defaults (`3 / 100ms / 2000ms / jitter / respect`).

### Files
- `sdks/rust/src/providers/mod.rs` — **in-crate** `#[cfg(test)] mod retry_conformance`
  (the consumed helpers `is_retryable_status` / `parse_retry_after` are `pub(crate)` and
  feature-gated, so a `tests/` integration test — a separate crate — could not import them).
  Ships no runtime code.
- `sdks/python/tests/test_retry_conformance.py` (new)
- `sdks/typescript/tests/retry-conformance.test.ts` (new)

All three carry a `Mirrors specs/retry.md` header cross-linking the sibling suites.

### Local gate output (all green)
- **Rust** — `cargo clippy --all-features --all-targets -- -D warnings` → 0 warnings;
  `cargo test --all-features providers::retry_conformance` → **9 passed; 0 failed**.
- **Python** — `uv run pytest tests/test_retry_conformance.py -v` → **24 passed**.
- **TypeScript** — `npm run typecheck && npm run build && npm test` → exit 0,
  **594 passed / 9 skipped** (conformance file: 23 passed).

Test-only (the Rust `.rs` edit is a `#[cfg(test)]` mod). No existing test modified.
No merge/tag/publish intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
