### PR TITLE
feat(rust): stream termination and timeout lifecycle (M3 PR-R)

### DIFF
--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
 ### Breaking
 - **Truncated streams now error instead of ending cleanly.** Every HTTP stream adapter (openai, anthropic, gemini, gemini-code-assist, chatgpt-codex, ollama) yields `Err(MotosanError::IncompleteStream("<provider> ended without a terminal event"))` when the upstream connection closes without the provider terminal event (OpenAI-wire `[DONE]` or a `finish_reason` chunk — either suffices / `message_stop` / `finishReason` / `response.completed` / `"done":true`). OpenAI amendment: `finish_reason` is the semantic terminal — EOF after a stashed finish_reason still emits `done(stop_reason)` and completes cleanly; only EOF with NEITHER signal errors. The v0.10.1 invariant "exactly one terminal done event even when upstream closes without `[DONE]`" is retired for that neither-signal case. New `MotosanError::IncompleteStream(String)` variant — enum addition breaks exhaustive matches.
+- **Timeout API cleanup.** `Client::stream_read_timeout()` getter is removed; `ClientBuilder::stream_read_timeout_secs` is deprecated in favor of `read_idle_timeout(Duration)`. HTTP streams now enforce a 120s default read-idle deadline; idle expiry yields `MotosanError::StreamReadTimeout` and is never retried mid-stream.
+
+### Added
+- Unified timeout model: `ClientBuilder::connect_timeout(Duration)` (default 10s on the shared reqwest client), `.read_idle_timeout(Duration)` (default 120s), and `.total_timeout(Duration)` (default off; bounds each blocking `chat()` attempt, never streams; expiry surfaces as retryable `MotosanError::Network`).
 
 ## [0.23.0] - 2026-07-16
 

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
 ## [Unreleased]
 
+### Breaking
+- **Truncated streams now error instead of ending cleanly.** Every HTTP stream adapter (openai, anthropic, gemini, gemini-code-assist, chatgpt-codex, ollama) yields `Err(MotosanError::IncompleteStream("<provider> ended without a terminal event"))` when the upstream connection closes without the provider terminal event (OpenAI-wire `[DONE]` or a `finish_reason` chunk — either suffices / `message_stop` / `finishReason` / `response.completed` / `"done":true`). OpenAI amendment: `finish_reason` is the semantic terminal — EOF after a stashed finish_reason still emits `done(stop_reason)` and completes cleanly; only EOF with NEITHER signal errors. The v0.10.1 invariant "exactly one terminal done event even when upstream closes without `[DONE]`" is retired for that neither-signal case. New `MotosanError::IncompleteStream(String)` variant — enum addition breaks exhaustive matches.
+
 ## [0.23.0] - 2026-07-16
 
 ### Breaking

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -6,16 +6,30 @@ use crate::think_stripper::ThinkStripper;
 use crate::types::{ChatRequest, ChatResponse, Message, StreamEvent, StreamEventType};
 use std::time::Duration;
 
-#[cfg(any(
-    feature = "anthropic",
-    feature = "openai",
-    feature = "minimax",
-    feature = "ollama",
-    feature = "gemini",
-    feature = "gemini-code-assist",
-    feature = "chatgpt-codex",
-))]
-const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const DEFAULT_READ_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Unified timeout model:
+/// - `connect`: TCP/TLS connect deadline on the shared reqwest client.
+/// - `read_idle`: max gap between HTTP stream chunks before
+///   `MotosanError::StreamReadTimeout`.
+/// - `total`: opt-in wall-clock budget per blocking `chat()` attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TimeoutConfig {
+    pub(crate) connect: Duration,
+    pub(crate) read_idle: Duration,
+    pub(crate) total: Option<Duration>,
+}
+
+impl Default for TimeoutConfig {
+    fn default() -> Self {
+        Self {
+            connect: DEFAULT_CONNECT_TIMEOUT,
+            read_idle: DEFAULT_READ_IDLE_TIMEOUT,
+            total: None,
+        }
+    }
+}
 
 /// The provider selected and fully constructed at `ClientBuilder::build()`
 /// time. Dispatch borrows this instead of rebuilding per request.
@@ -97,7 +111,7 @@ pub struct Client {
     ollama_keep_alive: Option<String>,
     ollama_num_ctx: Option<u32>,
     retry_policy: RetryPolicy,
-    stream_read_timeout: Option<Duration>,
+    timeouts: TimeoutConfig,
     /// Pre-built Claude Code provider instance used when `provider ==
     /// Provider::ClaudeCode`. Configured via [`ClientBuilder::claude_code`].
     /// If `None`, a default [`ClaudeCodeProvider::new`] is used at dispatch
@@ -173,8 +187,16 @@ impl Client {
         &self.retry_policy
     }
 
-    pub fn stream_read_timeout(&self) -> Option<Duration> {
-        self.stream_read_timeout
+    pub fn connect_timeout(&self) -> Duration {
+        self.timeouts.connect
+    }
+
+    pub fn read_idle_timeout(&self) -> Duration {
+        self.timeouts.read_idle
+    }
+
+    pub fn total_timeout(&self) -> Option<Duration> {
+        self.timeouts.total
     }
 
     pub fn openai_auth_header(&self) -> Option<&str> {
@@ -295,9 +317,14 @@ impl Client {
             feature = "minimax",
             feature = "ollama_native",
             feature = "gemini",
+            feature = "gemini-code-assist",
+            feature = "chatgpt-codex",
         ))]
-        if let Some(timeout) = self.stream_read_timeout {
-            return Ok(Box::pin(ReadTimeoutStream::new(raw, timeout)));
+        if self.provider.uses_http_transport() {
+            return Ok(Box::pin(ReadTimeoutStream::new(
+                raw,
+                self.timeouts.read_idle,
+            )));
         }
         Ok(raw)
     }
@@ -453,6 +480,7 @@ impl Client {
             self.anthropic_base_url.clone(),
         )
         .with_retry_policy(self.retry_policy.clone())
+        .with_total_timeout(self.timeouts.total)
         .with_http_client(self.http.clone())
     }
 
@@ -470,6 +498,7 @@ impl Client {
             .with_auth_style(auth_style)
             .with_responses_fallback(self.openai_responses_fallback)
             .with_retry_policy(self.retry_policy.clone())
+            .with_total_timeout(self.timeouts.total)
             .with_http_client(self.http.clone());
 
         if let Some(ref url) = self.openai_chat_url {
@@ -502,6 +531,7 @@ impl Client {
         )
         .with_capabilities(ProviderCapabilities::text_only())
         .with_retry_policy(self.retry_policy.clone())
+        .with_total_timeout(self.timeouts.total)
         .with_http_client(self.http.clone())
     }
 
@@ -525,6 +555,7 @@ impl Client {
             .with_chat_url(chat_url)
             .with_auth_style(OpenAIAuthStyle::Bearer)
             .with_retry_policy(self.retry_policy.clone())
+            .with_total_timeout(self.timeouts.total)
             .with_http_client(self.http.clone())
     }
 
@@ -539,6 +570,7 @@ impl Client {
             .with_keep_alive(self.ollama_keep_alive.clone())
             .with_num_ctx(self.ollama_num_ctx)
             .with_retry_policy(self.retry_policy.clone())
+            .with_total_timeout(self.timeouts.total)
             .with_http_client(self.http.clone())
     }
 
@@ -568,6 +600,7 @@ impl Client {
             None,
         )
         .with_retry_policy(self.retry_policy.clone())
+        .with_total_timeout(self.timeouts.total)
         .with_http_client(self.http.clone())
     }
 
@@ -586,6 +619,7 @@ impl Client {
                 None,
             )
             .with_retry_policy(self.retry_policy.clone())
+            .with_total_timeout(self.timeouts.total)
             .with_http_client(self.http.clone()),
         }
     }
@@ -637,6 +671,7 @@ impl Client {
             None,
         )
         .with_retry_policy(self.retry_policy.clone())
+        .with_total_timeout(self.timeouts.total)
         .with_http_client(self.http.clone())
         .with_reasoning_effort(self.chatgpt_codex_reasoning_effort.clone())
     }
@@ -659,7 +694,9 @@ pub struct ClientBuilder {
     ollama_keep_alive: Option<String>,
     ollama_num_ctx: Option<u32>,
     retry_policy: Option<RetryPolicy>,
-    stream_read_timeout_secs: Option<u64>,
+    connect_timeout: Option<Duration>,
+    read_idle_timeout: Option<Duration>,
+    total_timeout: Option<Duration>,
     #[cfg(feature = "claude-code")]
     claude_code: Option<crate::providers::claude_code::ClaudeCodeProvider>,
     #[cfg(feature = "codex-cli")]
@@ -839,8 +876,30 @@ impl ClientBuilder {
         self
     }
 
+    /// TCP/TLS connect deadline for the shared HTTP client. Default: 10s.
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = Some(timeout);
+        self
+    }
+
+    /// Max idle gap between HTTP stream chunks before the stream yields
+    /// `MotosanError::StreamReadTimeout`. Default: 120s.
+    pub fn read_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.read_idle_timeout = Some(timeout);
+        self
+    }
+
+    /// Opt-in wall-clock budget per blocking `chat()` attempt. Default: off.
+    /// Never applied to streams.
+    pub fn total_timeout(mut self, timeout: Duration) -> Self {
+        self.total_timeout = Some(timeout);
+        self
+    }
+
+    /// Superseded alias for [`read_idle_timeout`](Self::read_idle_timeout).
+    #[deprecated(since = "0.24.0", note = "use read_idle_timeout(Duration)")]
     pub fn stream_read_timeout_secs(mut self, secs: u64) -> Self {
-        self.stream_read_timeout_secs = Some(secs);
+        self.read_idle_timeout = Some(Duration::from_secs(secs));
         self
     }
 
@@ -983,6 +1042,12 @@ impl ClientBuilder {
             }
         }
 
+        let timeouts = TimeoutConfig {
+            connect: self.connect_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT),
+            read_idle: self.read_idle_timeout.unwrap_or(DEFAULT_READ_IDLE_TIMEOUT),
+            total: self.total_timeout,
+        };
+
         #[cfg(any(
             feature = "anthropic",
             feature = "openai",
@@ -993,7 +1058,7 @@ impl ClientBuilder {
             feature = "chatgpt-codex",
         ))]
         let http = reqwest::Client::builder()
-            .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+            .connect_timeout(timeouts.connect)
             .build()
             .map_err(|e| MotosanError::Config(format!("failed to build HTTP client: {e}")))?;
 
