### PR TITLE
feat(ts): IncompleteStreamError, timeouts, AbortSignal cancellation (M3)

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -14,7 +14,7 @@
         "vitest": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -13,7 +13,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=18"
+    "node": ">=20.3"
   },
   "files": [
     "dist",

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1,4 +1,4 @@
-import { ConfigError } from './error.js'
+import { CancelledError, ConfigError } from './error.js'
 import {
   dispatchChat,
   dispatchStream,
@@ -6,6 +6,8 @@ import {
   textOnly,
   type Provider,
   type ProviderImpl as DispatchProvider,
+  type ProviderRequestOptions,
+  type RequestOptions,
 } from './provider.js'
 import { RetryPolicy } from './retry.js'
 import { collectStream, type BoxStream } from './stream.js'
@@ -21,10 +23,23 @@ import type { ChatRequest, ChatResponse, StreamEvent } from './types.js'
 
 export type ProviderName = Provider
 
+/** E4 one-timeout-model settings (milliseconds). */
+export interface TimeoutSettings {
+  /** Connect budget; fused with readIdleMs into http/fetch.ts's disarm-at-headers deadline. Default 10_000. */
+  connectMs?: number
+  /** Max gap between stream events (readTimeoutStream). Default 120_000. */
+  readIdleMs?: number
+  /** Whole-call budget, chat() only — NEVER applied to stream body consumption. Default undefined (off). */
+  totalMs?: number
+}
+
+const DEFAULT_CONNECT_MS = 10_000
+const DEFAULT_READ_IDLE_MS = 120_000
+
 export interface ProviderLike {
   capabilities?(): ReturnType<DispatchProvider['capabilities']>
-  chat(request: ChatRequest): Promise<ChatResponse>
-  stream(request: ChatRequest): AsyncIterable<StreamEvent>
+  chat(request: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse>
+  stream(request: ChatRequest, opts?: ProviderRequestOptions): AsyncIterable<StreamEvent>
 }
 
 /**
@@ -59,8 +74,8 @@ function asDispatchProvider(provider: ProviderLike): DispatchProvider {
 
   return {
     capabilities: textOnly,
-    chat: (request: ChatRequest) => provider.chat(request),
-    stream: (request: ChatRequest) => provider.stream(request),
+    chat: (request: ChatRequest, opts?: ProviderRequestOptions) => provider.chat(request, opts),
+    stream: (request: ChatRequest, opts?: ProviderRequestOptions) => provider.stream(request, opts),
   }
 }
 
@@ -73,7 +88,7 @@ export class ClientBuilder {
   protected _apiKey?: string
   protected _model?: string
   protected _retryPolicy: RetryPolicy = RetryPolicy.default()
-  protected _streamReadTimeoutSecs?: number
+  protected _timeouts: TimeoutSettings = {}
   protected _anthropicBaseUrl?: string
   protected _minimaxBaseUrl?: string
   protected _geminiBaseUrl?: string
@@ -110,8 +125,15 @@ export class ClientBuilder {
     return this
   }
 
+  /** E4 one-timeout-model. Unset fields keep defaults (connect 10s, readIdle 120s, total off). */
+  timeouts(t: TimeoutSettings): this {
+    this._timeouts = { ...this._timeouts, ...t }
+    return this
+  }
+
+  /** @deprecated Alias for timeouts({ readIdleMs: n * 1000 }); superseded by the E4 timeout model. */
   streamReadTimeoutSecs(n: number): this {
-    this._streamReadTimeoutSecs = n
+    this._timeouts = { ...this._timeouts, readIdleMs: n * 1000 }
     return this
   }
 
@@ -315,7 +337,7 @@ export class ClientBuilder {
     }
 
     const provider = this.buildProvider(this._provider, apiKey ?? '')
-    return new Client(provider, this._streamReadTimeoutSecs)
+    return new Client(provider, this._timeouts)
   }
 }
 
@@ -327,7 +349,9 @@ export class ClientBuilder {
  */
 export class Client {
   private provider: DispatchProvider
-  private streamReadTimeoutSecs?: number
+  private readonly connectMs: number
+  private readonly readIdleMs: number
+  private readonly totalMs?: number
 
   static builder(): ClientBuilder {
     return new ClientBuilder()
@@ -342,9 +366,11 @@ export class Client {
           minimaxBaseUrl?: string
         }
       | ProviderLike,
-    streamReadTimeoutSecs?: number,
+    timeouts?: TimeoutSettings,
   ) {
-    this.streamReadTimeoutSecs = streamReadTimeoutSecs
+    this.connectMs = timeouts?.connectMs ?? DEFAULT_CONNECT_MS
+    this.readIdleMs = timeouts?.readIdleMs ?? DEFAULT_READ_IDLE_MS
+    this.totalMs = timeouts?.totalMs
 
     if (typeof (options as ProviderLike).chat === 'function') {
       this.provider = asDispatchProvider(options as ProviderLike)
@@ -388,34 +414,74 @@ export class Client {
     }
   }
 
-  /** Send a chat request; validates capabilities BEFORE any HTTP call. */
-  async chat(request: ChatRequest): Promise<ChatResponse> {
-    return dispatchChat(this.provider, request)
+  /**
+   * Send a chat request; validates capabilities BEFORE any HTTP call.
+   * Signals (E4/E6): the caller signal plus the opt-in totalMs budget
+   * (AbortSignal.timeout, armed across the WHOLE call including retries) are
+   * the only whole-call signals. The connect budget is NOT composed here — it
+   * rides preHeadersTimeoutMs into http/fetch.ts, where its timer is
+   * disarmed the moment headers arrive.
+   */
+  async chat(request: ChatRequest, opts?: RequestOptions): Promise<ChatResponse> {
+    let signal = opts?.signal
+    if (this.totalMs !== undefined) {
+      const total = AbortSignal.timeout(this.totalMs)
+      signal = signal ? AbortSignal.any([signal, total]) : total
+    }
+    try {
+      return await dispatchChat(this.provider, request, {
+        signal,
+        callerSignal: opts?.signal,
+        preHeadersTimeoutMs: this.connectMs + this.readIdleMs,
+      })
+    } catch (error) {
+      if (opts?.signal?.aborted && !(error instanceof CancelledError)) {
+        throw new CancelledError()
+      }
+      throw error
+    }
   }
 
   /**
-   * Stream a chat request: dispatch (validate → provider.stream) → optional
-   * readTimeoutStream → stripThink. Matches Rust ordering.
+   * Stream a chat request: dispatch (validate -> provider.stream) ->
+   * readTimeoutStream(readIdleMs, ALWAYS on; default 120s) -> stripThink ->
+   * caller-abort translation. Streams get ONLY the caller signal: totalMs
+   * never applies to stream body consumption.
    */
-  stream(request: ChatRequest): AsyncIterable<StreamEvent> {
-    let stream: BoxStream = dispatchStream(this.provider, request)
-
-    if (this.streamReadTimeoutSecs !== undefined) {
-      stream = readTimeoutStream(stream, this.streamReadTimeoutSecs)
-    }
-
+  stream(request: ChatRequest, opts?: RequestOptions): AsyncIterable<StreamEvent> {
+    let stream: BoxStream = dispatchStream(this.provider, request, {
+      signal: opts?.signal,
+      callerSignal: opts?.signal,
+      preHeadersTimeoutMs: this.connectMs + this.readIdleMs,
+    })
+    stream = readTimeoutStream(stream, this.readIdleMs / 1000)
     stream = stripThink(stream)
-    return stream
+    return this.translateCallerAbort(stream, opts?.signal)
+  }
+
+  /** Mid-stream caller abort surfaces as CancelledError, never a raw AbortError (E6). */
+  private async *translateCallerAbort(
+    inner: BoxStream,
+    callerSignal: AbortSignal | undefined,
+  ): AsyncIterable<StreamEvent> {
+    try {
+      for await (const evt of inner) yield evt
+    } catch (error) {
+      if (callerSignal?.aborted && !(error instanceof CancelledError)) {
+        throw new CancelledError()
+      }
+      throw error
+    }
   }
 
   /** Stream and collect the full response into a ChatResponse. */
-  async streamCollect(request: ChatRequest): Promise<ChatResponse> {
-    return collectStream(this.stream(request))
+  async streamCollect(request: ChatRequest, opts?: RequestOptions): Promise<ChatResponse> {
+    return collectStream(this.stream(request, opts))
   }
 
   /** Stream and collect, preferring the request's model override in the result. */
-  async streamCollectWith(request: ChatRequest): Promise<ChatResponse> {
-    const response = await collectStream(this.stream(request))
+  async streamCollectWith(request: ChatRequest, opts?: RequestOptions): Promise<ChatResponse> {
+    const response = await collectStream(this.stream(request, opts))
     if (request.model) {
       response.model = request.model
     }

--- a/sdks/typescript/src/error.ts
+++ b/sdks/typescript/src/error.ts
@@ -29,6 +29,18 @@ export class IncompleteStreamError extends StreamError {
 }
 
 /**
+ * Thrown when the CALLER's AbortSignal aborts a request. NEVER retried
+ * (specs/retry.md transport table). Fetch-internal AbortError/TimeoutError
+ * with no caller signal aborted (e.g. AbortSignal.timeout) stay retryable.
+ */
+export class CancelledError extends MotosanError {
+  constructor(message = 'request cancelled by caller') {
+    super(message)
+    this.name = 'CancelledError'
+  }
+}
+
+/**
  * Error thrown when a stream read operation times out.
  * Carries the timeout duration in seconds.
  */
@@ -105,8 +117,11 @@ export function isRetryableNetworkError(error: unknown): boolean {
     return false
   }
 
-  // AbortError (fetch cancelled/timed out at fetch level)
-  if (error.name === 'AbortError') {
+  // AbortError / TimeoutError: fetch cancelled or timed out at fetch level.
+  // undici rejects with signal.reason — a TimeoutError DOMException for
+  // AbortSignal.timeout. Caller-signal aborts are translated to
+  // CancelledError BEFORE classification and never reach this predicate.
+  if (error.name === 'AbortError' || error.name === 'TimeoutError') {
     return true
   }
 

--- a/sdks/typescript/src/error.ts
+++ b/sdks/typescript/src/error.ts
@@ -12,6 +12,23 @@ export class NetworkError extends MotosanError {}
 export class StreamError extends MotosanError {}
 
 /**
+ * Error thrown when the upstream byte/event stream ends (EOF) without the
+ * provider's terminal event (Anthropic message_stop, OpenAI [DONE], Gemini
+ * finishReason, Ollama done:true, Codex response.completed). Message
+ * convention: `incomplete stream: <provider> ended without a terminal event`.
+ * Subclasses StreamError deliberately (migration softener): existing
+ * `instanceof StreamError` handlers keep catching truncation. Replaces the
+ * retired v0.10.1 "exactly one terminal done even when upstream closes
+ * without [DONE]" invariant (M3/E3; specs/types.md stream termination).
+ */
+export class IncompleteStreamError extends StreamError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'IncompleteStreamError'
+  }
+}
+
+/**
  * Error thrown when a stream read operation times out.
  * Carries the timeout duration in seconds.
  */

--- a/sdks/typescript/src/http/fetch.ts
+++ b/sdks/typescript/src/http/fetch.ts
@@ -1,7 +1,36 @@
 import { extractErrorMessage, mapHttpError, ProviderError } from '../error.js'
 
 export interface FetchOptions {
+  /** Caller signal (streams) or caller+totalMs composition (chat). Stays armed for the whole call. */
   signal?: AbortSignal
+  /**
+   * E4 connect budget. Arms a timer-driven AbortController that is DISARMED
+   * the moment `await fetch(...)` resolves (headers received), so it never
+   * bounds body reads and a slow generation cannot trip it.
+   */
+  preHeadersTimeoutMs?: number
+}
+
+async function fetchWithTimeouts(
+  url: string,
+  fetchOptions: RequestInit,
+  options?: FetchOptions,
+): Promise<Response> {
+  const signals: AbortSignal[] = []
+  if (options?.signal) signals.push(options.signal)
+  let timer: ReturnType<typeof setTimeout> | undefined
+  if (options?.preHeadersTimeoutMs !== undefined) {
+    const connectController = new AbortController()
+    timer = setTimeout(() => connectController.abort(), options.preHeadersTimeoutMs)
+    signals.push(connectController.signal)
+  }
+  if (signals.length === 1) fetchOptions.signal = signals[0]
+  if (signals.length > 1) fetchOptions.signal = AbortSignal.any(signals)
+  try {
+    return await fetch(url, fetchOptions)
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
 }
 
 async function throwMappedError(response: Response): Promise<never> {
@@ -34,11 +63,8 @@ export async function postJson<T = unknown>(
     headers: { 'content-type': 'application/json', ...headers },
     body: JSON.stringify(body),
   }
-  if (options?.signal) {
-    fetchOptions.signal = options.signal
-  }
 
-  const response = await fetch(url, fetchOptions)
+  const response = await fetchWithTimeouts(url, fetchOptions, options)
 
   if (!response.ok) {
     await throwMappedError(response)
@@ -58,11 +84,8 @@ export async function postStream(
     headers: { 'content-type': 'application/json', ...headers },
     body: JSON.stringify(body),
   }
-  if (options?.signal) {
-    fetchOptions.signal = options.signal
-  }
 
-  const response = await fetch(url, fetchOptions)
+  const response = await fetchWithTimeouts(url, fetchOptions, options)
 
   if (!response.ok) {
     await throwMappedError(response)

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -29,7 +29,7 @@ export {
   CHATGPT_CODEX_MODELS,
 } from './models.js'
 export { serializeGeminiRequest } from './serialize/gemini.js'
-export type { ProviderCapabilities, Provider } from './provider.js'
+export type { ProviderCapabilities, Provider, RequestOptions, ProviderRequestOptions } from './provider.js'
 export { textOnly, withImage, fullCaps, minimaxCaps, validateRequest } from './provider.js'
 
 // M4: server-side MCP types (also covered by `export * from './types.js'`; listed

--- a/sdks/typescript/src/provider.ts
+++ b/sdks/typescript/src/provider.ts
@@ -5,7 +5,7 @@
  * `types.rs:903-930` (ProviderCapabilities).
  */
 
-import { UnsupportedFeatureError } from './error.js'
+import { StreamReadTimeoutError, UnsupportedFeatureError } from './error.js'
 import type { BoxStream } from './stream.js'
 import type { ChatRequest, ChatResponse, ContentBlock, StreamEvent } from './types.js'
 
@@ -101,6 +101,24 @@ export function validateRequest(req: ChatRequest, caps: ProviderCapabilities): v
  */
 export type Provider = 'anthropic' | 'openai' | 'minimax' | 'ollama' | 'gemini' | 'chatgpt_codex'
 
+/** Per-request options accepted by Client.chat / Client.stream. */
+export interface RequestOptions {
+  /** Caller cancellation signal. Abort => CancelledError, never retried (E6). */
+  signal?: AbortSignal
+}
+
+/**
+ * What providers receive: `signal` is the fetch signal (caller signal, plus
+ * the opt-in totalMs AbortSignal.timeout on chat paths only); `callerSignal`
+ * is the raw caller signal, kept separate so the CancelledError-vs-
+ * retryable-abort split can test callerSignal.aborted; `preHeadersTimeoutMs`
+ * is the E4 connect budget, disarmed by http/fetch.ts once headers arrive.
+ */
+export interface ProviderRequestOptions extends RequestOptions {
+  callerSignal?: AbortSignal
+  preHeadersTimeoutMs?: number
+}
+
 /**
  * Minimal shape a provider must expose to be dispatched: a capability reshape
  * plus chat/stream. Concrete providers (AnthropicProvider/OpenAIProvider/
@@ -108,8 +126,8 @@ export type Provider = 'anthropic' | 'openai' | 'minimax' | 'ollama' | 'gemini' 
  */
 export interface ProviderImpl {
   capabilities(): ProviderCapabilities
-  chat(req: ChatRequest): Promise<ChatResponse>
-  stream(req: ChatRequest): BoxStream
+  chat(req: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse>
+  stream(req: ChatRequest, opts?: ProviderRequestOptions): BoxStream
 }
 
 /**
@@ -117,9 +135,13 @@ export interface ProviderImpl {
  * provider.chat (which owns its retry loop). NO retry here; mirrors Rust
  * client.rs dispatch_chat (validate → p.chat).
  */
-export async function dispatchChat(provider: ProviderImpl, req: ChatRequest): Promise<ChatResponse> {
+export async function dispatchChat(
+  provider: ProviderImpl,
+  req: ChatRequest,
+  opts?: ProviderRequestOptions,
+): Promise<ChatResponse> {
   validateRequest(req, provider.capabilities())
-  return provider.chat(req)
+  return provider.chat(req, opts)
 }
 
 /**
@@ -127,16 +149,20 @@ export async function dispatchChat(provider: ProviderImpl, req: ChatRequest): Pr
  * (which owns the initial-fetch retry; NO retry here). Sync return; the returned
  * generator throws on initial-fetch failure after provider internal retries.
  */
-export function dispatchStream(provider: ProviderImpl, req: ChatRequest): BoxStream {
+export function dispatchStream(
+  provider: ProviderImpl,
+  req: ChatRequest,
+  opts?: ProviderRequestOptions,
+): BoxStream {
   validateRequest(req, provider.capabilities())
-  return provider.stream(req)
+  return provider.stream(req, opts)
 }
 
 /**
- * Stream wrapper that applies a read timeout. SILENTLY terminates (returns/ends)
- * on timeout — does NOT throw, matching the M1 mid-stream-failure swallow contract.
- * Ports Rust `ReadTimeoutStream`: reset the deadline on each yielded event; if no
- * event arrives before the deadline, end the stream.
+ * Stream wrapper that applies a read-idle timeout. THROWS StreamReadTimeoutError
+ * when no event arrives within the deadline (E7 — the pre-M3 silent-end behavior
+ * is retired); the deadline resets on each yielded event and the inner iterator
+ * is cancelled before throwing.
  */
 export async function* readTimeoutStream(inner: BoxStream, timeoutSecs: number): BoxStream {
   const timeoutMs = timeoutSecs * 1000
@@ -173,7 +199,7 @@ export async function* readTimeoutStream(inner: BoxStream, timeoutSecs: number):
 
         if (raced === '__timeout__') {
           cancelInnerWithoutWaiting()
-          return
+          throw new StreamReadTimeoutError(timeoutSecs)
         }
 
         const result = raced as IteratorResult<StreamEvent>

--- a/sdks/typescript/src/providers/anthropic.ts
+++ b/sdks/typescript/src/providers/anthropic.ts
@@ -2,8 +2,8 @@ import { IncompleteStreamError, ProviderError, StreamError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { DEFAULT_ANTHROPIC_MODEL } from '../models.js'
 import { parseSse } from '../http/sse.js'
-import { fullCaps, type ProviderCapabilities } from '../provider.js'
-import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
+import { fullCaps, type ProviderCapabilities, type ProviderRequestOptions } from '../provider.js'
+import { attemptWithCancellation, classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import { serializeAnthropicRequest } from '../serialize/anthropic.js'
 import {
   doneEvent,
@@ -193,14 +193,20 @@ export class AnthropicProvider {
     return this.headers(beta ? { 'anthropic-beta': beta } : {})
   }
 
-  async chat(request: ChatRequest): Promise<ChatResponse> {
+  async chat(request: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse> {
     const model = request.model ?? this.model
     const serialized = serializeAnthropicRequest(request, model)
     const body = isSetupToken(this.apiKey) ? withOAuthSystemIdentity(serialized) : serialized
     const headers = this.requestHeaders(request, body)
     const payload = await withRetry(
       this.retryPolicy,
-      async () => postJson<any>(`${this.baseUrl}/v1/messages`, headers, body),
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postJson<any>(`${this.baseUrl}/v1/messages`, headers, body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
       classifyForRetry,
     )
 
@@ -236,11 +242,11 @@ export class AnthropicProvider {
     }
   }
 
-  stream(request: ChatRequest): BoxStream {
-    return this.streamImpl(request)
+  stream(request: ChatRequest, opts?: ProviderRequestOptions): BoxStream {
+    return this.streamImpl(request, opts)
   }
 
-  private async *streamImpl(request: ChatRequest) {
+  private async *streamImpl(request: ChatRequest, opts?: ProviderRequestOptions) {
     const model = request.model ?? this.model
     const serialized = {
       ...serializeAnthropicRequest(request, model),
@@ -254,7 +260,13 @@ export class AnthropicProvider {
     // has been returned").
     const responseBody = await withRetry(
       this.retryPolicy,
-      async () => postStream(`${this.baseUrl}/v1/messages`, headers, body),
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postStream(`${this.baseUrl}/v1/messages`, headers, body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
       classifyForRetry,
     )
 

--- a/sdks/typescript/src/providers/anthropic.ts
+++ b/sdks/typescript/src/providers/anthropic.ts
@@ -1,4 +1,4 @@
-import { ProviderError, StreamError } from '../error.js'
+import { IncompleteStreamError, ProviderError, StreamError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { DEFAULT_ANTHROPIC_MODEL } from '../models.js'
 import { parseSse } from '../http/sse.js'
@@ -140,15 +140,18 @@ interface StreamState {
 export class AnthropicProvider {
   private readonly model: string
   private readonly baseUrl: string
+  private readonly providerName: string
   private retryPolicy: RetryPolicy
 
   constructor(
     private readonly apiKey: string,
     model?: string,
     baseUrl = 'https://api.anthropic.com',
+    providerName = 'anthropic',
   ) {
     this.model = model ?? DEFAULT_ANTHROPIC_MODEL
     this.baseUrl = baseUrl
+    this.providerName = providerName
     this.retryPolicy = RetryPolicy.default()
   }
 
@@ -360,12 +363,12 @@ export class AnthropicProvider {
       }
     }
 
-    // Defensive: terminate even if message_stop never arrived.
-    if (state.stopReason !== undefined) {
-      yield doneWithStopReason(state.stopReason)
-    } else {
-      yield doneEvent()
-    }
+    // EOF without message_stop: truncation, not completion (M3/E3 — the
+    // fabricated clean done is retired). A message_delta stop_reason alone
+    // is NOT terminal; only message_stop is.
+    throw new IncompleteStreamError(
+      `incomplete stream: ${this.providerName} ended without a terminal event`,
+    )
   }
 
   capabilities(): ProviderCapabilities {

--- a/sdks/typescript/src/providers/chatgpt_codex.ts
+++ b/sdks/typescript/src/providers/chatgpt_codex.ts
@@ -12,8 +12,8 @@ import { IncompleteStreamError, StreamError } from '../error.js'
 import { postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_CHATGPT_CODEX_MODEL } from '../models.js'
-import { textOnly, type ProviderCapabilities } from '../provider.js'
-import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
+import { textOnly, type ProviderCapabilities, type ProviderRequestOptions } from '../provider.js'
+import { attemptWithCancellation, classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import {
   collectStream,
   doneWithStopReason,
@@ -205,18 +205,21 @@ export class ChatGptCodexProvider {
     return body
   }
 
-  async chat(request: ChatRequest): Promise<ChatResponse> {
+  async chat(request: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse> {
     const model = request.model ?? this.model
-    const response = await collectStream(this.stream(request))
+    const response = await collectStream(this.stream(request, opts))
     if (!response.model) response.model = model
     return response
   }
 
-  stream(request: ChatRequest): BoxStream {
-    return this.streamImpl(request)
+  stream(request: ChatRequest, opts?: ProviderRequestOptions): BoxStream {
+    return this.streamImpl(request, opts)
   }
 
-  private async *streamImpl(request: ChatRequest): AsyncGenerator<StreamEvent> {
+  private async *streamImpl(
+    request: ChatRequest,
+    opts?: ProviderRequestOptions,
+  ): AsyncGenerator<StreamEvent> {
     const model = request.model ?? this.model
     const body = this.buildResponsesBody(request, model)
     const headers = this.headers()
@@ -225,7 +228,13 @@ export class ChatGptCodexProvider {
     // other providers: nothing is retried after the first emitted event).
     const responseBody = await withRetry(
       this.retryPolicy,
-      async () => postStream(this.baseUrl, headers, body),
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postStream(this.baseUrl, headers, body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
       classifyForRetry,
     )
 

--- a/sdks/typescript/src/providers/chatgpt_codex.ts
+++ b/sdks/typescript/src/providers/chatgpt_codex.ts
@@ -8,7 +8,7 @@
  * the Python mid-stream `StreamError` raise).
  */
 
-import { StreamError } from '../error.js'
+import { IncompleteStreamError, StreamError } from '../error.js'
 import { postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_CHATGPT_CODEX_MODEL } from '../models.js'
@@ -16,7 +16,6 @@ import { textOnly, type ProviderCapabilities } from '../provider.js'
 import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import {
   collectStream,
-  doneEvent,
   doneWithStopReason,
   textEvent,
   thinkingDelta,
@@ -239,92 +238,86 @@ export class ChatGptCodexProvider {
     // only. Map item.id → call_id so every tool event carries the call_id.
     const itemIdToCallId = new Map<string, string>()
 
-    // Fatal `error` / `response.failed` frames throw a StreamError (Rust/
-    // Python parity). Other post-start body errors still end silently (M3).
-    try {
-      for await (const evt of parseSse(responseBody)) {
-        const data = evt.data
-        if (!data || data === '[DONE]' || typeof data !== 'object') continue
+    // Fatal `error` / `response.failed` frames throw a StreamError; other
+    // body errors propagate (M3 removed the swallow).
+    for await (const evt of parseSse(responseBody)) {
+      const data = evt.data
+      if (!data || data === '[DONE]' || typeof data !== 'object') continue
 
-        switch (data.type) {
-          case 'response.output_text.delta': {
-            const delta = data.delta
-            if (typeof delta === 'string' && delta) yield textEvent(delta)
-            break
-          }
-          case 'response.reasoning_text.delta':
-          case 'response.reasoning_summary_text.delta': {
-            const delta = data.delta
-            if (typeof delta === 'string' && delta) yield thinkingDelta(delta)
-            break
-          }
-          case 'response.output_item.added': {
-            const item = data.item
-            if (item && item.type === 'function_call' && item.call_id) {
-              sawToolCall = true
-              if (item.id) itemIdToCallId.set(String(item.id), String(item.call_id))
-              yield toolCallStart(String(item.call_id), String(item.name ?? ''))
-            }
-            break
-          }
-          case 'response.function_call_arguments.delta': {
-            const itemId = data.item_id
-            const delta = data.delta
-            if (itemId && typeof delta === 'string') {
-              const callId = itemIdToCallId.get(String(itemId)) ?? String(itemId)
-              yield toolCallArgsWithId(callId, delta)
-            }
-            break
-          }
-          case 'response.output_item.done': {
-            const item = data.item
-            if (item && item.type === 'function_call' && item.call_id) {
-              yield toolCallEndWithId(String(item.call_id))
-            }
-            break
-          }
-          case 'response.completed': {
-            const response =
-              data.response && typeof data.response === 'object' ? data.response : {}
-            const usage = response.usage
-            if (usage && typeof usage === 'object') {
-              const u: Usage = {
-                inputTokens: Number(usage.input_tokens ?? 0),
-                outputTokens: Number(usage.output_tokens ?? 0),
-              }
-              const cached = Number(usage.input_tokens_details?.cached_tokens ?? 0)
-              if (cached > 0) u.cacheReadInputTokens = cached
-              yield usageEvent(u)
-            }
-            const status = response.status ?? 'completed'
-            const stop: StopReason = sawToolCall
-              ? 'tool_use'
-              : status === 'incomplete'
-                ? 'max_tokens'
-                : 'end_turn'
-            yield doneWithStopReason(stop)
-            return
-          }
-          case 'error':
-          case 'response.failed':
-            // Fatal stream error frame: surface it (Rust MotosanError::Stream
-            // / Python StreamError parity).
-            throw new StreamError(chatGptCodexErrorMessage(data))
-          default:
-            break
+      switch (data.type) {
+        case 'response.output_text.delta': {
+          const delta = data.delta
+          if (typeof delta === 'string' && delta) yield textEvent(delta)
+          break
         }
+        case 'response.reasoning_text.delta':
+        case 'response.reasoning_summary_text.delta': {
+          const delta = data.delta
+          if (typeof delta === 'string' && delta) yield thinkingDelta(delta)
+          break
+        }
+        case 'response.output_item.added': {
+          const item = data.item
+          if (item && item.type === 'function_call' && item.call_id) {
+            sawToolCall = true
+            if (item.id) itemIdToCallId.set(String(item.id), String(item.call_id))
+            yield toolCallStart(String(item.call_id), String(item.name ?? ''))
+          }
+          break
+        }
+        case 'response.function_call_arguments.delta': {
+          const itemId = data.item_id
+          const delta = data.delta
+          if (itemId && typeof delta === 'string') {
+            const callId = itemIdToCallId.get(String(itemId)) ?? String(itemId)
+            yield toolCallArgsWithId(callId, delta)
+          }
+          break
+        }
+        case 'response.output_item.done': {
+          const item = data.item
+          if (item && item.type === 'function_call' && item.call_id) {
+            yield toolCallEndWithId(String(item.call_id))
+          }
+          break
+        }
+        case 'response.completed': {
+          const response =
+            data.response && typeof data.response === 'object' ? data.response : {}
+          const usage = response.usage
+          if (usage && typeof usage === 'object') {
+            const u: Usage = {
+              inputTokens: Number(usage.input_tokens ?? 0),
+              outputTokens: Number(usage.output_tokens ?? 0),
+            }
+            const cached = Number(usage.input_tokens_details?.cached_tokens ?? 0)
+            if (cached > 0) u.cacheReadInputTokens = cached
+            yield usageEvent(u)
+          }
+          const status = response.status ?? 'completed'
+          const stop: StopReason = sawToolCall
+            ? 'tool_use'
+            : status === 'incomplete'
+              ? 'max_tokens'
+              : 'end_turn'
+          yield doneWithStopReason(stop)
+          return
+        }
+        case 'error':
+        case 'response.failed':
+          // Fatal stream error frame: surface it (Rust MotosanError::Stream
+          // / Python StreamError parity).
+          throw new StreamError(chatGptCodexErrorMessage(data))
+        default:
+          break
       }
-    } catch (error) {
-      if (error instanceof StreamError) {
-        throw error
-      }
-      // Ignore other post-start stream-body errors; end without a terminal
-      // done (mirrors ollama.ts:362-366). Surfacing these is milestone M3.
-      return
     }
 
-    // Defensive terminal for a clean EOF without response.completed
-    // (mirrors anthropic.ts:386-391). response.completed returns earlier.
-    yield doneEvent()
+    // EOF without response.completed: truncation, not completion (M3/E2/E3 —
+    // the defensive doneEvent() is retired). chat() = collectStream(stream()),
+    // so a truncated chat() now rejects with IncompleteStreamError too.
+    throw new IncompleteStreamError(
+      'incomplete stream: chatgpt_codex ended without a terminal event',
+    )
   }
 }

--- a/sdks/typescript/src/providers/gemini.ts
+++ b/sdks/typescript/src/providers/gemini.ts
@@ -2,8 +2,8 @@ import { IncompleteStreamError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_GEMINI_MODEL } from '../models.js'
-import { withImage, type ProviderCapabilities } from '../provider.js'
-import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
+import { withImage, type ProviderCapabilities, type ProviderRequestOptions } from '../provider.js'
+import { attemptWithCancellation, classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import { serializeGeminiRequest } from '../serialize/gemini.js'
 import {
   BoxStream,
@@ -91,14 +91,20 @@ export class GeminiProvider {
     return { 'x-goog-api-key': this.apiKey } // (gemini.rs:77)
   }
 
-  async chat(request: ChatRequest): Promise<ChatResponse> {
+  async chat(request: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse> {
     const model = this.resolveModel(request)
     const url = this.generateUrl(model)
     const body = serializeGeminiRequest(request, model)
 
     const payload = await withRetry(
       this.retryPolicy,
-      async () => postJson<any>(url, this.headers(), body),
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postJson<any>(url, this.headers(), body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
       classifyForRetry,
     )
 
@@ -149,11 +155,11 @@ export class GeminiProvider {
     }
   }
 
-  stream(request: ChatRequest): BoxStream {
-    return this.streamImpl(request)
+  stream(request: ChatRequest, opts?: ProviderRequestOptions): BoxStream {
+    return this.streamImpl(request, opts)
   }
 
-  private async *streamImpl(request: ChatRequest) {
+  private async *streamImpl(request: ChatRequest, opts?: ProviderRequestOptions) {
     const model = this.resolveModel(request)
     const url = this.streamUrl(model)
     const body = serializeGeminiRequest(request, model)
@@ -162,7 +168,13 @@ export class GeminiProvider {
     // body is obtained, parseSse drives with NO mid-stream retry (gemini.rs:372-413).
     const responseBody = await withRetry(
       this.retryPolicy,
-      async () => postStream(url, this.headers(), body),
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postStream(url, this.headers(), body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
       classifyForRetry,
     )
 

--- a/sdks/typescript/src/providers/gemini.ts
+++ b/sdks/typescript/src/providers/gemini.ts
@@ -1,3 +1,4 @@
+import { IncompleteStreamError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_GEMINI_MODEL } from '../models.js'
@@ -170,6 +171,7 @@ export class GeminiProvider {
     // doneWithStopReason) or stream EOF. NO defensive EOF done (gemini.rs:531;
     // contrast openai.ts:460-474). (sse.ts [DONE] is advisory and never
     // terminates — sse.ts:7-9,134-139.)
+    let sawTerminal = false
     for await (const evt of parseSse(responseBody)) {
       const data = evt.data
 
@@ -217,9 +219,13 @@ export class GeminiProvider {
       // done LAST, only when finishReason present — the ONLY terminator
       // (gemini.rs:513-523).
       if (finishReason !== undefined) {
+        sawTerminal = true
         yield doneWithStopReason(mapFinishReason(finishReason, hasToolCalls))
       }
     }
-    // EOF: generator ends naturally. NO fabricated done (gemini.rs:531).
+    // EOF without any finishReason: truncation, not completion (M3/E2).
+    if (!sawTerminal) {
+      throw new IncompleteStreamError('incomplete stream: gemini ended without a terminal event')
+    }
   }
 }

--- a/sdks/typescript/src/providers/minimax.ts
+++ b/sdks/typescript/src/providers/minimax.ts
@@ -11,7 +11,7 @@
  * (Rust client.rs:577).
  */
 import { DEFAULT_MINIMAX_MODEL } from '../models.js'
-import { minimaxCaps, type ProviderCapabilities } from '../provider.js'
+import { minimaxCaps, type ProviderCapabilities, type ProviderRequestOptions } from '../provider.js'
 import { RetryPolicy } from '../retry.js'
 import type { BoxStream } from '../stream.js'
 import type { ChatRequest, ChatResponse } from '../types.js'
@@ -37,12 +37,12 @@ export class MinimaxProvider {
     return this
   }
 
-  chat(request: ChatRequest): Promise<ChatResponse> {
-    return this.inner.chat(request)
+  chat(request: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse> {
+    return this.inner.chat(request, opts)
   }
 
-  stream(request: ChatRequest): BoxStream {
-    return this.inner.stream(request)
+  stream(request: ChatRequest, opts?: ProviderRequestOptions): BoxStream {
+    return this.inner.stream(request, opts)
   }
 
   /** Text-only but MCP-capable via Anthropic-compatible wire. */

--- a/sdks/typescript/src/providers/minimax.ts
+++ b/sdks/typescript/src/providers/minimax.ts
@@ -28,6 +28,7 @@ export class MinimaxProvider {
       apiKey,
       model ?? DEFAULT_MINIMAX_MODEL,
       baseUrl ?? DEFAULT_MINIMAX_BASE_URL,
+      'minimax',
     )
   }
 

--- a/sdks/typescript/src/providers/ollama.ts
+++ b/sdks/typescript/src/providers/ollama.ts
@@ -1,3 +1,4 @@
+import { IncompleteStreamError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseNdjson } from '../http/ndjson.js'
 import { DEFAULT_OLLAMA_MODEL } from '../models.js'
@@ -287,51 +288,47 @@ export class OllamaProvider {
       classifyForRetry,
     )
 
-    // Adapter over parseNdjson: decide termination on done:true.
-    try {
-      for await (const obj of parseNdjson(responseBody)) {
-        const done = (obj as { done?: unknown }).done === true
-        if (done) {
-          // Rust StreamEvent::done() carries NO stop_reason — plain doneEvent.
-          yield doneEvent()
-          return
-        }
+    // Adapter over parseNdjson: terminal event is done:true. Body errors
+    // propagate (M3 removed the M1-era swallow).
+    for await (const obj of parseNdjson(responseBody)) {
+      const done = (obj as { done?: unknown }).done === true
+      if (done) {
+        // Rust StreamEvent::done() carries NO stop_reason — plain doneEvent.
+        yield doneEvent()
+        return
+      }
 
-        const message = (obj as { message?: any }).message
-        const content =
-          typeof message?.content === 'string' ? message.content : ''
-        const thinking =
-          typeof message?.thinking === 'string' ? message.thinking : ''
+      const message = (obj as { message?: any }).message
+      const content =
+        typeof message?.content === 'string' ? message.content : ''
+      const thinking =
+        typeof message?.thinking === 'string' ? message.thinking : ''
 
-        // text selection (ollama.rs:459-465). Streamed thinking is surfaced as
-        // a plain textEvent (folded into the text stream).
-        let text: string
-        if (thinking !== '' && content === '') {
-          text = thinking
-        } else if (content !== '') {
-          text = content
-        } else {
-          text = ''
-        }
-        if (text !== '') {
-          yield textEvent(text)
-        }
+      // text selection (ollama.rs:459-465). Streamed thinking is surfaced as
+      // a plain textEvent (folded into the text stream).
+      let text: string
+      if (thinking !== '' && content === '') {
+        text = thinking
+      } else if (content !== '') {
+        text = content
+      } else {
+        text = ''
+      }
+      if (text !== '') {
+        yield textEvent(text)
+      }
 
-        // 3-event pattern per tool call (ollama.rs:471-483).
-        if (message) {
-          for (const tc of OllamaProvider.extractToolCalls(message)) {
-            yield toolCallStart(tc.id, tc.name)
-            yield toolCallArgsWithId(tc.id, JSON.stringify(tc.input))
-            yield toolCallEndWithId(tc.id)
-          }
+      // 3-event pattern per tool call (ollama.rs:471-483).
+      if (message) {
+        for (const tc of OllamaProvider.extractToolCalls(message)) {
+          yield toolCallStart(tc.id, tc.name)
+          yield toolCallArgsWithId(tc.id, JSON.stringify(tc.input))
+          yield toolCallEndWithId(tc.id)
         }
       }
-    } catch {
-      // Ignore post-start stream body errors, matching Rust's partial-success
-      // stream semantics: end without synthesizing a terminal done event.
-      return
     }
-    // EOF without done:true — let the generator end (NO synthesized done),
-    // matching Rust Poll::Ready(None). collectStream fabricates a stop_reason.
+    // EOF without done:true: truncation, not completion (M3/E2). done:true
+    // returns from the generator above, so reaching here means no terminal.
+    throw new IncompleteStreamError('incomplete stream: ollama ended without a terminal event')
   }
 }

--- a/sdks/typescript/src/providers/ollama.ts
+++ b/sdks/typescript/src/providers/ollama.ts
@@ -2,8 +2,8 @@ import { IncompleteStreamError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseNdjson } from '../http/ndjson.js'
 import { DEFAULT_OLLAMA_MODEL } from '../models.js'
-import { textOnly, type ProviderCapabilities } from '../provider.js'
-import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
+import { textOnly, type ProviderCapabilities, type ProviderRequestOptions } from '../provider.js'
+import { attemptWithCancellation, classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import {
   doneEvent,
   textEvent,
@@ -219,11 +219,17 @@ export class OllamaProvider {
     return out
   }
 
-  async chat(req: ChatRequest): Promise<ChatResponse> {
+  async chat(req: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse> {
     const body = this.buildRequestBody(req, false)
     const payload = await withRetry(
       this.retryPolicy,
-      async () => postJson<any>(this.endpoint(), {}, body),
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postJson<any>(this.endpoint(), {}, body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
       classifyForRetry,
     )
 
@@ -274,17 +280,23 @@ export class OllamaProvider {
     }
   }
 
-  stream(req: ChatRequest): BoxStream {
-    return this.streamImpl(req)
+  stream(req: ChatRequest, opts?: ProviderRequestOptions): BoxStream {
+    return this.streamImpl(req, opts)
   }
 
-  private async *streamImpl(req: ChatRequest) {
+  private async *streamImpl(req: ChatRequest, opts?: ProviderRequestOptions) {
     const body = this.buildRequestBody(req, true)
 
     // Retry ONLY the initial postStream fetch via the shared engine.
     const responseBody = await withRetry(
       this.retryPolicy,
-      async () => postStream(this.endpoint(), {}, body),
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postStream(this.endpoint(), {}, body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
       classifyForRetry,
     )
 

--- a/sdks/typescript/src/providers/openai.ts
+++ b/sdks/typescript/src/providers/openai.ts
@@ -1,3 +1,4 @@
+import { IncompleteStreamError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_OPENAI_MODEL } from '../models.js'
@@ -425,20 +426,26 @@ export class OpenAIProvider {
       }
     }
 
-    // Defensive: EOF without [DONE] — emit terminal once.
+    // EOF without the [DONE] sentinel (M3, amended): a stashed finish_reason
+    // means the stream is SEMANTICALLY complete — [DONE] is only the
+    // transport epilogue — so emit the terminal done carrying it, open-tool
+    // flush included (mirrors the [DONE] branch; narrow survival of the
+    // pre-M3 EOF fabrication, ONLY when finish_reason was seen). EOF with
+    // NEITHER signal is truncation: the no-signal fabrication is retired.
     if (!doneEmitted) {
-      // If a tool is still open (no finish_reason/[DONE] closed it), flush it.
-      if (openToolIndex !== undefined) {
-        const openId = toolBuffer.get(openToolIndex)?.id
-        if (openId) {
-          yield toolCallEndWithId(openId)
+      if (pendingStopReason !== undefined) {
+        if (openToolIndex !== undefined) {
+          const openId = toolBuffer.get(openToolIndex)?.id
+          if (openId) {
+            yield toolCallEndWithId(openId)
+          }
+          openToolIndex = undefined
         }
-        openToolIndex = undefined
+        doneEmitted = true
+        yield doneWithStopReason(pendingStopReason)
+        return
       }
-      doneEmitted = true
-      yield pendingStopReason !== undefined
-        ? doneWithStopReason(pendingStopReason)
-        : doneEvent()
+      throw new IncompleteStreamError('incomplete stream: openai ended without a terminal event')
     }
   }
 }

--- a/sdks/typescript/src/providers/openai.ts
+++ b/sdks/typescript/src/providers/openai.ts
@@ -2,8 +2,8 @@ import { IncompleteStreamError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_OPENAI_MODEL } from '../models.js'
-import { withImage, type ProviderCapabilities } from '../provider.js'
-import { classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
+import { withImage, type ProviderCapabilities, type ProviderRequestOptions } from '../provider.js'
+import { attemptWithCancellation, classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import { serializeOpenAiRequest } from '../serialize/openai.js'
 import {
   doneEvent,
@@ -142,7 +142,10 @@ export class OpenAIProvider {
     return ''
   }
 
-  private async chatViaResponses(request: ChatRequest): Promise<ChatResponse> {
+  private async chatViaResponses(
+    request: ChatRequest,
+    opts?: ProviderRequestOptions,
+  ): Promise<ChatResponse> {
     const model = request.model ?? this.model
     const instructionsParts: string[] = []
 
@@ -210,7 +213,13 @@ export class OpenAIProvider {
 
     const payload = await withRetry(
       this.retryPolicy,
-      async () => postJson<any>(this.responsesUrl, this.headers(), body),
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postJson<any>(this.responsesUrl, this.headers(), body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
       classifyForRetry,
     )
     const content = this.extractResponsesText(payload)
@@ -239,7 +248,7 @@ export class OpenAIProvider {
     }
   }
 
-  async chat(request: ChatRequest): Promise<ChatResponse> {
+  async chat(request: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse> {
     const resolvedModel = request.model ?? this.model
     const body = serializeOpenAiRequest(request, resolvedModel)
 
@@ -247,7 +256,13 @@ export class OpenAIProvider {
     try {
       payload = await withRetry(
         this.retryPolicy,
-        async () => postJson<any>(this.chatUrl, this.headers(), body),
+        async () =>
+          attemptWithCancellation(opts?.callerSignal, () =>
+            postJson<any>(this.chatUrl, this.headers(), body, {
+              signal: opts?.signal,
+              preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+            }),
+          ),
         classifyForRetry,
       )
     } catch (error) {
@@ -256,7 +271,7 @@ export class OpenAIProvider {
         error instanceof Error &&
         (error as { status?: number }).status === 404
       ) {
-        return this.chatViaResponses(request)
+        return this.chatViaResponses(request, opts)
       }
       throw error
     }
@@ -299,15 +314,15 @@ export class OpenAIProvider {
     }
   }
 
-  stream(request: ChatRequest): BoxStream {
-    return this.streamImpl(request)
+  stream(request: ChatRequest, opts?: ProviderRequestOptions): BoxStream {
+    return this.streamImpl(request, opts)
   }
 
   capabilities(): ProviderCapabilities {
     return withImage()
   }
 
-  private async *streamImpl(request: ChatRequest) {
+  private async *streamImpl(request: ChatRequest, opts?: ProviderRequestOptions) {
     const resolvedModel = request.model ?? this.model
     const body = serializeOpenAiRequest(request, resolvedModel)
     body.stream = true
@@ -315,7 +330,13 @@ export class OpenAIProvider {
     // Retry ONLY the initial fetch; no retry after the first emitted event.
     const responseBody = await withRetry(
       this.retryPolicy,
-      async () => postStream(this.chatUrl, this.headers(), body),
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postStream(this.chatUrl, this.headers(), body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
       classifyForRetry,
     )
 

--- a/sdks/typescript/src/retry.ts
+++ b/sdks/typescript/src/retry.ts
@@ -1,4 +1,4 @@
-import { isRetryableNetworkError, isRetryableStatus } from './error.js'
+import { CancelledError, isRetryableNetworkError, isRetryableStatus } from './error.js'
 
 /** Fired via RetryPolicy.onRetry before each retry sleep (D7). */
 export interface RetryEvent {
@@ -145,6 +145,9 @@ export async function withRetry<T>(
  * `{ retryable: false }`.
  */
 export function classifyForRetry(errOrStatus: unknown): RetryClassification {
+  if (errOrStatus instanceof CancelledError) {
+    return { retryable: false }
+  }
   if (typeof errOrStatus === 'number') {
     return { retryable: isRetryableStatus(errOrStatus) }
   }
@@ -159,4 +162,23 @@ export function classifyForRetry(errOrStatus: unknown): RetryClassification {
     }
   }
   return { retryable: false }
+}
+
+/**
+ * Run one request attempt; if it fails while the CALLER's signal is aborted,
+ * throw CancelledError (classified non-retryable) instead of the raw abort
+ * (E6: the provider request catch tests callerSignal.aborted).
+ */
+export async function attemptWithCancellation<T>(
+  callerSignal: AbortSignal | undefined,
+  op: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await op()
+  } catch (error) {
+    if (callerSignal?.aborted) {
+      throw new CancelledError()
+    }
+    throw error
+  }
 }

--- a/sdks/typescript/tests/client-builder.test.ts
+++ b/sdks/typescript/tests/client-builder.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Client, ClientBuilder } from '../src/client.js'
-import { ConfigError, UnsupportedFeatureError } from '../src/error.js'
+import { ConfigError, StreamReadTimeoutError, UnsupportedFeatureError } from '../src/error.js'
 import { dispatchChat, readTimeoutStream } from '../src/provider.js'
 import { RetryPolicy } from '../src/retry.js'
 import { ChatGptCodexProvider } from '../src/providers/chatgpt_codex.js'
@@ -229,18 +229,15 @@ describe('readTimeoutStream', () => {
     vi.useRealTimers()
   })
 
-  it('silently terminates a stalled stream without throwing', async () => {
+  it('throws StreamReadTimeoutError on a stalled stream (silent-end retired in M3)', async () => {
     const stalled = (async function* () {
       await new Promise(() => {})
       yield { content: 'never', done: false, eventType: 'text' as const }
     })()
 
-    const wrapped = readTimeoutStream(stalled, 0.05)
-    const results: unknown[] = []
-    for await (const event of wrapped) {
-      results.push(event)
-    }
-    expect(results.length).toBe(0)
+    await expect(async () => {
+      for await (const _ of readTimeoutStream(stalled, 0.05)) void _
+    }).rejects.toThrow(StreamReadTimeoutError)
   })
 
   it('clears the pending timeout before yielding an event', async () => {
@@ -285,13 +282,11 @@ describe('readTimeoutStream', () => {
       },
     }
 
-    const results: unknown[] = []
-    for await (const event of readTimeoutStream(stalled, 0.05)) {
-      results.push(event)
-    }
+    await expect(async () => {
+      for await (const _ of readTimeoutStream(stalled, 0.05)) void _
+    }).rejects.toThrow(StreamReadTimeoutError)
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(results).toEqual([])
     expect(returnSpy).toHaveBeenCalledOnce()
   })
 
@@ -306,12 +301,10 @@ describe('readTimeoutStream', () => {
       },
     }
 
-    const results: unknown[] = []
-    for await (const event of readTimeoutStream(stalled, 0.05)) {
-      results.push(event)
-    }
+    await expect(async () => {
+      for await (const _ of readTimeoutStream(stalled, 0.05)) void _
+    }).rejects.toThrow(StreamReadTimeoutError)
 
-    expect(results).toEqual([])
     expect(returnSpy).toHaveBeenCalledOnce()
   })
 

--- a/sdks/typescript/tests/edge-cases.test.ts
+++ b/sdks/typescript/tests/edge-cases.test.ts
@@ -7,7 +7,7 @@ import { validateRequest, fullCaps } from '../src/provider.js'
 import { serializeAnthropicRequest } from '../src/serialize/anthropic.js'
 import { serializeOpenAiRequest } from '../src/serialize/openai.js'
 import { serializeGeminiRequest } from '../src/serialize/gemini.js'
-import { MotosanError, ProviderError } from '../src/error.js'
+import { IncompleteStreamError, MotosanError, ProviderError } from '../src/error.js'
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL, DEFAULT_GEMINI_MODEL } from '../src/models.js'
 import type { StreamEvent } from '../src/types.js'
 
@@ -121,13 +121,23 @@ describe('edge cases', () => {
     })
   })
 
-  describe('mid-stream reset / partial success', () => {
-    // Anthropic & OpenAI fabricate a defensive `done` on EOF without a terminal
-    // event (anthropic.ts:386-391, openai.ts:460-474). Gemini deliberately does
-    // NOT (gemini.ts:262) and is already covered in providers-gemini.test.ts —
-    // so it is excluded here per the plan's Step-1 "add only the missing" rule.
+  describe('mid-stream truncation (M3/E3: EOF without a terminal event throws)', () => {
+    // M3 retired the v0.10.1 "fabricate a clean done at EOF" invariant for
+    // the NEITHER-signal case (anthropic.ts defensive tail removed;
+    // openai.ts EOF fabrication narrowed: it survives ONLY when a
+    // finish_reason was stashed — the semantic terminal, amended 2026-07-17).
+    async function drainErr(stream: AsyncIterable<StreamEvent>) {
+      const events: StreamEvent[] = []
+      let error: unknown
+      try {
+        for await (const evt of stream) events.push(evt)
+      } catch (e) {
+        error = e
+      }
+      return { events, error }
+    }
 
-    it('Anthropic: stream that ends without message_stop terminates silently with a partial response', async () => {
+    it('Anthropic: stream that ends without message_stop throws IncompleteStreamError', async () => {
       const transcript =
         'event: message_start\n' +
         'data: {"type":"message_start","message":{"usage":{"input_tokens":5,"output_tokens":0}}}\n\n' +
@@ -139,52 +149,55 @@ describe('edge cases', () => {
       stubSseFetch(transcript)
 
       const provider = new AnthropicProvider('key', 'claude-3-5-sonnet-20241022')
-      const events: StreamEvent[] = []
-      for await (const evt of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
-        events.push(evt)
-      }
+      const { events, error } = await drainErr(provider.stream({ messages: [{ role: 'user', content: 'hi' }] }))
+      expect(error).toBeInstanceOf(IncompleteStreamError)
+      expect((error as Error).message).toBe('incomplete stream: anthropic ended without a terminal event')
       expect(events.filter((e) => e.eventType === 'text' && !e.done).map((e) => e.content)).toEqual([
         'partial',
       ])
-      const last = events[events.length - 1]
-      expect(last.done).toBe(true)
+      expect(events.some((e) => e.done)).toBe(false)
 
-      // collectStream tolerates the drop and fabricates a terminal stopReason.
       stubSseFetch(transcript)
-      const resp = await collectStream(
-        provider.stream({ messages: [{ role: 'user', content: 'hi' }] }),
-      )
-      expect(resp.content).toBe('partial')
-      expect(Array.isArray(resp.toolCalls)).toBe(true)
-      expect(resp.toolCalls.length).toBe(0)
-      expect(resp.stopReason).toBe('end_turn') // fabricated: no tool calls
+      await expect(
+        collectStream(provider.stream({ messages: [{ role: 'user', content: 'hi' }] })),
+      ).rejects.toBeInstanceOf(IncompleteStreamError)
     })
 
-    it('OpenAI: stream that ends without [DONE]/finish_reason terminates silently with a partial response', async () => {
+    it('OpenAI: stream that ends without [DONE] throws IncompleteStreamError', async () => {
       const transcript =
         'data: {"choices":[{"index":0,"delta":{"content":"partial"}}]}\n\n'
       // No further chunks, no finish_reason, no [DONE] — dropped mid-flight.
       stubSseFetch(transcript)
 
       const provider = new OpenAIProvider('sk-test', 'gpt-4o')
+      const { events, error } = await drainErr(provider.stream({ messages: [{ role: 'user', content: 'hi' }] }))
+      expect(error).toBeInstanceOf(IncompleteStreamError)
+      expect((error as Error).message).toBe('incomplete stream: openai ended without a terminal event')
+      expect(events.some((e) => e.done)).toBe(false)
+
+      stubSseFetch(transcript)
+      await expect(
+        collectStream(provider.stream({ messages: [{ role: 'user', content: 'hi' }] })),
+      ).rejects.toBeInstanceOf(IncompleteStreamError)
+    })
+
+    it('OpenAI: finish_reason then EOF without [DONE] completes with the stashed stop reason (either signal suffices)', async () => {
+      // Amended M3 rule (2026-07-17): finish_reason is the SEMANTIC terminal;
+      // [DONE] is only the transport epilogue. This pins the narrow surviving
+      // path of the pre-M3 EOF fabrication (openai.ts pendingStopReason).
+      const transcript =
+        'data: {"choices":[{"index":0,"delta":{"content":"partial"}}]}\n\n' +
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"length"}]}\n\n'
+      stubSseFetch(transcript)
+      const provider = new OpenAIProvider('sk-test', 'gpt-4o')
       const events: StreamEvent[] = []
       for await (const evt of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
         events.push(evt)
       }
-      expect(events.filter((e) => e.eventType === 'text' && !e.done).map((e) => e.content)).toEqual([
-        'partial',
-      ])
       const last = events[events.length - 1]
       expect(last.done).toBe(true)
-
-      stubSseFetch(transcript)
-      const resp = await collectStream(
-        provider.stream({ messages: [{ role: 'user', content: 'hi' }] }),
-      )
-      expect(resp.content).toBe('partial')
-      expect(Array.isArray(resp.toolCalls)).toBe(true)
-      expect(resp.toolCalls.length).toBe(0)
-      expect(resp.stopReason).toBe('end_turn')
+      expect(last.stopReason).toBe('max_tokens')
+      expect(events.filter((e) => e.done)).toHaveLength(1)
     })
   })
 

--- a/sdks/typescript/tests/incomplete-stream.test.ts
+++ b/sdks/typescript/tests/incomplete-stream.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import * as sdk from '../src/index.js'
+import { AnthropicProvider } from '../src/providers/anthropic.js'
+import { GeminiProvider } from '../src/providers/gemini.js'
+import { OllamaProvider } from '../src/providers/ollama.js'
+import { MinimaxProvider } from '../src/providers/minimax.js'
+import { ChatGptCodexProvider } from '../src/providers/chatgpt_codex.js'
+import { collectStream } from '../src/stream.js'
+import { IncompleteStreamError, MotosanError, StreamError } from '../src/error.js'
+import type { ChatRequest, StreamEvent } from '../src/types.js'
+
+const REQ: ChatRequest = { messages: [{ role: 'user', content: 'hi' }] }
+
+function stubBodyFetch(transcript: string, contentType = 'text/event-stream'): void {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(transcript))
+      controller.close()
+    },
+  })
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(body, { status: 200, headers: { 'content-type': contentType } })),
+  )
+}
+
+async function drain(stream: AsyncIterable<StreamEvent>) {
+  const events: StreamEvent[] = []
+  let error: unknown
+  try {
+    for await (const e of stream) events.push(e)
+  } catch (e) {
+    error = e
+  }
+  return { events, error }
+}
+
+describe('IncompleteStreamError (E1)', () => {
+  it('subclasses StreamError (migration softener) + MotosanError, and is exported from the package root', () => {
+    const err = new IncompleteStreamError('incomplete stream: anthropic ended without a terminal event')
+    expect(err).toBeInstanceOf(StreamError)
+    expect(err).toBeInstanceOf(MotosanError)
+    expect(err.name).toBe('IncompleteStreamError')
+    expect(typeof sdk.IncompleteStreamError).toBe('function')
+  })
+})
+
+describe('adapter EOF-without-terminal-event enforcement (E2/E3)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const ANTHROPIC_PARTIAL =
+    'event: content_block_delta\n' +
+    'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n'
+
+  const cases = [
+    {
+      name: 'gemini',
+      transcript: 'data: {"candidates":[{"content":{"parts":[{"text":"partial"}],"role":"model"}}]}\n\n',
+      contentType: 'text/event-stream',
+      make: () => new GeminiProvider('k'),
+    },
+    {
+      name: 'ollama',
+      transcript: '{"message":{"content":"partial"},"done":false}\n',
+      contentType: 'application/x-ndjson',
+      make: () => new OllamaProvider('llama3.2', 'http://localhost:11434'),
+    },
+    {
+      name: 'minimax',
+      transcript: ANTHROPIC_PARTIAL,
+      contentType: 'text/event-stream',
+      make: () => new MinimaxProvider('key'),
+    },
+    {
+      name: 'chatgpt_codex',
+      transcript: 'data: {"type":"response.output_text.delta","delta":"partial"}\n\n',
+      contentType: 'text/event-stream',
+      make: () => new ChatGptCodexProvider('tok', 'acct'),
+    },
+  ]
+
+  for (const c of cases) {
+    it(`${c.name}: EOF after a text delta throws IncompleteStreamError (partial text already yielded)`, async () => {
+      stubBodyFetch(c.transcript, c.contentType)
+      const { events, error } = await drain(c.make().stream(REQ))
+      expect(error).toBeInstanceOf(IncompleteStreamError)
+      expect((error as Error).message).toBe(`incomplete stream: ${c.name} ended without a terminal event`)
+      expect(events.filter((e) => e.eventType === 'text' && !e.done).map((e) => e.content)).toEqual(['partial'])
+      expect(events.some((e) => e.done)).toBe(false)
+    })
+  }
+
+  it('anthropic: a message_delta stop_reason without message_stop is still incomplete (only message_stop is terminal)', async () => {
+    stubBodyFetch(
+      ANTHROPIC_PARTIAL +
+        'event: message_delta\n' +
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+    )
+    const { error } = await drain(new AnthropicProvider('key', 'claude-3-5-sonnet-20241022').stream(REQ))
+    expect(error).toBeInstanceOf(IncompleteStreamError)
+  })
+
+  it('collectStream propagates IncompleteStreamError (no stop_reason fallback for truncation)', async () => {
+    stubBodyFetch(ANTHROPIC_PARTIAL)
+    const provider = new AnthropicProvider('key', 'claude-3-5-sonnet-20241022')
+    await expect(collectStream(provider.stream(REQ))).rejects.toBeInstanceOf(IncompleteStreamError)
+  })
+})

--- a/sdks/typescript/tests/providers-anthropic.test.ts
+++ b/sdks/typescript/tests/providers-anthropic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { StreamError } from '../src/error.js'
+import { IncompleteStreamError, StreamError } from '../src/error.js'
 import { AnthropicProvider } from '../src/providers/anthropic.js'
 import type { ChatRequest, StreamEvent } from '../src/types.js'
 
@@ -615,7 +615,7 @@ describe('AnthropicProvider beta headers (M4)', () => {
   })
 
   it('streamImpl also adds the MCP beta header', async () => {
-    // Return an empty SSE body so the generator completes without events.
+    // Return an empty SSE body so EOF is reached before a terminal event.
     vi.stubGlobal(
       'fetch',
       vi.fn(async (url: string, options?: RequestInit) => {
@@ -631,13 +631,17 @@ describe('AnthropicProvider beta headers (M4)', () => {
       }),
     )
     const provider = new AnthropicProvider('k', 'claude-sonnet-4-6')
-    const events: StreamEvent[] = []
-    for await (const e of provider.stream({
-      messages: [{ role: 'user', content: 'hi' }],
-      mcpServers: [{ type: 'url', url: 'https://m.example/sse', name: 'm' }],
-    })) {
-      events.push(e)
+    let error: unknown
+    try {
+      for await (const _ of provider.stream({
+        messages: [{ role: 'user', content: 'hi' }],
+        mcpServers: [{ type: 'url', url: 'https://m.example/sse', name: 'm' }],
+      }))
+        void _
+    } catch (e) {
+      error = e
     }
+    expect(error).toBeInstanceOf(IncompleteStreamError)
     expect(captured?.headers['anthropic-beta']).toBe('mcp-client-2025-11-20')
   })
 })

--- a/sdks/typescript/tests/providers-gemini.test.ts
+++ b/sdks/typescript/tests/providers-gemini.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { GeminiProvider } from '../src/providers/gemini.js'
 import { collectStream } from '../src/stream.js'
-import { UnsupportedFeatureError } from '../src/error.js'
+import { IncompleteStreamError, UnsupportedFeatureError } from '../src/error.js'
 import { validateRequest } from '../src/provider.js'
 import type { ChatRequest, StreamEvent } from '../src/types.js'
 
@@ -349,7 +349,7 @@ describe('GeminiProvider — SSE stream (no [DONE]; finishReason terminates)', (
     expect(resp.toolCalls[0].input.q).toBe('x')
   })
 
-  it('skips a defensive [DONE] line and does not fabricate a done on EOF (gemini.rs:447-449,531)', async () => {
+  it('skips a defensive [DONE] line and throws IncompleteStreamError on EOF without finishReason (M3/E2)', async () => {
     const mockFetch = vi.fn(async () => {
       // No finishReason anywhere; a stray [DONE] must be ignored; stream ends on EOF.
       const sse = [
@@ -362,8 +362,13 @@ describe('GeminiProvider — SSE stream (no [DONE]; finishReason terminates)', (
 
     const provider = new GeminiProvider('k')
     const events: StreamEvent[] = []
-    for await (const evt of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
-      events.push(evt)
+    let error: unknown
+    try {
+      for await (const evt of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+        events.push(evt)
+      }
+    } catch (e) {
+      error = e
     }
     // Exactly one text event; NO fabricated done (Gemini adapter never emits a
     // defensive EOF done — only finishReason drives it).
@@ -371,13 +376,11 @@ describe('GeminiProvider — SSE stream (no [DONE]; finishReason terminates)', (
       'partial',
     ])
     expect(events.some((e) => e.done)).toBe(false)
+    expect(error).toBeInstanceOf(IncompleteStreamError)
 
-    // collectStream still produces a response (tolerates a missing done).
-    const resp = await collectStream(
-      provider.stream({ messages: [{ role: 'user', content: 'hi' }] }),
-    )
-    expect(resp.content).toBe('partial')
-    expect(resp.stopReason).toBe('end_turn') // fabricated from toolCalls.length === 0
+    await expect(
+      collectStream(provider.stream({ messages: [{ role: 'user', content: 'hi' }] })),
+    ).rejects.toBeInstanceOf(IncompleteStreamError)
   })
 
   it('emits a usage event from usageMetadata (gemini.rs:496-511)', async () => {

--- a/sdks/typescript/tests/providers-ollama.test.ts
+++ b/sdks/typescript/tests/providers-ollama.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { OllamaProvider } from '../src/providers/ollama.js'
 import { DEFAULT_OLLAMA_MODEL } from '../src/models.js'
 import { RetryPolicy } from '../src/retry.js'
+import { IncompleteStreamError } from '../src/error.js'
 import type { ChatRequest, StreamEvent } from '../src/types.js'
 
 const BASE = 'http://localhost:11434'
@@ -359,22 +360,27 @@ describe('OllamaProvider stream (native NDJSON adapter)', () => {
     expect(events[events.length - 1].done).toBe(true)
   })
 
-  it('ends WITHOUT synthesizing a done event on EOF without done:true', async () => {
+  it('throws IncompleteStreamError on EOF without done:true (M3/E2)', async () => {
     stubNdjson([
       '{"message":{"content":"a"},"done":false}\n',
       '{"message":{"content":"b"},"done":false}\n',
     ])
     const provider = new OllamaProvider('llama3.2', BASE)
     const events: StreamEvent[] = []
-    for await (const e of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
-      events.push(e)
+    let error: unknown
+    try {
+      for await (const e of provider.stream({ messages: [{ role: 'user', content: 'hi' }] })) {
+        events.push(e)
+      }
+    } catch (e) {
+      error = e
     }
-    // No terminal done event synthesized (matches Rust Poll::Ready(None)).
-    expect(events.every((e) => !e.done)).toBe(true)
+    expect(error).toBeInstanceOf(IncompleteStreamError)
+    expect((error as Error).message).toBe('incomplete stream: ollama ended without a terminal event')
     expect(events.map((e) => e.content)).toEqual(['a', 'b'])
   })
 
-  it('ends without throwing when the NDJSON body errors after yielding data', async () => {
+  it('propagates an NDJSON body error after yielding partial data (M3: swallow removed)', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => {
@@ -402,7 +408,7 @@ describe('OllamaProvider stream (native NDJSON adapter)', () => {
           events.push(e)
         }
       })(),
-    ).resolves.toBeUndefined()
+    ).rejects.toThrow('socket closed')
     expect(events).toEqual([{ content: 'partial', done: false, eventType: 'text' }])
   })
 })

--- a/sdks/typescript/tests/retry-conformance.test.ts
+++ b/sdks/typescript/tests/retry-conformance.test.ts
@@ -5,8 +5,8 @@
 // A failure means the implementation drifted from specs/retry.md — fix the
 // implementation (or the spec plus all three suites), never this file alone.
 import { describe, expect, it } from 'vitest'
-import { isRetryableStatus, parseRetryAfter } from '../src/error.js'
-import { RetryPolicy } from '../src/retry.js'
+import { CancelledError, isRetryableStatus, parseRetryAfter } from '../src/error.js'
+import { classifyForRetry, RetryPolicy } from '../src/retry.js'
 
 const RETRYABLE = [408, 409, 429, 500, 502, 503, 529, 599]
 const NON_RETRYABLE = [200, 301, 400, 401, 403, 404, 422, 499]
@@ -74,5 +74,25 @@ describe('specs/retry.md § backoff (full jitter)', () => {
     expect(policy.maxDelayMs).toBe(2000)
     expect(policy.jitter).toBe(true)
     expect(policy.respectRetryAfter).toBe(true)
+  })
+})
+
+describe('specs/retry.md § transport classification (M3 amendment)', () => {
+  // Coordination: the M3 spec task adds the CancelledError row to
+  // specs/retry.md's transport table; this TS suite is the ONLY conformance
+  // suite that changes — Rust (drop-based cancellation) and Python (asyncio
+  // CancelledError propagates untouched) had no classification change, so
+  // their suites need NO new row (Task 9 verifies exactly that).
+  it('CancelledError (caller-supplied signal aborted) is NEVER retryable', () => {
+    expect(classifyForRetry(new CancelledError()).retryable).toBe(false)
+  })
+
+  it('fetch-internal AbortError / TimeoutError (no caller signal) stay retryable', () => {
+    const abort = new Error('aborted')
+    abort.name = 'AbortError'
+    const timeout = new Error('timed out')
+    timeout.name = 'TimeoutError'
+    expect(classifyForRetry(abort).retryable).toBe(true)
+    expect(classifyForRetry(timeout).retryable).toBe(true)
   })
 })

--- a/sdks/typescript/tests/timeouts-cancellation.test.ts
+++ b/sdks/typescript/tests/timeouts-cancellation.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Client, ClientBuilder } from '../src/client.js'
+import { CancelledError, StreamReadTimeoutError } from '../src/error.js'
+import { readTimeoutStream } from '../src/provider.js'
+import { RetryPolicy } from '../src/retry.js'
+
+function immediateRetryPolicy(): RetryPolicy {
+  return new RetryPolicy({
+    maxRetries: 2,
+    baseDelayMs: 0,
+    maxDelayMs: 0,
+    jitter: false,
+    respectRetryAfter: false,
+  })
+}
+
+function anthropicPayload(text: string): string {
+  return JSON.stringify({
+    content: [{ type: 'text', text }],
+    model: 'claude-sonnet-4-6',
+    usage: { input_tokens: 1, output_tokens: 2 },
+    stop_reason: 'end_turn',
+  })
+}
+
+function abortError(): Error {
+  const error = new Error('This operation was aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+describe('E7: readTimeoutStream throws on idle expiry', () => {
+  it('throws StreamReadTimeoutError instead of ending silently', async () => {
+    const stalled = (async function* () {
+      await new Promise(() => {})
+      yield { content: 'never', done: false, eventType: 'text' as const }
+    })()
+
+    await expect(async () => {
+      for await (const _ of readTimeoutStream(stalled, 0.05)) void _
+    }).rejects.toThrow(StreamReadTimeoutError)
+  })
+
+  it('Client.stream applies readIdleMs by default and throws on a stalled provider', async () => {
+    const fakeProvider = {
+      capabilities: () => ({ supportsImage: false, supportsDocument: false, supportsMcp: false }),
+      async chat(): Promise<never> {
+        throw new Error('unused')
+      },
+      async *stream() {
+        yield { content: 'a', done: false, eventType: 'text' as const }
+        await new Promise(() => {})
+      },
+    }
+
+    const client = new Client(fakeProvider, { readIdleMs: 50 })
+    await expect(async () => {
+      for await (const _ of client.stream({ messages: [{ role: 'user', content: 'hi' }] })) void _
+    }).rejects.toThrow(StreamReadTimeoutError)
+  })
+})
+
+describe('E6/E4: per-request cancellation and timeout composition', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('caller abort mid-request throws CancelledError after exactly 1 fetch (never retried)', async () => {
+    const controller = new AbortController()
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        calls += 1
+        expect(init?.signal).toBeDefined()
+        controller.abort()
+        throw abortError()
+      }),
+    )
+
+    const client = new ClientBuilder()
+      .provider('anthropic')
+      .apiKey('test-key')
+      .retryPolicy(immediateRetryPolicy())
+      .build()
+
+    await expect(
+      client.chat({ messages: [{ role: 'user', content: 'hi' }] }, { signal: controller.signal }),
+    ).rejects.toThrow(CancelledError)
+    expect(calls).toBe(1)
+  })
+
+  it('AbortSignal.timeout expiry (no caller signal) stays retryable', async () => {
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1
+        if (calls === 1) {
+          const error = new Error('The operation was aborted due to timeout')
+          error.name = 'TimeoutError'
+          throw error
+        }
+        return new Response(anthropicPayload('ok'), { status: 200 })
+      }),
+    )
+
+    const client = new ClientBuilder()
+      .provider('anthropic')
+      .apiKey('test-key')
+      .retryPolicy(immediateRetryPolicy())
+      .timeouts({ totalMs: 5_000 })
+      .build()
+
+    const response = await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(response.content).toBe('ok')
+    expect(calls).toBe(2)
+  })
+
+  it('default timeouts never abort a slow-but-successful chat (50ms to headers)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        return new Response(anthropicPayload('ok'), { status: 200 })
+      }),
+    )
+    const client = new ClientBuilder().provider('anthropic').apiKey('test-key').build()
+    const response = await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(response.content).toBe('ok')
+  })
+
+  it('connect budget disarms at headers: a body slower than connectMs+readIdleMs still succeeds', async () => {
+    let capturedSignal: AbortSignal | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        capturedSignal = init?.signal ?? undefined
+        const body = new ReadableStream<Uint8Array>({
+          async start(c) {
+            await new Promise((resolve) => setTimeout(resolve, 80))
+            c.enqueue(new TextEncoder().encode(anthropicPayload('slow ok')))
+            c.close()
+          },
+        })
+        return new Response(body, { status: 200 })
+      }),
+    )
+
+    const client = new ClientBuilder()
+      .provider('anthropic')
+      .apiKey('test-key')
+      .retryPolicy(immediateRetryPolicy())
+      .timeouts({ connectMs: 10, readIdleMs: 20 })
+      .build()
+
+    const response = await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(response.content).toBe('slow ok')
+    expect(capturedSignal?.aborted).toBe(false)
+  })
+
+  it('caller abort mid-stream surfaces CancelledError, not a raw AbortError', async () => {
+    const controller = new AbortController()
+    const sse =
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n'
+    const body = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(sse))
+      },
+      pull() {
+        controller.abort()
+        throw abortError()
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } })),
+    )
+
+    const client = new ClientBuilder()
+      .provider('anthropic')
+      .apiKey('test-key')
+      .retryPolicy(immediateRetryPolicy())
+      .build()
+
+    await expect(async () => {
+      for await (const _ of client.stream(
+        { messages: [{ role: 'user', content: 'hi' }] },
+        { signal: controller.signal },
+      ))
+        void _
+    }).rejects.toThrow(CancelledError)
+  })
+})


### PR DESCRIPTION
## Summary
- Add TS IncompleteStreamError and enforce adapter EOF-without-terminal-event errors across HTTP stream providers.
- Add ClientBuilder.timeouts({ connectMs, readIdleMs, totalMs }), per-request AbortSignal cancellation, CancelledError retry classification, and throwing read-idle timeouts.
- Keep M3 flips scoped to the plan's TS flip list; CancelledError conformance row is TS-only.

M3 PR-T: docs/superpowers/plans/2026-07-16-stream-retry-m3-implementation.md

## Verification
- npm run typecheck && npm run build && npm test
- pre-push gate passed: Python unit, Rust unit, Python live Anthropic, Rust live Anthropic

PR-S/spec prerequisite is already merged (#227). Do not merge here; no tag or publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)