### PR TITLE
docs(specs): stream termination contract + cancellation semantics (M3)

### DIFF
--- a/specs/retry.md
+++ b/specs/retry.md
@@ -24,6 +24,7 @@ retryable_status(s) = s == 408 || s == 409 || s == 429 || s >= 500
 | HTTP 429 (rate limit) | ✅ |
 | HTTP ≥ 500 (server error) | ✅ |
 | Transport / connection error (table below) | ✅ |
+| Caller-initiated cancellation (TypeScript `CancelledError`, table below) | ❌ never |
 | Any other 4xx (400, 401, 403, 404, 422, …) | ❌ never |
 | Success-body parse error; any error after the first stream event | ❌ never |
 
@@ -41,13 +42,22 @@ Python's `_is_retryable` is attribute-based: `RateLimitError` → retry;
 `NetworkError` → retry; `ProviderError` → retry iff
 `error.status_code in {408, 409}` or `(error.status_code or 0) >= 500`.
 
-Transport / connection errors (always retryable):
+Transport / connection / cancellation errors:
 
-| SDK | Surfaced as | Predicate |
-|-----|-------------|-----------|
-| Rust | `MotosanError::Network` | `is_retryable_network_error`: `reqwest::Error::is_timeout() \|\| is_connect() \|\| is_request() \|\| is_body()` |
-| Python | `NetworkError` | providers wrap `httpx.HTTPError` raised while sending (`httpx.TransportError`-derived in practice: `ConnectError`, `ConnectTimeout`, `ReadTimeout`, `ReadError`, …); every `NetworkError` is retryable |
-| TypeScript | raw fetch/Node error, classified directly | `isRetryableNetworkError`: `error.name === 'AbortError'`, `error instanceof TypeError`, or Node `error.code` ∈ {`ECONNREFUSED`, `ENOTFOUND`, `ETIMEDOUT`} |
+| SDK | Surfaced as | Predicate | Retry |
+|-----|-------------|-----------|-------|
+| Rust | `MotosanError::Network` | `is_retryable_network_error`: `reqwest::Error::is_timeout() \|\| is_connect() \|\| is_request() \|\| is_body()` | ✅ |
+| Python | `NetworkError` | providers wrap `httpx.HTTPError` raised while sending (`httpx.TransportError`-derived in practice: `ConnectError`, `ConnectTimeout`, `ReadTimeout`, `ReadError`, …); every `NetworkError` is retryable | ✅ |
+| TypeScript | raw fetch/Node error, classified directly | `isRetryableNetworkError`: `error.name === 'AbortError'` **when no caller-supplied signal is aborted**, `error instanceof TypeError`, or Node `error.code` ∈ {`ECONNREFUSED`, `ENOTFOUND`, `ETIMEDOUT`} | ✅ |
+| TypeScript | `CancelledError` (`extends MotosanError`) | the caller-supplied per-request `AbortSignal` is aborted at failure time | ❌ never |
+
+TypeScript AbortError split — an abort is classified by **who
+aborted**. If the caller-supplied per-request `AbortSignal` is
+aborted, the SDK throws `CancelledError`: the caller asked to stop,
+and retrying would override that intent. A fetch-internal
+`AbortError` with no caller signal aborted (e.g. an SDK-composed
+`AbortSignal.timeout`) remains a retryable transport error, exactly
+as before.
 
 ## Retry-After
 
@@ -112,6 +122,14 @@ has been yielded to the caller, every error — even one retryable by
 class — propagates verbatim: replaying a partially consumed stream
 would double-emit content. Connection-phase failures (before the first
 event) follow the normal classification table.
+
+Read-idle timeout errors that fire mid-stream (Rust
+`MotosanError::StreamReadTimeout`, TypeScript
+`StreamReadTimeoutError`, and Python `StreamReadTimeoutError` —
+surfaced from `httpx.ReadTimeout`) are **not retried**: they occur
+after the first emitted event, so the rule above applies, even though
+timeout-class transport errors are retryable during the connection
+phase.
 
 Reference conformance tests:
 `sdks/python/tests/test_client_stream_with.py::test_stream_with_does_not_retry_provider_error_after_yield`

--- a/specs/types.md
+++ b/specs/types.md
@@ -112,7 +112,7 @@ Passing unsupported content returns `Err(UnsupportedFeature)` before any network
 | Field | Type | Notes |
 |-------|------|-------|
 | `content` | `string` | Text delta |