@@ -1001,10 +1066,16 @@ impl ClientBuilder {
         let retry_policy = retry_policy_override.clone().unwrap_or_default();
 
         #[cfg(feature = "gemini-code-assist")]
-        let gemini_code_assist = match (self.gemini_code_assist, retry_policy_override.as_ref()) {
+        let mut gemini_code_assist = match (self.gemini_code_assist, retry_policy_override.as_ref())
+        {
             (Some(provider), Some(policy)) => Some(provider.with_retry_policy(policy.clone())),
             (provider, _) => provider,
         };
+        #[cfg(feature = "gemini-code-assist")]
+        if timeouts.total.is_some() {
+            gemini_code_assist =
+                gemini_code_assist.map(|provider| provider.with_total_timeout(timeouts.total));
+        }
 
         let mut client = Client {
             provider,
@@ -1024,7 +1095,7 @@ impl ClientBuilder {
             ollama_keep_alive: self.ollama_keep_alive,
             ollama_num_ctx: self.ollama_num_ctx,
             retry_policy,
-            stream_read_timeout: self.stream_read_timeout_secs.map(Duration::from_secs),
+            timeouts,
             #[cfg(feature = "claude-code")]
             claude_code: self.claude_code,
             #[cfg(feature = "codex-cli")]
@@ -1070,6 +1141,8 @@ impl ClientBuilder {
     feature = "minimax",
     feature = "ollama_native",
     feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
 ))]
 struct ReadTimeoutStream {
     inner: BoxStream,
@@ -1084,6 +1157,8 @@ struct ReadTimeoutStream {
     feature = "minimax",
     feature = "ollama_native",
     feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
 ))]
 impl ReadTimeoutStream {
     fn new(inner: BoxStream, timeout: Duration) -> Self {
@@ -1102,6 +1177,8 @@ impl ReadTimeoutStream {
     feature = "minimax",
     feature = "ollama_native",
     feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
 ))]
 impl futures_core::Stream for ReadTimeoutStream {
     type Item = Result<StreamEvent, MotosanError>;

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -6,6 +6,79 @@ use crate::think_stripper::ThinkStripper;
 use crate::types::{ChatRequest, ChatResponse, Message, StreamEvent, StreamEventType};
 use std::time::Duration;
 
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The provider selected and fully constructed at `ClientBuilder::build()`
+/// time. Dispatch borrows this instead of rebuilding per request.
+#[derive(Debug, Clone)]
+enum BuiltProvider {
+    #[cfg(feature = "anthropic")]
+    Anthropic(crate::providers::anthropic::AnthropicProvider),
+    #[cfg(feature = "openai")]
+    OpenAI(crate::providers::openai::OpenAIProvider),
+    #[cfg(feature = "minimax")]
+    Minimax(crate::providers::anthropic::AnthropicProvider),
+    #[cfg(feature = "ollama")]
+    OllamaCompat(crate::providers::openai::OpenAIProvider),
+    #[cfg(feature = "ollama")]
+    OllamaNative(crate::providers::ollama::OllamaProvider),
+    #[cfg(feature = "claude-code")]
+    ClaudeCode(crate::providers::claude_code::ClaudeCodeProvider),
+    #[cfg(feature = "codex-cli")]
+    CodexCli(crate::providers::codex_cli::CodexCliProvider),
+    #[cfg(feature = "gemini-cli")]
+    GeminiCli(crate::providers::gemini_cli::GeminiCliProvider),
+    #[cfg(feature = "gemini")]
+    Gemini(crate::providers::gemini::GeminiProvider),
+    #[cfg(feature = "gemini-code-assist")]
+    GeminiCodeAssist(crate::providers::gemini_code_assist::GeminiCodeAssistProvider),
+    #[cfg(feature = "chatgpt-codex")]
+    ChatGptCodex(crate::providers::chatgpt_codex::ChatGptCodexProvider),
+    /// Selected provider's cargo feature is not enabled.
+    Disabled(&'static str),
+}
+
+impl BuiltProvider {
+    fn as_impl(&self) -> Result<&dyn crate::providers::ProviderImpl, MotosanError> {
+        match self {
+            #[cfg(feature = "anthropic")]
+            BuiltProvider::Anthropic(p) => Ok(p),
+            #[cfg(feature = "openai")]
+            BuiltProvider::OpenAI(p) => Ok(p),
+            #[cfg(feature = "minimax")]
+            BuiltProvider::Minimax(p) => Ok(p),
+            #[cfg(feature = "ollama")]
+            BuiltProvider::OllamaCompat(p) => Ok(p),
+            #[cfg(feature = "ollama")]
+            BuiltProvider::OllamaNative(p) => Ok(p),
+            #[cfg(feature = "claude-code")]
+            BuiltProvider::ClaudeCode(p) => Ok(p),
+            #[cfg(feature = "codex-cli")]
+            BuiltProvider::CodexCli(p) => Ok(p),
+            #[cfg(feature = "gemini-cli")]
+            BuiltProvider::GeminiCli(p) => Ok(p),
+            #[cfg(feature = "gemini")]
+            BuiltProvider::Gemini(p) => Ok(p),
+            #[cfg(feature = "gemini-code-assist")]
+            BuiltProvider::GeminiCodeAssist(p) => Ok(p),
+            #[cfg(feature = "chatgpt-codex")]
+            BuiltProvider::ChatGptCodex(p) => Ok(p),
+            BuiltProvider::Disabled(feature) => Err(MotosanError::Config(format!(
+                "{feature} feature is not enabled"
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Client {
@@ -65,6 +138,18 @@ pub struct Client {
     /// via [`ClientBuilder::chatgpt_codex_reasoning_effort`].
     #[cfg(feature = "chatgpt-codex")]
     chatgpt_codex_reasoning_effort: Option<String>,
+    built: BuiltProvider,
+    /// Shared HTTP transport. `reqwest::Client` clones share one connection pool.
+    #[cfg(any(
+        feature = "anthropic",
+        feature = "openai",
+        feature = "minimax",
+        feature = "ollama",
+        feature = "gemini",
+        feature = "gemini-code-assist",
+        feature = "chatgpt-codex",
+    ))]
+    http: reqwest::Client,
 }
 
 impl Client {
@@ -197,181 +282,9 @@ impl Client {
     }
 
     async fn dispatch_chat(&self, request: ChatRequest) -> Result<ChatResponse, MotosanError> {
-        match self.provider {
-            Provider::Anthropic => {
-                #[cfg(feature = "anthropic")]
-                {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_anthropic_provider();
-                    p.validate_request(&request)?;
-                    p.chat(request).await
-                }
-                #[cfg(not(feature = "anthropic"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("anthropic"))
-                }
-            }
-            Provider::OpenAI => {
-                #[cfg(feature = "openai")]
-                {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_openai_provider();
-                    p.validate_request(&request)?;
-                    p.chat(request).await
-                }
-                #[cfg(not(feature = "openai"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("openai"))
-                }
-            }
-            Provider::Minimax => {
-                #[cfg(feature = "minimax")]
-                {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_minimax_provider();
-                    p.validate_request(&request)?;
-                    p.chat(request).await
-                }
-                #[cfg(not(feature = "minimax"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("minimax"))
-                }
-            }
-            Provider::Ollama => {
-                #[cfg(feature = "ollama")]
-                {
-                    use crate::providers::ProviderImpl;
-                    // Auto-route to OllamaProvider (native /api/chat) when
-                    // ollama_native is explicitly enabled OR any of the
-                    // Ollama-specific tuning fields is set, since the
-                    // OpenAI-compat /v1/chat/completions endpoint silently
-                    // drops keep_alive / options.num_ctx / think
-                    // server-side. Otherwise stay on the OpenAI-compat
-                    // path for backwards compatibility.
-                    //
-                    // Capability trade-off: OllamaProvider is text-only
-                    // (no image capability) while the OpenAI-compat path
-                    // declares with_image(). Auto-switching strips image
-                    // capability — the wrapped validate_request error
-                    // below tells the caller WHY their image input
-                    // stopped working.
-                    let needs_native = self.ollama_native
-                        || self.ollama_keep_alive.is_some()
-                        || self.ollama_num_ctx.is_some()
-                        || self.ollama_think.is_some();
-                    if needs_native {
-                        let p = self.build_ollama_native_provider();
-                        p.validate_request(&request).map_err(|e| match e {
-                            MotosanError::UnsupportedFeature(msg) => MotosanError::UnsupportedFeature(format!(
-                                "{msg} — Provider::Ollama was auto-routed to the native /api/chat endpoint \
-                                 because one of ollama_keep_alive / ollama_num_ctx / ollama_think is set, \
-                                 and the native endpoint is text-only. Either remove the tuning field(s) to \
-                                 stay on the OpenAI-compat path (which supports images), or remove the image \
-                                 input."
-                            )),
-                            other => other,
-                        })?;
-                        p.chat(request).await
-                    } else {
-                        let p = self.build_ollama_provider();
-                        p.validate_request(&request)?;
-                        p.chat(request).await
-                    }
-                }
-                #[cfg(not(feature = "ollama"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("ollama"))
-                }
-            }
-            Provider::ClaudeCode => {
-                #[cfg(feature = "claude-code")]
-                {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_claude_code_provider();
-                    p.validate_request(&request)?;
-                    p.chat(request).await
-                }
-                #[cfg(not(feature = "claude-code"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("claude-code"))
-                }
-            }
-            Provider::CodexCli => {
-                #[cfg(feature = "codex-cli")]
-                {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_codex_cli_provider();
-                    p.validate_request(&request)?;
-                    p.chat(request).await
-                }
-                #[cfg(not(feature = "codex-cli"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("codex-cli"))
-                }
-            }
-            Provider::GeminiCli => {
-                #[cfg(feature = "gemini-cli")]
-                {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_gemini_cli_provider();
-                    p.validate_request(&request)?;
-                    p.chat(request).await
-                }
-                #[cfg(not(feature = "gemini-cli"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("gemini-cli"))
-                }
-            }
-            Provider::Gemini => {
-                #[cfg(feature = "gemini")]
-                {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_gemini_provider();
-                    p.validate_request(&request)?;
-                    p.chat(request).await
-                }
-                #[cfg(not(feature = "gemini"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("gemini"))
-                }
-            }
-            Provider::GeminiCodeAssist => {
-                #[cfg(feature = "gemini-code-assist")]
-                {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_gemini_code_assist_provider();
-                    p.validate_request(&request)?;
-                    p.chat(request).await
-                }
-                #[cfg(not(feature = "gemini-code-assist"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("gemini-code-assist"))
-                }
-            }
-            Provider::OpenAiChatGpt => {
-                #[cfg(feature = "chatgpt-codex")]
-                {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_chatgpt_codex_provider();
-                    p.validate_request(&request)?;
-                    p.chat(request).await
-                }
-                #[cfg(not(feature = "chatgpt-codex"))]
-                {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("chatgpt-codex"))
-                }
-            }
-        }
+        let provider = self.built.as_impl()?;
+        self.validate_for_dispatch(provider, &request)?;
+        provider.chat(request).await
     }
 
     async fn dispatch_stream(&self, request: ChatRequest) -> Result<BoxStream, MotosanError> {
@@ -390,187 +303,146 @@ impl Client {
     }
 
     async fn dispatch_stream_inner(&self, request: ChatRequest) -> Result<BoxStream, MotosanError> {
+        let provider = self.built.as_impl()?;
+        self.validate_for_dispatch(provider, &request)?;
+        provider.stream(request).await
+    }
+
+    fn validate_for_dispatch(
+        &self,
+        provider: &dyn crate::providers::ProviderImpl,
+        request: &ChatRequest,
+    ) -> Result<(), MotosanError> {
+        // Same auto-switch capability trade-off message as the pre-0.24
+        // dispatch arms: chat and stream must never split on this.
+        #[cfg(feature = "ollama")]
+        if matches!(self.built, BuiltProvider::OllamaNative(_)) {
+            return provider.validate_request(request).map_err(|e| match e {
+                MotosanError::UnsupportedFeature(msg) => MotosanError::UnsupportedFeature(format!(
+                    "{msg} — Provider::Ollama was auto-routed to the native /api/chat endpoint \
+                     because one of ollama_keep_alive / ollama_num_ctx / ollama_think is set, \
+                     and the native endpoint is text-only. Either remove the tuning field(s) to \
+                     stay on the OpenAI-compat path (which supports images), or remove the image \
+                     input."
+                )),
+                other => other,
+            });
+        }
+
+        provider.validate_request(request)
+    }
+
+    fn construct_built_provider(&self) -> BuiltProvider {
         match self.provider {
             Provider::Anthropic => {
                 #[cfg(feature = "anthropic")]
                 {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_anthropic_provider();
-                    p.validate_request(&request)?;
-                    p.stream(request).await
+                    BuiltProvider::Anthropic(self.build_anthropic_provider())
                 }
                 #[cfg(not(feature = "anthropic"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("anthropic"))
+                    BuiltProvider::Disabled("anthropic")
                 }
             }
             Provider::OpenAI => {
                 #[cfg(feature = "openai")]
                 {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_openai_provider();
-                    p.validate_request(&request)?;
-                    p.stream(request).await
+                    BuiltProvider::OpenAI(self.build_openai_provider())
                 }
                 #[cfg(not(feature = "openai"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("openai"))
+                    BuiltProvider::Disabled("openai")
                 }
             }
             Provider::Minimax => {
                 #[cfg(feature = "minimax")]
                 {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_minimax_provider();
-                    p.validate_request(&request)?;
-                    p.stream(request).await
+                    BuiltProvider::Minimax(self.build_minimax_provider())
                 }
                 #[cfg(not(feature = "minimax"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("minimax"))
+                    BuiltProvider::Disabled("minimax")
                 }
             }
             Provider::Ollama => {
                 #[cfg(feature = "ollama")]
                 {
-                    use crate::providers::ProviderImpl;
-                    // Same auto-switch + capability trade-off as
-                    // dispatch_chat — keep the routing condition
-                    // identical so chat and stream are never split.
                     let needs_native = self.ollama_native
                         || self.ollama_keep_alive.is_some()
                         || self.ollama_num_ctx.is_some()
                         || self.ollama_think.is_some();
                     if needs_native {
-                        let p = self.build_ollama_native_provider();
-                        p.validate_request(&request).map_err(|e| match e {
-                            MotosanError::UnsupportedFeature(msg) => MotosanError::UnsupportedFeature(format!(
-                                "{msg} — Provider::Ollama was auto-routed to the native /api/chat endpoint \
-                                 because one of ollama_keep_alive / ollama_num_ctx / ollama_think is set, \
-                                 and the native endpoint is text-only. Either remove the tuning field(s) to \
-                                 stay on the OpenAI-compat path (which supports images), or remove the image \
-                                 input."
-                            )),
-                            other => other,
-                        })?;
-                        p.stream(request).await
+                        BuiltProvider::OllamaNative(self.build_ollama_native_provider())
                     } else {
-                        let p = self.build_ollama_provider();
-                        p.validate_request(&request)?;
-                        p.stream(request).await
+                        BuiltProvider::OllamaCompat(self.build_ollama_provider())
                     }
                 }
                 #[cfg(not(feature = "ollama"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("ollama"))
+                    BuiltProvider::Disabled("ollama")
                 }
             }
             Provider::ClaudeCode => {
                 #[cfg(feature = "claude-code")]
                 {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_claude_code_provider();
-                    p.validate_request(&request)?;
-                    p.stream(request).await
+                    BuiltProvider::ClaudeCode(self.build_claude_code_provider())
                 }
                 #[cfg(not(feature = "claude-code"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("claude-code"))
+                    BuiltProvider::Disabled("claude-code")
                 }
             }
             Provider::CodexCli => {
                 #[cfg(feature = "codex-cli")]
                 {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_codex_cli_provider();
-                    p.validate_request(&request)?;
-                    p.stream(request).await
+                    BuiltProvider::CodexCli(self.build_codex_cli_provider())
                 }
                 #[cfg(not(feature = "codex-cli"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("codex-cli"))
+                    BuiltProvider::Disabled("codex-cli")
                 }
             }
             Provider::GeminiCli => {
                 #[cfg(feature = "gemini-cli")]
                 {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_gemini_cli_provider();
-                    p.validate_request(&request)?;
-                    p.stream(request).await
+                    BuiltProvider::GeminiCli(self.build_gemini_cli_provider())
                 }
                 #[cfg(not(feature = "gemini-cli"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("gemini-cli"))
+                    BuiltProvider::Disabled("gemini-cli")
                 }
             }
             Provider::Gemini => {
                 #[cfg(feature = "gemini")]
                 {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_gemini_provider();
-                    p.validate_request(&request)?;
-                    p.stream(request).await
+                    BuiltProvider::Gemini(self.build_gemini_provider())
                 }
                 #[cfg(not(feature = "gemini"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("gemini"))
+                    BuiltProvider::Disabled("gemini")
                 }
             }
             Provider::GeminiCodeAssist => {
                 #[cfg(feature = "gemini-code-assist")]
                 {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_gemini_code_assist_provider();
-                    p.validate_request(&request)?;
-                    p.stream(request).await
+                    BuiltProvider::GeminiCodeAssist(self.build_gemini_code_assist_provider())
                 }
                 #[cfg(not(feature = "gemini-code-assist"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("gemini-code-assist"))
+                    BuiltProvider::Disabled("gemini-code-assist")
                 }
             }
             Provider::OpenAiChatGpt => {
                 #[cfg(feature = "chatgpt-codex")]
                 {
-                    use crate::providers::ProviderImpl;
-                    let p = self.build_chatgpt_codex_provider();
-                    p.validate_request(&request)?;
-                    p.stream(request).await
+                    BuiltProvider::ChatGptCodex(self.build_chatgpt_codex_provider())
                 }
                 #[cfg(not(feature = "chatgpt-codex"))]
                 {
-                    let _ = request;
-                    Err(Self::feature_not_enabled("chatgpt-codex"))
+                    BuiltProvider::Disabled("chatgpt-codex")
                 }
             }
         }
-    }
-
-    #[cfg(any(
-        not(feature = "anthropic"),
-        not(feature = "openai"),
-        not(feature = "minimax"),
-        not(feature = "ollama"),
-        not(feature = "ollama_native"),
-        not(feature = "claude-code"),
-        not(feature = "codex-cli"),
-        not(feature = "gemini-cli"),
-        not(feature = "gemini"),
-        not(feature = "gemini-code-assist"),
-        not(feature = "chatgpt-codex"),
-    ))]
-    fn feature_not_enabled(provider: &str) -> MotosanError {
-        MotosanError::Config(format!("{provider} feature is not enabled"))
     }
 
     #[cfg(feature = "anthropic")]
@@ -581,6 +453,7 @@ impl Client {
             self.anthropic_base_url.clone(),
         )
         .with_retry_policy(self.retry_policy.clone())
+        .with_http_client(self.http.clone())
     }
 
     #[cfg(feature = "openai")]
@@ -596,7 +469,8 @@ impl Client {
         let mut provider = OpenAIProvider::new(self.api_key.clone(), self.model.clone())
             .with_auth_style(auth_style)
             .with_responses_fallback(self.openai_responses_fallback)
-            .with_retry_policy(self.retry_policy.clone());
+            .with_retry_policy(self.retry_policy.clone())
+            .with_http_client(self.http.clone());
 
         if let Some(ref url) = self.openai_chat_url {
             provider = provider.with_chat_url(url.clone());
@@ -628,6 +502,7 @@ impl Client {
         )
         .with_capabilities(ProviderCapabilities::text_only())
         .with_retry_policy(self.retry_policy.clone())
+        .with_http_client(self.http.clone())
     }
 
     #[cfg(feature = "ollama")]
@@ -650,6 +525,7 @@ impl Client {
             .with_chat_url(chat_url)
             .with_auth_style(OpenAIAuthStyle::Bearer)
             .with_retry_policy(self.retry_policy.clone())
+            .with_http_client(self.http.clone())
     }
 
     #[cfg(feature = "ollama")]
@@ -663,6 +539,7 @@ impl Client {
             .with_keep_alive(self.ollama_keep_alive.clone())
             .with_num_ctx(self.ollama_num_ctx)
             .with_retry_policy(self.retry_policy.clone())
+            .with_http_client(self.http.clone())
     }
 
     #[cfg(feature = "claude-code")]
@@ -691,6 +568,7 @@ impl Client {
             None,
         )
         .with_retry_policy(self.retry_policy.clone())
+        .with_http_client(self.http.clone())
     }
 
     #[cfg(feature = "gemini-code-assist")]
@@ -707,7 +585,8 @@ impl Client {
                 self.model.clone(),
                 None,
             )
-            .with_retry_policy(self.retry_policy.clone()),
+            .with_retry_policy(self.retry_policy.clone())
+            .with_http_client(self.http.clone()),
         }
     }
 
@@ -758,6 +637,7 @@ impl Client {
             None,
         )
         .with_retry_policy(self.retry_policy.clone())
+        .with_http_client(self.http.clone())
         .with_reasoning_effort(self.chatgpt_codex_reasoning_effort.clone())
     }
 }
@@ -1103,7 +983,30 @@ impl ClientBuilder {
             }
         }
 
-        Ok(Client {
+        #[cfg(any(
+            feature = "anthropic",
+            feature = "openai",
+            feature = "minimax",
+            feature = "ollama",
+            feature = "gemini",
+            feature = "gemini-code-assist",
+            feature = "chatgpt-codex",
+        ))]
+        let http = reqwest::Client::builder()
+            .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+            .build()
+            .map_err(|e| MotosanError::Config(format!("failed to build HTTP client: {e}")))?;
+
+        let retry_policy_override = self.retry_policy.clone();
+        let retry_policy = retry_policy_override.clone().unwrap_or_default();
+
+        #[cfg(feature = "gemini-code-assist")]
+        let gemini_code_assist = match (self.gemini_code_assist, retry_policy_override.as_ref()) {
+            (Some(provider), Some(policy)) => Some(provider.with_retry_policy(policy.clone())),
+            (provider, _) => provider,
+        };
+
+        let mut client = Client {
             provider,
             api_key,
             model: self.model,
@@ -1120,7 +1023,7 @@ impl ClientBuilder {
             ollama_think: self.ollama_think,
             ollama_keep_alive: self.ollama_keep_alive,
             ollama_num_ctx: self.ollama_num_ctx,
-            retry_policy: self.retry_policy.unwrap_or_default(),
+            retry_policy,
             stream_read_timeout: self.stream_read_timeout_secs.map(Duration::from_secs),
             #[cfg(feature = "claude-code")]
             claude_code: self.claude_code,
@@ -1129,7 +1032,7 @@ impl ClientBuilder {
             #[cfg(feature = "gemini-cli")]
             gemini_cli: self.gemini_cli,
             #[cfg(feature = "gemini-code-assist")]
-            gemini_code_assist: self.gemini_code_assist,
+            gemini_code_assist,
             #[cfg(feature = "gemini-code-assist")]
             gemini_code_assist_project_id: self.gemini_code_assist_project_id,
             #[cfg(feature = "chatgpt-codex")]
@@ -1140,7 +1043,21 @@ impl ClientBuilder {
             chatgpt_codex_model: self.chatgpt_codex_model,
             #[cfg(feature = "chatgpt-codex")]
             chatgpt_codex_reasoning_effort: self.chatgpt_codex_reasoning_effort,
-        })
+            built: BuiltProvider::Disabled("uninitialized"),
+            #[cfg(any(
+                feature = "anthropic",
+                feature = "openai",
+                feature = "minimax",
+                feature = "ollama",
+                feature = "gemini",
+                feature = "gemini-code-assist",
+                feature = "chatgpt-codex",
+            ))]
+            http,
+        };
+        let built = client.construct_built_provider();
+        client.built = built;
+        Ok(client)
     }
 }
 

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -39,6 +39,12 @@ pub enum MotosanError {
     Stream(String),
     #[error("stream read timeout: no data received within {0} seconds")]
     StreamReadTimeout(u64),
+    /// Upstream byte/event stream ended without the provider terminal event
+    /// (OpenAI-wire `[DONE]` or a `finish_reason` chunk — either suffices /
+    /// `message_stop` / `finishReason` / `response.completed` / `"done":true`).
+    /// Payload: `"<provider> ended without a terminal event"`.
+    #[error("incomplete stream: {0}")]
+    IncompleteStream(String),
     #[error("unsupported feature: {0}")]
     UnsupportedFeature(String),
 }