-| `done` | `bool` | Exactly one terminal event per stream |
+| `done` | `bool` | Exactly one terminal event per *successfully completed* stream — see [Stream termination contract](#stream-termination-contract) |
 | `stop_reason` | `StopReason?` | Set on terminal event when provider reports one |
 | `event_type` | `StreamEventType` | |
 | `tool_call_id` | `string?` | |
@@ -124,9 +124,85 @@ Passing unsupported content returns `Err(UnsupportedFeature)` before any network
 
 `text` | `tool_call_start` | `tool_call_args` | `tool_call_end` | `usage` | `done`
 
+## Stream termination contract
+
+Every provider defines a **terminal event** that marks the successful
+end of a stream:
+
+| Provider family | Terminal event |
+|-----------------|----------------|
+| OpenAI | `data: [DONE]` SSE sentinel |
+| MiniMax | Python: `data: [DONE]` SSE sentinel (own OpenAI-compatible-wire adapter). Rust / TypeScript: `message_stop` — both delegate to the Anthropic adapter (Rust `build_minimax_provider` constructs an `AnthropicProvider`; TS `MinimaxProvider` wraps one), so the Anthropic rule applies |
+| Anthropic | `message_stop` SSE event (the Python adapter additionally treats a stray `data: [DONE]` as terminal) |
+| Gemini, GeminiCodeAssist | final SSE chunk carrying `finishReason` (a trailing `[DONE]` is tolerated but not required) |
+| ChatGPT Codex | `response.completed` SSE event |
+| Ollama | final NDJSON object with `"done": true` |
+
+**Terminal-event rule.** Enforcement lives in the **stream adapters**,
+not the collectors. When the upstream byte/event stream ends (EOF)
+**without** the provider's terminal event, the adapter yields/throws
+the `IncompleteStream` error below. Adapters MUST NOT fabricate a
+synthetic `done` event and MUST NOT end the stream silently:
+truncation is always distinguishable from completion.
+
+Collectors are unchanged: they keep propagating adapter errors (the
+M1 fallible-stream contract) and keep the `stop_reason` heuristic
+**only** for a real terminal event that lacks a reason — never as a
+substitute for a missing terminal event.
+
+### IncompleteStream error
+
+| SDK | Spelling |
+|-----|----------|
+| Rust | `MotosanError::IncompleteStream(String)` — `#[error("incomplete stream: {0}")]`; new enum variant ⇒ breaking, ships 0.24.0 |
+| Python | `class IncompleteStreamError(StreamError)` |
+| TypeScript | `export class IncompleteStreamError extends StreamError` |
+
+Message convention (all SDKs):
+`incomplete stream: <provider> ended without a terminal event` — e.g.
+`incomplete stream: openai ended without a terminal event`.
+
+Python and TypeScript subclass `StreamError` deliberately, as a
+migration softener: existing `except StreamError` /
+`instanceof StreamError` handlers still catch truncation. Handlers
+that must distinguish truncation match the subclass. Rust has no such
+softener — the new enum variant is the breaking change.
+
+### Retired invariant (v0.10.1)
+
+The former guarantee that streams "emit exactly one terminal `done`
+event **even when the upstream provider closes the connection
+without** `[DONE]` **and without any** `finish_reason` **chunk**"
+(introduced in the v0.10.1 era; implemented via the `done_emitted` /
+`doneEmitted` EOF fabrication in the Rust and TypeScript OpenAI
+adapters — which also served MiniMax before its v0.14 move to the
+Anthropic wire — and equivalent defensive-EOF fabrication or
+silent-end paths elsewhere, e.g. the TypeScript Anthropic adapter's
+fallback `done` at EOF) is **deliberately retired**. Fabricating
+`done` on a truncated EOF made truncation indistinguishable from
+completion. The narrower invariant that survives: a stream that
+terminates *without error* emits exactly one terminal `done` event.
+
+### Cancellation
+
+- **Rust** — drop-cancellation: dropping the stream (or the `chat()`
+  future) drops the underlying `reqwest` response/future, which
+  cancels the in-flight HTTP request and releases the connection.
+  There is no explicit cancel API; this is documented behavior, not a
+  code change.
+- **TypeScript** — per-request `AbortSignal`: aborting a
+  caller-supplied signal cancels the underlying `fetch` and surfaces
+  `CancelledError extends MotosanError`, which is never retried — see
+  [`retry.md`](./retry.md#classification).
+- **Python** — standard `asyncio` task cancellation: cancelling the
+  task awaiting `chat()` / iterating `stream()` raises
+  `asyncio.CancelledError` through the SDK, and `httpx` closes the
+  underlying connection. The SDK neither swallows nor converts
+  `CancelledError`.
+
 ## MotosanError (Rust)
 
-`Auth` | `RateLimit` | `InvalidRequest` | `Config` | `ProviderError` | `Network` | `Stream` | `StreamReadTimeout(u64)` | `UnsupportedFeature(String)`
+`Auth` | `RateLimit` | `InvalidRequest` | `Config` | `ProviderError` | `Network` | `Stream` | `StreamReadTimeout(u64)` | `IncompleteStream(String)` | `UnsupportedFeature(String)`
 
 Retry classification, backoff, and `Retry-After` handling are specified in [`retry.md`](./retry.md).
 

--- a/specs/types.md
+++ b/specs/types.md
@@ -131,8 +131,8 @@ end of a stream:
 
 | Provider family | Terminal event |
 |-----------------|----------------|
-| OpenAI | `data: [DONE]` SSE sentinel |
-| MiniMax | Python: `data: [DONE]` SSE sentinel (own OpenAI-compatible-wire adapter). Rust / TypeScript: `message_stop` — both delegate to the Anthropic adapter (Rust `build_minimax_provider` constructs an `AnthropicProvider`; TS `MinimaxProvider` wraps one), so the Anthropic rule applies |
+| OpenAI | `data: [DONE]` SSE sentinel, or a `finish_reason`-bearing chunk (either suffices; `finish_reason` is the semantic terminal, `[DONE]` the transport epilogue) |
+| MiniMax | Python: `data: [DONE]` SSE sentinel, or a `finish_reason`-bearing chunk (either suffices, as for OpenAI — own OpenAI-compatible-wire adapter). Rust / TypeScript: `message_stop` — both delegate to the Anthropic adapter (Rust `build_minimax_provider` constructs an `AnthropicProvider`; TS `MinimaxProvider` wraps one), so the Anthropic rule applies |
 | Anthropic | `message_stop` SSE event (the Python adapter additionally treats a stray `data: [DONE]` as terminal) |
 | Gemini, GeminiCodeAssist | final SSE chunk carrying `finishReason` (a trailing `[DONE]` is tolerated but not required) |
 | ChatGPT Codex | `response.completed` SSE event |
@@ -143,7 +143,10 @@ not the collectors. When the upstream byte/event stream ends (EOF)
 **without** the provider's terminal event, the adapter yields/throws
 the `IncompleteStream` error below. Adapters MUST NOT fabricate a
 synthetic `done` event and MUST NOT end the stream silently:
-truncation is always distinguishable from completion.
+truncation is always distinguishable from completion. (On the OpenAI
+wire the `done` event may be *emitted at EOF* when a `finish_reason`
+chunk — a real terminal event per the table above — already arrived;
+that is delivery of a received terminal, not fabrication.)
 
 Collectors are unchanged: they keep propagating adapter errors (the
 M1 fallible-stream contract) and keep the `stop_reason` heuristic
@@ -180,8 +183,13 @@ Anthropic wire — and equivalent defensive-EOF fabrication or
 silent-end paths elsewhere, e.g. the TypeScript Anthropic adapter's
 fallback `done` at EOF) is **deliberately retired**. Fabricating
 `done` on a truncated EOF made truncation indistinguishable from
-completion. The narrower invariant that survives: a stream that
-terminates *without error* emits exactly one terminal `done` event.
+completion. What is retired is precisely the NEITHER-signal
+fabrication: on the OpenAI wire an EOF after a `finish_reason`-bearing
+chunk is a *semantically complete* stream (per the terminal-event
+table above) and still emits `done` carrying the stashed stop reason —
+that path is NOT retired. The narrower invariant that survives: a
+stream that terminates *without error* emits exactly one terminal
+`done` event.
 
 ### Cancellation
 


### PR DESCRIPTION
## Summary
- M3 PR-S / Task 1 from docs/superpowers/plans/2026-07-16-stream-retry-m3-implementation.md
- Amend specs/types.md with the stream termination contract, provider terminal events, IncompleteStream spellings, retired fabricated-done invariant, and cancellation semantics
- Amend specs/retry.md with TypeScript CancelledError classification and non-retryable mid-stream read-idle timeout semantics

## Gate / CI
- Docs-only PR by design: this repo does not produce CI checks for docs-only PRs. Completion proof is OPEN PR state plus diff summary.
- Local Task 1 checks: grep consistency checks for old done row, IncompleteStream, message_stop, and CancelledError; Markdown table pipe-count sanity with escaped pipes ignored; git diff --check.
- Local pre-push hook also passed after syncing Python dev extras: Python unit tests, Rust unit tests, Python live Anthropic tests, Rust live Anthropic tests.

## Ordering
- PR-R/P/T must not merge before PR-S.

🤖 Generated with [Claude Code](https://claude.com/claude-code)