@@ -130,6 +136,10 @@ mod tests {
                 "stream read timeout: no data received within 5 seconds",
             ),
             (
+                MotosanError::IncompleteStream("openai ended without a terminal event".into()),
+                "incomplete stream: openai ended without a terminal event",
+            ),
+            (
                 MotosanError::UnsupportedFeature("u".into()),
                 "unsupported feature: u",
             ),
@@ -159,6 +169,7 @@ mod tests {
             MotosanError::Network("n".into()),
             MotosanError::Stream("s".into()),
             MotosanError::StreamReadTimeout(5),
+            MotosanError::IncompleteStream("i".into()),
             MotosanError::UnsupportedFeature("u".into()),
         ];
         for err in errors {

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -3,8 +3,8 @@ const DEFAULT_MAX_TOKENS: u32 = 8192;
 use crate::error::MotosanError;
 use crate::models::DEFAULT_ANTHROPIC_MODEL;
 use crate::providers::{
-    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
-    ChatResponseBuilder, ProviderImpl,
+    apply_total_timeout, extract_error_message, extract_request_id, map_http_error,
+    parse_retry_after, send_with_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -20,6 +20,7 @@ use reqwest::Client;
 use serde_json::{json, Value};
 use std::pin::Pin;
 use std::task::Poll;
+use std::time::Duration;
 use tokio_stream::StreamExt;
 
 #[derive(Debug, Clone)]
@@ -29,6 +30,7 @@ pub struct AnthropicProvider {
     model: String,
     base_url: String,
     retry_policy: RetryPolicy,
+    total_timeout: Option<Duration>,
     capabilities: ProviderCapabilities,
 }
 
@@ -44,12 +46,19 @@ impl AnthropicProvider {
             model: model.unwrap_or_else(|| DEFAULT_ANTHROPIC_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| "https://api.anthropic.com".to_string()),
             retry_policy: RetryPolicy::default(),
+            total_timeout: None,
             capabilities: ProviderCapabilities::full(),
         }
     }
 
     pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
         self.retry_policy = retry_policy;
+        self
+    }
+
+    /// Opt-in wall-clock budget per blocking `chat()` attempt.
+    pub fn with_total_timeout(mut self, total: Option<Duration>) -> Self {
+        self.total_timeout = total;
         self
     }
 
@@ -469,7 +478,9 @@ impl ProviderImpl for AnthropicProvider {
         // Redirect to stream path and collect the full response.
         if is_oauth {
             let stream = self.stream(req).await?;
-            let mut response = crate::stream::collect_stream(stream).await?;
+            let mut response =
+                crate::providers::collect_stream_with_total_timeout(stream, self.total_timeout)
+                    .await?;
             response.model = self.model.clone();
             return Ok(response);
         }
@@ -485,7 +496,7 @@ impl ProviderImpl for AnthropicProvider {
                 .header("anthropic-version", "2023-06-01")
                 .json(&body);
             let request = Self::apply_beta_header(request, has_mcp, is_oauth, adaptive_thinking);
-            self.apply_auth(request)
+            apply_total_timeout(self.apply_auth(request), self.total_timeout)
         })
         .await?;
 

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -22,6 +22,7 @@ use std::pin::Pin;
 use std::task::Poll;
 use tokio_stream::StreamExt;
 
+#[derive(Debug, Clone)]
 pub struct AnthropicProvider {
     http: Client,
     api_key: String,
@@ -49,6 +50,15 @@ impl AnthropicProvider {
 
     pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
         self.retry_policy = retry_policy;
+        self
+    }
+
+    /// Replace the internal `reqwest::Client` with a caller-supplied one.
+    /// `ClientBuilder::build()` uses this to hand every HTTP provider one
+    /// shared, connect-timeout-configured client so all providers share a
+    /// single connection pool instead of each constructing their own.
+    pub fn with_http_client(mut self, http: Client) -> Self {
+        self.http = http;
         self
     }
 

--- a/sdks/rust/src/providers/anthropic.rs
+++ b/sdks/rust/src/providers/anthropic.rs
@@ -20,6 +20,7 @@ use reqwest::Client;
 use serde_json::{json, Value};
 use std::pin::Pin;
 use std::task::Poll;
+use tokio_stream::StreamExt;
 
 pub struct AnthropicProvider {
     http: Client,
@@ -824,13 +825,17 @@ impl ProviderImpl for AnthropicProvider {
             ));
         }
 
-        let raw_stream = response.bytes_stream().eventsource();
+        let raw_stream = response
+            .bytes_stream()
+            .chain(tokio_stream::once(Ok("\n".into())))
+            .eventsource();
         let adapter = AnthropicStreamAdapter {
             inner: Box::pin(raw_stream),
             pending: std::collections::VecDeque::new(),
             current_tool_id: None,
             current_stop_reason: None,
             current_thinking_buf: None,
+            saw_terminal: false,
         };
 
         Ok(Box::pin(adapter))
@@ -866,6 +871,8 @@ struct AnthropicStreamAdapter {
     /// open this accumulator (we don't surface redacted content as
     /// thinking deltas).
     current_thinking_buf: Option<String>,
+    /// True once `message_stop` (or a terminal error) has been yielded.
+    saw_terminal: bool,
 }
 
 impl Stream for AnthropicStreamAdapter {
@@ -1085,6 +1092,7 @@ impl Stream for AnthropicStreamAdapter {
                             continue;
                         }
                         "message_stop" => {
+                            self.saw_terminal = true;
                             let done = match self.current_stop_reason.take() {
                                 Some(reason) => StreamEvent::done_with_stop_reason(reason),
                                 None => StreamEvent::done(),
@@ -1092,6 +1100,7 @@ impl Stream for AnthropicStreamAdapter {
                             return Poll::Ready(Some(Ok(done)));
                         }
                         "error" => {
+                            self.saw_terminal = true;
                             let err_type =
                                 payload["error"]["type"].as_str().unwrap_or("unknown_error");
                             let message = payload["error"]["message"]
@@ -1105,9 +1114,18 @@ impl Stream for AnthropicStreamAdapter {
                     }
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    self.saw_terminal = true;
                     return Poll::Ready(Some(Err(MotosanError::Stream(e.to_string()))));
                 }
-                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(None) => {
+                    if !self.saw_terminal {
+                        self.saw_terminal = true;
+                        return Poll::Ready(Some(Err(MotosanError::IncompleteStream(
+                            "anthropic ended without a terminal event".to_string(),
+                        ))));
+                    }
+                    return Poll::Ready(None);
+                }
                 Poll::Pending => return Poll::Pending,
             }
         }
@@ -1131,6 +1149,7 @@ mod tests {
             current_tool_id: None,
             current_stop_reason: None,
             current_thinking_buf: None,
+            saw_terminal: false,
         };
 
         let item = adapter.next().await.expect("one item");

--- a/sdks/rust/src/providers/chatgpt_codex.rs
+++ b/sdks/rust/src/providers/chatgpt_codex.rs
@@ -60,6 +60,15 @@ impl ChatGptCodexProvider {
         self
     }
 
+    /// Replace the internal `reqwest::Client` with a caller-supplied one.
+    /// `ClientBuilder::build()` uses this to hand every HTTP provider one
+    /// shared, connect-timeout-configured client so all providers share a
+    /// single connection pool instead of each constructing their own.
+    pub fn with_http_client(mut self, http: Client) -> Self {
+        self.http = http;
+        self
+    }
+
     /// Set the default reasoning effort (`low`/`medium`/`high`/…) used when a
     /// request omits `provider_options["reasoning_effort"]`. A per-request
     /// value always takes precedence. Pass `None` to leave the body's

--- a/sdks/rust/src/providers/chatgpt_codex.rs
+++ b/sdks/rust/src/providers/chatgpt_codex.rs
@@ -283,6 +283,7 @@ impl ProviderImpl for ChatGptCodexProvider {
             seen_tool_ids: HashSet::new(),
             saw_tool_call: false,
             error: None,
+            saw_terminal: false,
         };
         Ok(Box::pin(adapter))
     }
@@ -323,6 +324,7 @@ struct ChatGptCodexStreamAdapter {
     /// A fatal stream error to surface on the next `poll_next` (top-level
     /// `error` / `response.failed`).
     error: Option<String>,
+    saw_terminal: bool,
 }
 
 impl ChatGptCodexStreamAdapter {
@@ -473,6 +475,7 @@ impl ChatGptCodexStreamAdapter {
                 };
                 self.pending
                     .push_back(StreamEvent::done_with_stop_reason(stop_reason));
+                self.saw_terminal = true;
             }
 
             // Fatal stream errors -> surfaced as Err on the next poll.
@@ -514,6 +517,7 @@ impl Stream for ChatGptCodexStreamAdapter {
             return Poll::Ready(Some(Ok(ev)));
         }
         if let Some(msg) = self.error.take() {
+            self.saw_terminal = true;
             return Poll::Ready(Some(Err(MotosanError::Stream(msg))));
         }
 
@@ -534,14 +538,24 @@ impl Stream for ChatGptCodexStreamAdapter {
                         return Poll::Ready(Some(Ok(first)));
                     }
                     if let Some(msg) = self.error.take() {
+                        self.saw_terminal = true;
                         return Poll::Ready(Some(Err(MotosanError::Stream(msg))));
                     }
                     continue;
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    self.saw_terminal = true;
                     return Poll::Ready(Some(Err(MotosanError::Stream(e.to_string()))));
                 }
-                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(None) => {
+                    if !self.saw_terminal {
+                        self.saw_terminal = true;
+                        return Poll::Ready(Some(Err(MotosanError::IncompleteStream(
+                            "chatgpt-codex ended without a terminal event".to_string(),
+                        ))));
+                    }
+                    return Poll::Ready(None);
+                }
                 Poll::Pending => return Poll::Pending,
             }
         }
@@ -747,6 +761,7 @@ mod tests {
                 seen_tool_ids: HashSet::new(),
                 saw_tool_call: false,
                 error: None,
+                saw_terminal: false,
             }
         }
 
@@ -925,6 +940,7 @@ mod tests {
                 seen_tool_ids: HashSet::new(),
                 saw_tool_call: false,
                 error: None,
+                saw_terminal: false,
             };
 
             let item = adapter.next().await.expect("one item");

--- a/sdks/rust/src/providers/chatgpt_codex.rs
+++ b/sdks/rust/src/providers/chatgpt_codex.rs
@@ -4,7 +4,7 @@ use crate::providers::{
     ProviderImpl,
 };
 use crate::retry::RetryPolicy;
-use crate::stream::{collect_stream, BoxStream};
+use crate::stream::BoxStream;
 use crate::types::{
     ChatRequest, ChatResponse, ProviderCapabilities, Role, StopReason, StreamEvent, Usage,
 };
@@ -16,6 +16,7 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::pin::Pin;
 use std::task::Poll;
+use std::time::Duration;
 
 /// Default endpoint for the ChatGPT-backend Responses API.
 const CHATGPT_CODEX_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
@@ -30,6 +31,7 @@ pub struct ChatGptCodexProvider {
     model: String,
     base_url: String,
     retry_policy: RetryPolicy,
+    total_timeout: Option<Duration>,
     /// Default reasoning effort emitted as `reasoning.effort` when a request
     /// does not carry a per-request `provider_options["reasoning_effort"]`.
     /// `None` leaves the `reasoning` object off the body entirely. The string
@@ -51,12 +53,19 @@ impl ChatGptCodexProvider {
             model: model.into(),
             base_url: base_url.unwrap_or_else(|| CHATGPT_CODEX_URL.to_string()),
             retry_policy: RetryPolicy::default(),
+            total_timeout: None,
             reasoning_effort: None,
         }
     }
 
     pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
         self.retry_policy = policy;
+        self
+    }
+
+    /// Opt-in wall-clock budget per blocking `chat()` attempt.
+    pub fn with_total_timeout(mut self, total: Option<Duration>) -> Self {
+        self.total_timeout = total;
         self
     }
 
@@ -254,7 +263,8 @@ impl ProviderImpl for ChatGptCodexProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let model = req.model.clone().unwrap_or_else(|| self.model.clone());
         let stream = self.stream(req).await?;
-        let mut response = collect_stream(stream).await?;
+        let mut response =
+            crate::providers::collect_stream_with_total_timeout(stream, self.total_timeout).await?;
         if response.model.is_empty() {
             response.model = model;
         }

--- a/sdks/rust/src/providers/gemini.rs
+++ b/sdks/rust/src/providers/gemini.rs
@@ -3,8 +3,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::error::MotosanError;
 use crate::models::DEFAULT_GEMINI_MODEL;
 use crate::providers::{
-    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
-    ChatResponseBuilder, ProviderImpl,
+    apply_total_timeout, extract_error_message, extract_request_id, map_http_error,
+    parse_retry_after, send_with_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -20,6 +20,7 @@ use serde_json::{json, Value};
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::task::Poll;
+use std::time::Duration;
 
 const DEFAULT_MAX_TOKENS: u32 = 8192;
 const BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
@@ -38,6 +39,7 @@ pub struct GeminiProvider {
     model: String,
     base_url: String,
     retry_policy: RetryPolicy,
+    total_timeout: Option<Duration>,
 }
 
 impl GeminiProvider {
@@ -52,11 +54,18 @@ impl GeminiProvider {
             model: model.unwrap_or_else(|| DEFAULT_GEMINI_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| BASE_URL.to_string()),
             retry_policy: RetryPolicy::default(),
+            total_timeout: None,
         }
     }
 
     pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
         self.retry_policy = policy;
+        self
+    }
+
+    /// Opt-in wall-clock budget per blocking `chat()` attempt.
+    pub fn with_total_timeout(mut self, total: Option<Duration>) -> Self {
+        self.total_timeout = total;
         self
     }
 
@@ -331,12 +340,15 @@ impl ProviderImpl for GeminiProvider {
         let body = Self::build_request(&req);
 
         let response = send_with_retry(&self.retry_policy, || {
-            self.apply_auth(
-                self.http
-                    .post(&url)
-                    .header("content-type", "application/json"),
+            apply_total_timeout(
+                self.apply_auth(
+                    self.http
+                        .post(&url)
+                        .header("content-type", "application/json"),
+                )
+                .json(&body),
+                self.total_timeout,
             )
-            .json(&body)
         })
         .await?;
 

--- a/sdks/rust/src/providers/gemini.rs
+++ b/sdks/rust/src/providers/gemini.rs
@@ -379,6 +379,7 @@ impl ProviderImpl for GeminiProvider {
         let adapter = GeminiStreamAdapter {
             inner: Box::pin(sse),
             pending: VecDeque::new(),
+            saw_terminal: false,
         };
         Ok(Box::pin(adapter))
     }
@@ -396,6 +397,7 @@ struct GeminiStreamAdapter {
         >,
     >,
     pending: VecDeque<StreamEvent>,
+    saw_terminal: bool,
 }
 
 impl Stream for GeminiStreamAdapter {
@@ -479,6 +481,7 @@ impl Stream for GeminiStreamAdapter {
                     }
 
                     if let Some(reason) = finish_reason {
+                        self.saw_terminal = true;
                         let stop_reason = match reason {
                             "STOP" if has_tool_calls => StopReason::ToolUse,
                             "STOP" => StopReason::EndTurn,
@@ -496,9 +499,18 @@ impl Stream for GeminiStreamAdapter {
                     continue;
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    self.saw_terminal = true;
                     return Poll::Ready(Some(Err(MotosanError::Stream(e.to_string()))));
                 }
-                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(None) => {
+                    if !self.saw_terminal {
+                        self.saw_terminal = true;
+                        return Poll::Ready(Some(Err(MotosanError::IncompleteStream(
+                            "gemini ended without a terminal event".to_string(),
+                        ))));
+                    }
+                    return Poll::Ready(None);
+                }
                 Poll::Pending => return Poll::Pending,
             }
         }
@@ -541,6 +553,7 @@ mod tests {
         let mut adapter = GeminiStreamAdapter {
             inner: Box::pin(inner),
             pending: VecDeque::new(),
+            saw_terminal: false,
         };
 
         let item = adapter.next().await.expect("one item");

--- a/sdks/rust/src/providers/gemini.rs
+++ b/sdks/rust/src/providers/gemini.rs
@@ -60,6 +60,15 @@ impl GeminiProvider {
         self
     }
 
+    /// Replace the internal `reqwest::Client` with a caller-supplied one.
+    /// `ClientBuilder::build()` uses this to hand every HTTP provider one
+    /// shared, connect-timeout-configured client so all providers share a
+    /// single connection pool instead of each constructing their own.
+    pub fn with_http_client(mut self, http: Client) -> Self {
+        self.http = http;
+        self
+    }
+
     fn generate_url(&self, req: &ChatRequest) -> String {
         let model = req.model.as_deref().unwrap_or(&self.model);
         format!("{}/models/{}:generateContent", self.base_url, model)

--- a/sdks/rust/src/providers/gemini_code_assist.rs
+++ b/sdks/rust/src/providers/gemini_code_assist.rs
@@ -146,6 +146,7 @@ impl ProviderImpl for GeminiCodeAssistProvider {
             inner: Box::pin(sse),
             pending: VecDeque::new(),
             seen_tool_ids: std::collections::HashSet::new(),
+            saw_terminal: false,
         };
         Ok(Box::pin(adapter))
     }
@@ -165,6 +166,7 @@ struct CodeAssistStreamAdapter {
     pending: VecDeque<StreamEvent>,
     /// Track tool call IDs we've seen to detect duplicates (API may reuse IDs).
     seen_tool_ids: std::collections::HashSet<String>,
+    saw_terminal: bool,
 }
 
 impl Stream for CodeAssistStreamAdapter {
@@ -277,6 +279,7 @@ impl Stream for CodeAssistStreamAdapter {
 
                     // Terminal event
                     if let Some(reason) = finish_reason {
+                        self.saw_terminal = true;
                         let stop_reason = match reason {
                             "STOP" if has_tool_calls => StopReason::ToolUse,
                             "STOP" => StopReason::EndTurn,
@@ -294,9 +297,18 @@ impl Stream for CodeAssistStreamAdapter {
                     continue;
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    self.saw_terminal = true;
                     return Poll::Ready(Some(Err(MotosanError::Stream(e.to_string()))));
                 }
-                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(None) => {
+                    if !self.saw_terminal {
+                        self.saw_terminal = true;
+                        return Poll::Ready(Some(Err(MotosanError::IncompleteStream(
+                            "gemini-code-assist ended without a terminal event".to_string(),
+                        ))));
+                    }
+                    return Poll::Ready(None);
+                }
                 Poll::Pending => return Poll::Pending,
             }
         }
@@ -410,6 +422,7 @@ mod tests {
                 inner: Box::pin(inner),
                 pending: VecDeque::new(),
                 seen_tool_ids: std::collections::HashSet::new(),
+                saw_terminal: false,
             };
 
             let item = adapter.next().await.expect("one item");
@@ -423,6 +436,7 @@ mod tests {
                 inner: make_sse(json),
                 pending: VecDeque::new(),
                 seen_tool_ids: std::collections::HashSet::new(),
+                saw_terminal: false,
             };
             let events: Vec<_> = (&mut adapter).collect::<Result<Vec<_>, _>>().await.unwrap();
             let text: String = events
@@ -442,6 +456,7 @@ mod tests {
                 inner: make_sse(json),
                 pending: VecDeque::new(),
                 seen_tool_ids: std::collections::HashSet::new(),
+                saw_terminal: false,
             };
             let events: Vec<_> = (&mut adapter).collect::<Result<Vec<_>, _>>().await.unwrap();
             let start = events
@@ -458,6 +473,7 @@ mod tests {
                 inner: make_sse(json),
                 pending: VecDeque::new(),
                 seen_tool_ids: std::collections::HashSet::new(),
+                saw_terminal: false,
             };
             let events: Vec<_> = (&mut adapter).collect::<Result<Vec<_>, _>>().await.unwrap();
             let start = events

--- a/sdks/rust/src/providers/gemini_code_assist.rs
+++ b/sdks/rust/src/providers/gemini_code_assist.rs
@@ -8,7 +8,7 @@ use crate::providers::{
     ProviderImpl,
 };
 use crate::retry::RetryPolicy;
-use crate::stream::{collect_stream, BoxStream};
+use crate::stream::BoxStream;
 use crate::types::{ChatRequest, ChatResponse, StopReason, StreamEvent, Usage};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
@@ -18,7 +18,7 @@ use serde_json::{json, Value};
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::task::Poll;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 static TOOL_CALL_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -49,6 +49,7 @@ pub struct GeminiCodeAssistProvider {
     model: String,
     base_url: String,
     retry_policy: RetryPolicy,
+    total_timeout: Option<Duration>,
 }
 
 impl GeminiCodeAssistProvider {
@@ -65,11 +66,18 @@ impl GeminiCodeAssistProvider {
             model: model.unwrap_or_else(|| DEFAULT_GEMINI_CODE_ASSIST_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| GEMINI_CODE_ASSIST_BASE_URL.to_string()),
             retry_policy: RetryPolicy::default(),
+            total_timeout: None,
         }
     }
 
     pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
         self.retry_policy = policy;
+        self
+    }
+
+    /// Opt-in wall-clock budget per blocking `chat()` attempt.
+    pub fn with_total_timeout(mut self, total: Option<Duration>) -> Self {
+        self.total_timeout = total;
         self
     }
 
@@ -120,7 +128,8 @@ impl ProviderImpl for GeminiCodeAssistProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatResponse, MotosanError> {
         let model = req.model.clone().unwrap_or_else(|| self.model.clone());
         let stream = self.stream(req).await?;
-        let mut response = collect_stream(stream).await?;
+        let mut response =
+            crate::providers::collect_stream_with_total_timeout(stream, self.total_timeout).await?;
         if response.model.is_empty() {
             response.model = model;
         }

--- a/sdks/rust/src/providers/gemini_code_assist.rs
+++ b/sdks/rust/src/providers/gemini_code_assist.rs
@@ -73,6 +73,15 @@ impl GeminiCodeAssistProvider {
         self
     }
 
+    /// Replace the internal `reqwest::Client` with a caller-supplied one.
+    /// `ClientBuilder::build()` uses this to hand every HTTP provider one
+    /// shared, connect-timeout-configured client so all providers share a
+    /// single connection pool instead of each constructing their own.
+    pub fn with_http_client(mut self, http: Client) -> Self {
+        self.http = http;
+        self
+    }
+
     fn stream_url(&self) -> String {
         format!("{}/v1internal:streamGenerateContent?alt=sse", self.base_url)
     }

--- a/sdks/rust/src/providers/mod.rs
+++ b/sdks/rust/src/providers/mod.rs
@@ -75,6 +75,25 @@ pub enum Provider {
     OpenAiChatGpt,
 }
 
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+impl Provider {
+    /// True when the provider speaks HTTP through the shared reqwest client.
+    pub(crate) fn uses_http_transport(&self) -> bool {
+        !matches!(
+            self,
+            Provider::ClaudeCode | Provider::CodexCli | Provider::GeminiCli
+        )
+    }
+}
+
 #[async_trait]
 pub trait ProviderImpl: Send + Sync {
     fn capabilities(&self) -> ProviderCapabilities {
@@ -461,6 +480,50 @@ pub(crate) async fn send_with_retry(
         }
 
         return Ok(response);
+    }
+}
+
+/// Apply the opt-in total timeout to a blocking-chat request.
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "minimax",
+    feature = "ollama_native",
+    feature = "gemini",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+pub(crate) fn apply_total_timeout(
+    rb: reqwest::RequestBuilder,
+    total: Option<Duration>,
+) -> reqwest::RequestBuilder {
+    match total {
+        Some(timeout) => rb.timeout(timeout),
+        None => rb,
+    }
+}
+
+/// Total-timeout wrapper for providers whose `chat()` is stream+collect.
+#[cfg(any(
+    feature = "anthropic",
+    feature = "gemini-code-assist",
+    feature = "chatgpt-codex",
+))]
+pub(crate) async fn collect_stream_with_total_timeout(
+    stream: BoxStream,
+    total: Option<Duration>,
+) -> Result<ChatResponse, MotosanError> {
+    match total {
+        Some(timeout) => {
+            match tokio::time::timeout(timeout, crate::stream::collect_stream(stream)).await {
+                Ok(result) => result,
+                Err(_) => Err(MotosanError::Network(format!(
+                    "total timeout: chat did not complete within {}s",
+                    timeout.as_secs()
+                ))),
+            }
+        }
+        None => crate::stream::collect_stream(stream).await,
     }
 }
 

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -15,6 +15,7 @@ use serde_json::{json, Value};
 use std::pin::Pin;
 use std::task::Poll;
 
+#[derive(Debug, Clone)]
 pub struct OllamaProvider {
     http: Client,
     model: String,
@@ -55,6 +56,15 @@ impl OllamaProvider {
 
     pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
         self.retry_policy = retry_policy;
+        self
+    }
+
+    /// Replace the internal `reqwest::Client` with a caller-supplied one.
+    /// `ClientBuilder::build()` uses this to hand every HTTP provider one
+    /// shared, connect-timeout-configured client so all providers share a
+    /// single connection pool instead of each constructing their own.
+    pub fn with_http_client(mut self, http: Client) -> Self {
+        self.http = http;
         self
     }
 

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -1,8 +1,8 @@
 use crate::error::MotosanError;
 use crate::models::DEFAULT_OLLAMA_MODEL;
 use crate::providers::{
-    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
-    ChatResponseBuilder, ProviderImpl,
+    apply_total_timeout, extract_error_message, extract_request_id, map_http_error,
+    parse_retry_after, send_with_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -14,6 +14,7 @@ use reqwest::Client;
 use serde_json::{json, Value};
 use std::pin::Pin;
 use std::task::Poll;
+use std::time::Duration;
 
 #[derive(Debug, Clone)]
 pub struct OllamaProvider {
@@ -24,6 +25,7 @@ pub struct OllamaProvider {
     keep_alive: Option<String>,
     num_ctx: Option<u32>,
     retry_policy: RetryPolicy,
+    total_timeout: Option<Duration>,
 }
 
 impl OllamaProvider {
@@ -36,6 +38,7 @@ impl OllamaProvider {
             keep_alive: None,
             num_ctx: None,
             retry_policy: RetryPolicy::default(),
+            total_timeout: None,
         }
     }
 
@@ -56,6 +59,12 @@ impl OllamaProvider {
 
     pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
         self.retry_policy = retry_policy;
+        self
+    }
+
+    /// Opt-in wall-clock budget per blocking `chat()` attempt.
+    pub fn with_total_timeout(mut self, total: Option<Duration>) -> Self {
+        self.total_timeout = total;
         self
     }
 
@@ -258,7 +267,10 @@ impl ProviderImpl for OllamaProvider {
         let body = self.build_request_body(&req, false);
 
         let response = send_with_retry(&self.retry_policy, || {
-            self.http.post(self.endpoint()).json(&body)
+            apply_total_timeout(
+                self.http.post(self.endpoint()).json(&body),
+                self.total_timeout,
+            )
         })
         .await?;
 

--- a/sdks/rust/src/providers/ollama.rs
+++ b/sdks/rust/src/providers/ollama.rs
@@ -390,6 +390,7 @@ impl ProviderImpl for OllamaProvider {
         let adapter = OllamaStreamAdapter {
             inner: Box::pin(ndjson_stream),
             pending: std::collections::VecDeque::new(),
+            saw_terminal: false,
         };
 
         Ok(Box::pin(adapter))
@@ -401,6 +402,7 @@ impl ProviderImpl for OllamaProvider {
 struct OllamaStreamAdapter {
     inner: Pin<Box<dyn Stream<Item = Result<String, MotosanError>> + Send>>,
     pending: std::collections::VecDeque<StreamEvent>,
+    saw_terminal: bool,
 }
 
 impl Stream for OllamaStreamAdapter {
@@ -427,6 +429,7 @@ impl Stream for OllamaStreamAdapter {
                         .and_then(Value::as_bool)
                         .unwrap_or(false);
                     if done {
+                        self.saw_terminal = true;
                         return Poll::Ready(Some(Ok(StreamEvent::done())));
                     }
 
@@ -474,9 +477,18 @@ impl Stream for OllamaStreamAdapter {
                 Poll::Ready(Some(Err(e))) => {
                     // Inner NdjsonStream already yields a typed MotosanError; pass it
                     // through unchanged (re-wrapping would double the "stream error:" prefix).
+                    self.saw_terminal = true;
                     return Poll::Ready(Some(Err(e)));
                 }
-                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(None) => {
+                    if !self.saw_terminal {
+                        self.saw_terminal = true;
+                        return Poll::Ready(Some(Err(MotosanError::IncompleteStream(
+                            "ollama ended without a terminal event".to_string(),
+                        ))));
+                    }
+                    return Poll::Ready(None);
+                }
                 Poll::Pending => return Poll::Pending,
             }
         }
@@ -557,6 +569,7 @@ mod tests {
         let mut adapter = OllamaStreamAdapter {
             inner: Box::pin(inner),
             pending: std::collections::VecDeque::new(),
+            saw_terminal: false,
         };
 
         let item = adapter.next().await.expect("one item");

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -655,9 +655,11 @@ struct OpenAIStreamAdapter {
     /// terminal `done` event when the `[DONE]` sentinel arrives — this
     /// avoids emitting two `done` events per stream.
     pending_stop_reason: Option<StopReason>,
-    /// Whether we have already emitted a terminal `done` event. Prevents
-    /// the EOF fallback from emitting a second one when the upstream
-    /// stream closes cleanly after the `[DONE]` sentinel.
+    /// Whether a terminal outcome was already yielded ([DONE] parsed, an
+    /// error surfaced, or the EOF arm resolved). The EOF arm combines this
+    /// with `pending_stop_reason` to decide done(stash) — finish_reason is
+    /// the semantic terminal — vs IncompleteStream when NEITHER signal
+    /// arrived.
     done_emitted: bool,
 }
 
@@ -844,18 +846,23 @@ impl Stream for OpenAIStreamAdapter {
                     return Poll::Ready(Some(Err(MotosanError::Stream(e.to_string()))));
                 }
                 Poll::Ready(None) => {
-                    // End of upstream stream. Guarantee the consumer always
-                    // sees exactly one terminal `done` event, even when the
-                    // provider closes the connection without sending
-                    // `[DONE]` and without any `finish_reason` chunk (some
-                    // non-conformant proxies do this).
+                    // M3 (amended 2026-07-17): upstream closed without the
+                    // `[DONE]` transport epilogue. A stashed finish_reason
+                    // is the SEMANTIC terminal — the stream is complete, so
+                    // emit the terminal done carrying it (narrow survival
+                    // of the pre-0.24 EOF flush, ONLY when finish_reason
+                    // was seen). EOF with NEITHER signal is truncation: a
+                    // typed error, never a fabricated done.
                     if !self.done_emitted {
                         self.done_emitted = true;
-                        let done = match self.pending_stop_reason.take() {
-                            Some(reason) => StreamEvent::done_with_stop_reason(reason),
-                            None => StreamEvent::done(),
-                        };
-                        return Poll::Ready(Some(Ok(done)));
+                        if let Some(reason) = self.pending_stop_reason.take() {
+                            return Poll::Ready(Some(Ok(StreamEvent::done_with_stop_reason(
+                                reason,
+                            ))));
+                        }
+                        return Poll::Ready(Some(Err(MotosanError::IncompleteStream(
+                            "openai ended without a terminal event".to_string(),
+                        ))));
                     }
                     return Poll::Ready(None);
                 }

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -33,6 +33,7 @@ pub const DEFAULT_OPENAI_CHAT_URL: &str = "https://api.openai.com/v1/chat/comple
 /// Default Responses API endpoint for OpenAI.
 pub const DEFAULT_OPENAI_RESPONSES_URL: &str = "https://api.openai.com/v1/responses";
 
+#[derive(Debug, Clone)]
 pub struct OpenAIProvider {
     http: Client,
     api_key: String,
@@ -80,6 +81,15 @@ impl OpenAIProvider {
 
     pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
         self.retry_policy = retry_policy;
+        self
+    }
+
+    /// Replace the internal `reqwest::Client` with a caller-supplied one.
+    /// `ClientBuilder::build()` uses this to hand every HTTP provider one
+    /// shared, connect-timeout-configured client so all providers share a
+    /// single connection pool instead of each constructing their own.
+    pub fn with_http_client(mut self, http: Client) -> Self {
+        self.http = http;
         self
     }
 

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -1,8 +1,8 @@
 use crate::error::MotosanError;
 use crate::models::DEFAULT_OPENAI_MODEL;
 use crate::providers::{
-    extract_error_message, extract_request_id, map_http_error, parse_retry_after, send_with_retry,
-    ChatResponseBuilder, ProviderImpl,
+    apply_total_timeout, extract_error_message, extract_request_id, map_http_error,
+    parse_retry_after, send_with_retry, ChatResponseBuilder, ProviderImpl,
 };
 use crate::retry::RetryPolicy;
 use crate::stream::BoxStream;
@@ -19,6 +19,7 @@ use serde_json::{json, Value};
 use std::collections::{BTreeMap, VecDeque};
 use std::pin::Pin;
 use std::task::Poll;
+use std::time::Duration;
 
 #[derive(Debug, Clone)]
 pub enum OpenAIAuthStyle {
@@ -47,6 +48,7 @@ pub struct OpenAIProvider {
     auth_style: OpenAIAuthStyle,
     responses_fallback: bool,
     retry_policy: RetryPolicy,
+    total_timeout: Option<Duration>,
 }
 
 impl OpenAIProvider {
@@ -66,6 +68,7 @@ impl OpenAIProvider {
             auth_style: OpenAIAuthStyle::Bearer,
             responses_fallback: false,
             retry_policy: RetryPolicy::default(),
+            total_timeout: None,
         }
     }
 
@@ -81,6 +84,12 @@ impl OpenAIProvider {
 
     pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
         self.retry_policy = retry_policy;
+        self
+    }
+
+    /// Opt-in wall-clock budget per blocking `chat()` attempt.
+    pub fn with_total_timeout(mut self, total: Option<Duration>) -> Self {
+        self.total_timeout = total;
         self
     }
 
@@ -255,7 +264,10 @@ impl OpenAIProvider {
         }
 
         let response = send_with_retry(&self.retry_policy, || {
-            self.apply_auth(self.http.post(&self.responses_url).json(&body))
+            apply_total_timeout(
+                self.apply_auth(self.http.post(&self.responses_url).json(&body)),
+                self.total_timeout,
+            )
         })
         .await?;
 
@@ -504,7 +516,10 @@ impl ProviderImpl for OpenAIProvider {
         let body = OpenAIRequestBuilder::new(req, self.model.clone()).build();
 
         let response = send_with_retry(&self.retry_policy, || {
-            self.apply_auth(self.http.post(&self.chat_url).json(&body))
+            apply_total_timeout(
+                self.apply_auth(self.http.post(&self.chat_url).json(&body)),
+                self.total_timeout,
+            )
         })
         .await?;
 

--- a/sdks/rust/tests/anthropic_stream.rs
+++ b/sdks/rust/tests/anthropic_stream.rs
@@ -52,6 +52,43 @@ async fn anthropic_stream_emits_content_and_done_event() {
 }
 
 #[tokio::test]
+async fn anthropic_stream_eof_without_message_stop_yields_incomplete_stream() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"par\"}}\n\n",
+    );
+    server
+        .mock("POST", "/v1/messages")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+    let mut stream = provider.stream(request).await.expect("stream");
+    let mut saw_done = false;
+    let mut last_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(ev) => saw_done |= ev.done,
+            Err(e) => {
+                last_err = Some(e);
+                break;
+            }
+        }
+    }
+    assert!(!saw_done, "must not fabricate a done event on truncation");
+    match last_err.expect("EOF without message_stop must yield an error") {
+        motosan_ai::MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "anthropic ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn anthropic_stream_ignores_unknown_and_malformed_events() {
     let mut server = mockito::Server::new_async().await;
     let sse_body = concat!(

--- a/sdks/rust/tests/chatgpt_codex.rs
+++ b/sdks/rust/tests/chatgpt_codex.rs
@@ -31,6 +31,54 @@ fn no_retry() -> RetryPolicy {
         .max_delay_ms(0)
 }
 
+#[tokio::test]
+async fn codex_stream_eof_without_response_completed_yields_incomplete_stream() {
+    let mut server = mockito::Server::new_async().await;
+    // Truncated: response.created + one text delta, but the terminal
+    // `response.completed` frame never arrives.
+    let truncated = concat!(
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\"}}\n\n",
+        "data: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Hi\",\"item_id\":\"msg_1\",\"output_index\":1}\n\n"
+    );
+    server
+        .mock("POST", Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(truncated)
+        .create_async()
+        .await;
+
+    let provider =
+        ChatGptCodexProvider::new("oauth-token", "acct-123", "gpt-5.5", Some(server.url()));
+    let mut stream = provider
+        .stream(
+            ChatRequest::builder()
+                .messages(vec![Message::user("hi")])
+                .build(),
+        )
+        .await
+        .unwrap();
+
+    let mut saw_done = false;
+    let mut last_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(ev) => saw_done |= ev.done,
+            Err(e) => {
+                last_err = Some(e);
+                break;
+            }
+        }
+    }
+    assert!(!saw_done, "must not fabricate a done event on truncation");
+    match last_err.expect("EOF without response.completed must yield an error") {
+        MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "chatgpt-codex ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // stream() e2e
 // ---------------------------------------------------------------------------

--- a/sdks/rust/tests/client_builder.rs
+++ b/sdks/rust/tests/client_builder.rs
@@ -115,6 +115,116 @@ async fn builder_anthropic_base_url_is_forwarded_to_http_request() {
     mock.assert_async().await;
 }
 
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn built_client_serves_sequential_requests_from_one_provider() {
+    // 0.24.0 build-once smoke: ClientBuilder::build() constructs the provider a
+    // single time and dispatch borrows it. Two sequential chat() calls against
+    // one mockito server prove the pre-built provider serves repeated requests.
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_body(
+            serde_json::json!({
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": [{"type": "text", "text": "ok"}]
+            })
+            .to_string(),
+        )
+        .expect(2)
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .provider(Provider::Anthropic)
+        .api_key("test-key")
+        .anthropic_base_url(server.url())
+        .build()
+        .expect("build client");
+
+    let first = client
+        .chat(vec![Message::user("one")])
+        .await
+        .expect("first chat");
+    let second = client
+        .chat(vec![Message::user("two")])
+        .await
+        .expect("second chat");
+    assert_eq!(first.content, "ok");
+    assert_eq!(second.content, "ok");
+    mock.assert_async().await;
+}
+
+#[cfg(feature = "gemini-code-assist")]
+#[tokio::test]
+async fn prebuilt_gemini_code_assist_applies_client_builder_retry_policy() {
+    // Regression guard (0.24.0): ClientBuilder::retry_policy was silently
+    // discarded when a pre-built GeminiCodeAssistProvider was attached. The
+    // pre-built provider carries a zero-retry policy; the builder sets one
+    // fast retry. Fixed: builder policy wins -> the 503 is retried and chat
+    // succeeds. Old behavior: zero-retry wins -> chat() errors on the 503.
+    use motosan_ai::providers::gemini_code_assist::GeminiCodeAssistProvider;
+
+    let mut server = mockito::Server::new_async().await;
+    let failed = server
+        .mock(
+            "POST",
+            mockito::Matcher::Regex("streamGenerateContent".into()),
+        )
+        .with_status(503)
+        .with_body(r#"{"error":{"message":"overloaded"}}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let sse = serde_json::json!({"response": {"candidates": [{"content": {"parts":
+        [{"text": "recovered"}], "role": "model"}, "finishReason": "STOP"}],
+        "usageMetadata": {"promptTokenCount": 5, "candidatesTokenCount": 3}}});
+    let recovered = server
+        .mock(
+            "POST",
+            mockito::Matcher::Regex("streamGenerateContent".into()),
+        )
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(format!("data: {sse}\n\n"))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .provider(Provider::GeminiCodeAssist)
+        .gemini_code_assist(
+            GeminiCodeAssistProvider::new("ya29.fake", "my-project", None, Some(server.url()))
+                .with_retry_policy(
+                    RetryPolicy::new()
+                        .max_retries(0)
+                        .base_delay_ms(0)
+                        .max_delay_ms(0),
+                ),
+        )
+        .retry_policy(
+            RetryPolicy::new()
+                .max_retries(1)
+                .base_delay_ms(1)
+                .max_delay_ms(5)
+                .jitter(false),
+        )
+        .build()
+        .expect("build client");
+
+    let response = client
+        .chat(vec![Message::user("hi")])
+        .await
+        .expect("builder retry_policy must be applied to the pre-built provider");
+    assert_eq!(response.content, "recovered");
+    failed.assert_async().await;
+    recovered.assert_async().await;
+}
+
 #[cfg(feature = "minimax")]
 #[tokio::test]
 async fn builder_accepts_minimax_base_url_override() {

--- a/sdks/rust/tests/client_timeouts.rs
+++ b/sdks/rust/tests/client_timeouts.rs
@@ -1,0 +1,192 @@
+#![cfg(feature = "openai")]
+
+use motosan_ai::{Client, Message, MotosanError, Provider, RetryCause, RetryPolicy};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio_stream::StreamExt;
+
+#[test]
+fn builder_timeout_defaults_are_10s_120s_none() {
+    let client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .build()
+        .expect("build client");
+    assert_eq!(client.connect_timeout(), Duration::from_secs(10));
+    assert_eq!(client.read_idle_timeout(), Duration::from_secs(120));
+    assert_eq!(client.total_timeout(), None);
+}
+
+#[test]
+fn builder_timeout_setters_override_defaults() {
+    let client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .connect_timeout(Duration::from_secs(3))
+        .read_idle_timeout(Duration::from_secs(30))
+        .total_timeout(Duration::from_secs(90))
+        .build()
+        .expect("build client");
+    assert_eq!(client.connect_timeout(), Duration::from_secs(3));
+    assert_eq!(client.read_idle_timeout(), Duration::from_secs(30));
+    assert_eq!(client.total_timeout(), Some(Duration::from_secs(90)));
+}
+
+#[test]
+fn stream_read_timeout_secs_is_an_alias_for_read_idle() {
+    #[allow(deprecated)]
+    let client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .stream_read_timeout_secs(30)
+        .build()
+        .expect("build client");
+    assert_eq!(client.read_idle_timeout(), Duration::from_secs(30));
+}
+
+#[tokio::test]
+async fn hung_stream_yields_stream_read_timeout() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_chunked_body(|w| {
+            w.write_all(b"data: {\"choices\":[{\"delta\":{\"content\":\"hello world\"}}]}\n\n")?;
+            w.flush()?;
+            std::thread::sleep(std::time::Duration::from_millis(1500));
+            Ok(())
+        })
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .openai_chat_url(format!("{}/v1/chat/completions", server.url()))
+        .read_idle_timeout(Duration::from_millis(200))
+        .build()
+        .expect("build client");
+
+    let mut stream = client
+        .stream(vec![Message::user("hi")])
+        .await
+        .expect("stream opens");
+    let mut text = String::new();
+    let mut saw_timeout = false;
+    let mut saw_done = false;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(ev) => {
+                saw_done |= ev.done;
+                text.push_str(&ev.content);
+            }
+            Err(MotosanError::StreamReadTimeout(_)) => saw_timeout = true,
+            Err(other) => panic!("expected StreamReadTimeout, got {other:?}"),
+        }
+    }
+    assert!(
+        saw_timeout,
+        "idle stall must yield MotosanError::StreamReadTimeout"
+    );
+    assert!(
+        !saw_done,
+        "no fabricated terminal done after an idle timeout"
+    );
+    assert!(
+        text.starts_with("hello"),
+        "pre-stall content must be delivered, got {text:?}"
+    );
+}
+
+#[tokio::test]
+async fn total_timeout_does_not_apply_to_streams() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_chunked_body(|w| {
+            w.write_all(b"data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n")?;
+            w.flush()?;
+            std::thread::sleep(std::time::Duration::from_millis(400));
+            w.write_all(b"data: [DONE]\n\n")?;
+            w.flush()
+        })
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .openai_chat_url(format!("{}/v1/chat/completions", server.url()))
+        .total_timeout(Duration::from_millis(100))
+        .build()
+        .expect("build client");
+
+    let mut stream = client
+        .stream(vec![Message::user("hi")])
+        .await
+        .expect("stream opens");
+    let mut events = Vec::new();
+    while let Some(item) = stream.next().await {
+        events.push(item.expect("stream must outlive total_timeout"));
+    }
+    assert_eq!(events.first().map(|e| e.content.as_str()), Some("hello"));
+    assert!(
+        events.last().is_some_and(|e| e.done),
+        "terminal done must arrive"
+    );
+}
+
+#[tokio::test]
+async fn chat_total_timeout_maps_to_network_and_is_retried() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_srv = Arc::clone(&hits);
+    std::thread::spawn(move || {
+        let mut held = Vec::new();
+        for conn in listener.incoming() {
+            let Ok(socket) = conn else { break };
+            hits_srv.fetch_add(1, Ordering::SeqCst);
+            held.push(socket);
+        }
+    });
+
+    let events: Arc<Mutex<Vec<motosan_ai::RetryEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&events);
+    let mut policy = RetryPolicy::new()
+        .max_retries(1)
+        .base_delay_ms(0)
+        .max_delay_ms(0)
+        .jitter(false);
+    policy.on_retry = Some(Arc::new(move |event| sink.lock().unwrap().push(event)));
+
+    let client = Client::builder()
+        .provider(Provider::OpenAI)
+        .api_key("k")
+        .openai_chat_url(format!("http://{addr}/v1/chat/completions"))
+        .total_timeout(Duration::from_millis(200))
+        .retry_policy(policy)
+        .build()
+        .expect("build client");
+
+    let result = client.chat(vec![Message::user("hi")]).await;
+    assert!(
+        matches!(result, Err(MotosanError::Network(_))),
+        "total-timeout expiry maps to Network, got {result:?}"
+    );
+    let recorded = std::mem::take(&mut *events.lock().unwrap());
+    assert_eq!(
+        recorded.len(),
+        1,
+        "is_timeout() is retryable -> exactly one retry"
+    );
+    assert!(matches!(recorded[0].cause, RetryCause::Network(_)));
+    assert!(
+        hits.load(Ordering::SeqCst) >= 2,
+        "each attempt opens a fresh connection"
+    );
+}

--- a/sdks/rust/tests/collect_stream.rs
+++ b/sdks/rust/tests/collect_stream.rs
@@ -15,6 +15,24 @@ fn boxed_stream(events: Vec<StreamEvent>) -> motosan_ai::BoxStream {
 }
 
 #[tokio::test]
+async fn collect_stream_propagates_incomplete_stream_error() {
+    let stream: motosan_ai::BoxStream = Box::pin(tokio_stream::iter(vec![
+        Ok(StreamEvent::text("par")),
+        Err(motosan_ai::MotosanError::IncompleteStream(
+            "openai ended without a terminal event".to_string(),
+        )),
+    ]));
+    let err = collect_stream(stream)
+        .await
+        .expect_err("truncation must not collect into a ChatResponse");
+    assert!(matches!(
+        err,
+        motosan_ai::MotosanError::IncompleteStream(msg)
+            if msg == "openai ended without a terminal event"
+    ));
+}
+
+#[tokio::test]
 async fn collect_stream_returns_err_on_failing_stream() {
     let stream: motosan_ai::BoxStream = Box::pin(tokio_stream::iter(vec![Err(
         motosan_ai::MotosanError::Stream("boom".to_string()),

--- a/sdks/rust/tests/gemini_code_assist.rs
+++ b/sdks/rust/tests/gemini_code_assist.rs
@@ -22,6 +22,50 @@ fn no_retry() -> RetryPolicy {
         .max_delay_ms(0)
 }
 
+#[tokio::test]
+async fn code_assist_stream_eof_without_finish_reason_yields_incomplete_stream() {
+    let mut server = mockito::Server::new_async().await;
+    // Truncated: one text chunk, no finishReason frame ever arrives.
+    let body = sse_text("Hello", None);
+    server
+        .mock("POST", Matcher::Regex("streamGenerateContent".into()))
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(body)
+        .create_async()
+        .await;
+
+    let provider =
+        GeminiCodeAssistProvider::new("ya29.fake", "my-project", None, Some(server.url()));
+    let mut stream = provider
+        .stream(
+            ChatRequest::builder()
+                .messages(vec![Message::user("hi")])
+                .build(),
+        )
+        .await
+        .unwrap();
+
+    let mut saw_done = false;
+    let mut last_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(ev) => saw_done |= ev.done,
+            Err(e) => {
+                last_err = Some(e);
+                break;
+            }
+        }
+    }
+    assert!(!saw_done, "must not fabricate a done event on truncation");
+    match last_err.expect("EOF without finishReason must yield an error") {
+        MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "gemini-code-assist ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
+}
+
 fn fast_retry() -> RetryPolicy {
     RetryPolicy::new()
         .max_retries(1)

--- a/sdks/rust/tests/gemini_provider.rs
+++ b/sdks/rust/tests/gemini_provider.rs
@@ -27,6 +27,49 @@ fn fast_retry() -> RetryPolicy {
         .respect_retry_after(false)
 }
 
+#[tokio::test]
+async fn gemini_stream_eof_without_finish_reason_yields_incomplete_stream() {
+    let mut server = mockito::Server::new_async().await;
+    // Truncated: one text chunk, no finishReason frame ever arrives.
+    let body = sse_text("Hello", None);
+    server
+        .mock("POST", Matcher::Regex("streamGenerateContent".into()))
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(body)
+        .create_async()
+        .await;
+
+    let provider = GeminiProvider::new("key", None, Some(server.url()));
+    let mut stream = provider
+        .stream(
+            ChatRequest::builder()
+                .messages(vec![Message::user("hi")])
+                .build(),
+        )
+        .await
+        .unwrap();
+
+    let mut saw_done = false;
+    let mut last_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(ev) => saw_done |= ev.done,
+            Err(e) => {
+                last_err = Some(e);
+                break;
+            }
+        }
+    }
+    assert!(!saw_done, "must not fabricate a done event on truncation");
+    match last_err.expect("EOF without finishReason must yield an error") {
+        MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "gemini ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
+}
+
 fn no_retry() -> RetryPolicy {
     RetryPolicy::new()
         .max_retries(0)

--- a/sdks/rust/tests/ollama_native_provider.rs
+++ b/sdks/rust/tests/ollama_native_provider.rs
@@ -13,6 +13,45 @@ fn build_provider(base_url: String) -> OllamaProvider {
     OllamaProvider::new(DEFAULT_OLLAMA_MODEL.to_string(), base_url)
 }
 
+#[tokio::test]
+async fn ollama_stream_eof_without_done_frame_yields_incomplete_stream() {
+    let mut server = mockito::Server::new_async().await;
+    // NDJSON truncated mid-stream: no `"done":true` terminal object.
+    let ndjson_body = "{\"message\":{\"role\":\"assistant\",\"content\":\"The\"},\"done\":false}\n";
+    server
+        .mock("POST", "/api/chat")
+        .with_status(200)
+        .with_header("content-type", "application/x-ndjson")
+        .with_body(ndjson_body)
+        .create_async()
+        .await;
+
+    let provider = build_provider(server.url());
+    let request = ChatRequest::builder()
+        .message(Message::user("hello"))
+        .build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut saw_done = false;
+    let mut last_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(ev) => saw_done |= ev.done,
+            Err(e) => {
+                last_err = Some(e);
+                break;
+            }
+        }
+    }
+    assert!(!saw_done, "must not fabricate a done event on truncation");
+    match last_err.expect("EOF without a done:true frame must yield an error") {
+        motosan_ai::MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "ollama ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
+}
+
 fn build_provider_with_think(base_url: String) -> OllamaProvider {
     OllamaProvider::new(DEFAULT_OLLAMA_MODEL.to_string(), base_url).with_think(Some("on".into()))
 }

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -749,19 +749,21 @@ async fn openai_stream_propagates_finish_reason_stop() {
 }
 
 #[tokio::test]
-async fn openai_stream_eof_flush_when_done_sentinel_missing() {
-    // Some non-conformant OpenAI-compatible proxies skip the `[DONE]` line.
-    // Adapter must still emit a terminal done event with stop_reason from
-    // the upstream end-of-stream fallback.
+async fn openai_stream_finish_reason_then_eof_completes_with_stop_reason() {
+    // Amended M3 rule (2026-07-17): `finish_reason` is the SEMANTIC
+    // terminal event; `[DONE]` is only the transport epilogue. EOF after a
+    // finish_reason chunk is a COMPLETE stream — the adapter emits done
+    // carrying the stashed stop_reason, NOT Err(IncompleteStream).
+    // (Adjusted survival of the pre-0.24
+    // `openai_stream_eof_flush_when_done_sentinel_missing` pin.)
     let mut server = mockito::Server::new_async().await;
     let sse_body = concat!(
         "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n",
-        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n" // NOTE: no [DONE] sentinel
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n" // no [DONE]
     );
 
-    let mock = server
+    server
         .mock("POST", "/v1/chat/completions")
-        .match_header("authorization", "Bearer test-key")
         .with_status(200)
         .with_header("content-type", "text/event-stream")
         .with_body(sse_body)
@@ -776,33 +778,27 @@ async fn openai_stream_eof_flush_when_done_sentinel_missing() {
 
     let mut stream = provider.stream(request).await.expect("stream response");
     let mut events = Vec::new();
-    while let Some(event_item) = stream.next().await {
-        let event = event_item.expect("stream item should not fail");
-        events.push(event);
+    while let Some(item) = stream.next().await {
+        events.push(item.expect("finish_reason-terminated stream must not error"));
     }
 
     let done = events
         .iter()
         .find(|e| e.done)
-        .expect("EOF flush should still emit a done event when [DONE] sentinel is missing");
+        .expect("EOF after finish_reason emits the terminal done");
     assert_eq!(done.stop_reason, Some(StopReason::MaxTokens));
     assert_eq!(events.iter().filter(|e| e.done).count(), 1);
-
-    mock.assert_async().await;
+    assert_eq!(events[0].content, "hello");
 }
 
 #[tokio::test]
-async fn openai_stream_emits_done_on_eof_without_finish_reason_or_done_sentinel() {
-    // Worst-case non-conformant proxy: stream closes after a text chunk
-    // with no `finish_reason` and no `[DONE]`. Adapter must still emit
-    // exactly one terminal `done` event so callers don't hang.
+async fn openai_stream_eof_without_terminal_yields_incomplete_stream() {
+    // Flip of pre-0.24 `openai_stream_emits_done_on_eof_without_finish_reason_or_done_sentinel`.
     let mut server = mockito::Server::new_async().await;
-    // no finish_reason, no [DONE] — exercises the EOF-flush invariant.
     let sse_body = "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n";
 
-    let mock = server
+    server
         .mock("POST", "/v1/chat/completions")
-        .match_header("authorization", "Bearer test-key")
         .with_status(200)
         .with_header("content-type", "text/event-stream")
         .with_body(sse_body)
@@ -816,22 +812,24 @@ async fn openai_stream_emits_done_on_eof_without_finish_reason_or_done_sentinel(
         .build();
 
     let mut stream = provider.stream(request).await.expect("stream response");
-    let mut events = Vec::new();
-    while let Some(event_item) = stream.next().await {
-        let event = event_item.expect("stream item should not fail");
-        events.push(event);
+    let mut text = String::new();
+    let mut last_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(ev) => text.push_str(&ev.content),
+            Err(e) => {
+                last_err = Some(e);
+                break;
+            }
+        }
     }
-
-    let done_count = events.iter().filter(|e| e.done).count();
-    assert_eq!(
-        done_count, 1,
-        "expected exactly one terminal done event, got {done_count}"
-    );
-    let done = events.iter().find(|e| e.done).unwrap();
-    assert_eq!(done.stop_reason, None, "no stop_reason was reported");
-    assert_eq!(events[0].content, "hello");
-
-    mock.assert_async().await;
+    assert_eq!(text, "hello", "deltas before truncation still arrive");
+    match last_err.expect("EOF without terminal must yield an error") {
+        MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "openai ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Add Rust `MotosanError::IncompleteStream` and make HTTP stream adapters error on EOF without a provider terminal event.
- Preserve amended OpenAI-wire semantics: `[DONE]` or `finish_reason` is terminal; EOF after a stashed finish_reason completes with `done(stop_reason)`.
- Build the selected Rust provider once in `ClientBuilder::build()` with shared reqwest transport.
- Add unified Rust timeout model: connect/read-idle/total, with read-idle guarding HTTP streams and total applying only to blocking chat attempts.

## Verification
- `cargo fmt && cargo clippy --all-features --all-targets -- -D warnings && cargo test --all-features && cargo check --no-default-features`
- Pre-push gate: Python unit tests, Rust unit tests, Python live Anthropic tests, Rust live Anthropic tests

## Coordination
- Pair with PR #227; merge order: #227 first, then this PR.