### PR TITLE
feat(python): stream termination and timeout lifecycle (M3 PR-P)

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `motosan-ai` Python SDK are documented in this file.
 
+## [Unreleased]
+
+### Breaking
+- **Streaming:** HTTP provider streams that end without the provider's terminal event (`message_stop` / `[DONE]`-or-`finish_reason` on the OpenAI wire / `finishReason` / `response.completed` / `{"done": true}`) now raise `IncompleteStreamError` instead of ending silently as if complete - truncation is no longer indistinguishable from completion. `IncompleteStreamError` subclasses `StreamError` deliberately (migration softener): existing `except StreamError` handlers keep catching it; catch `IncompleteStreamError` to handle truncation specifically. Not retried (mid-stream errors are never retried, per `specs/retry.md`). CLI providers unchanged - child-process death already raises `StreamError` (M1); child death is not HTTP truncation.
+- **OpenAI-wire streaming (openai, minimax):** per the amended terminal-event contract (`specs/types.md`), a stream completes on `data: [DONE]` OR a `finish_reason`-bearing chunk - either suffices (`finish_reason` is the semantic terminal, `[DONE]` the transport epilogue). openai stashes the finish_reason-derived `stop_reason` and emits it with the terminal done event at `[DONE]` or, failing that, at EOF; minimax emits its usual no-stop_reason done at EOF after a finish_reason chunk. Truncation with NEITHER signal raises `IncompleteStreamError`. Mirrors the Rust 0.24.0 adapter.
+
+### Added
+- Unified timeout model (E4): `Client(..., connect_timeout: float = 10.0, read_idle_timeout: float = 120.0, total_timeout: float | None = None)` threaded into every HTTP provider as `httpx.Timeout(connect=connect_timeout, read=read_idle_timeout, write=read_idle_timeout, pool=connect_timeout)`. `total_timeout` (opt-in) bounds `chat()`/`chat_with()` wall clock including retries; it never applies to streams.
+- `StreamReadTimeoutError` (`MotosanError` subclass; mirrors Rust `StreamReadTimeout` / TS `StreamReadTimeoutError`): a streaming body idle past `read_idle_timeout` raises it. Never retried - mid-stream retry would replay already-yielded deltas.
+- Client lifecycle (E8): `await client.aclose()` and `async with Client(...) as client:`; every provider gains `aclose()` (no-op for CLI providers).
+- `cli_timeout` facade kwarg (keyword-only on `Client`; trailing parameter on `Client.codex_cli()`/`Client.gemini_cli()` - pass it by keyword): threads to `CodexCliClient`/`GeminiCliClient` `.timeout()`; `cli_timeout=None` maps to `.no_timeout()`.
+
+### Changed
+- **MiniMax timeout unified**: the hardcoded `httpx.AsyncClient(timeout=30)` outlier now uses the shared model (connect 10s, read/write 120s) - requests that previously failed at 30s idle now wait 120s.
+- Default connect timeout tightened from 120s (blanket `timeout=120.0`) to 10s across all HTTP providers.
+- A streaming-phase `httpx.ReadTimeout` now raises `StreamReadTimeoutError` instead of `StreamError("stream transport error: ...")` (anthropic/openai/gemini/gemini_code_assist/chatgpt_codex) or `NetworkError`/`StreamError` (minimax/ollama).
+- Non-2xx error-body reads in `stream()` now sit inside the same ReadTimeout-mapping/cleanup scope as the SSE loop. gemini previously ran `await resp.aread()` before its `try`/`finally` - a `ReadTimeout` there escaped as a raw httpx exception and the response was never closed on error statuses (leak now fixed); gemini_code_assist/chatgpt_codex ran it outside the inner catch chain (raw `ReadTimeout` escaped, response was closed). All three now raise `StreamReadTimeoutError` and always close the response.
+
 ## [0.16.0] - 2026-07-16
 
 ### Added

--- a/sdks/python/motosan_ai/__init__.py
+++ b/sdks/python/motosan_ai/__init__.py
@@ -4,12 +4,14 @@ from motosan_ai.client import Client, Provider
 from motosan_ai.error import (
     AuthError,
     ConfigError,
+    IncompleteStreamError,
     InvalidRequestError,
     MotosanError,
     NetworkError,
     ProviderError,
     RateLimitError,
     StreamError,
+    StreamReadTimeoutError,
 )
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
 from motosan_ai.providers import (
@@ -79,6 +81,7 @@ __all__ = [
     "ImageSource",
     "ImageSourceBase64",
     "ImageSourceUrl",
+    "IncompleteStreamError",
     "InvalidRequestError",
     "LocalProvider",
     "McpServerConfig",
@@ -99,6 +102,7 @@ __all__ = [
     "StreamError",
     "StreamEvent",
     "StreamEventType",
+    "StreamReadTimeoutError",
     "SystemBlock",
     "TextBlock",
     "ThinkingConfig",

--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import AsyncIterator, Iterable
 from dataclasses import replace
 from enum import StrEnum
+from types import TracebackType
 from typing import Any
 
 from motosan_ai.error import ConfigError, MotosanError, NetworkError, ProviderError, RateLimitError
@@ -24,6 +25,10 @@ from motosan_ai.think_stripper import ThinkStripper
 from motosan_ai.types import ChatRequest, ChatResponse, Message, StreamEvent, Tool
 
 logger = logging.getLogger(__name__)
+
+# cli_timeout sentinel: distinguishes "not passed" (keep the CLI provider's
+# default) from cli_timeout=None (which maps to .no_timeout()).
+_UNSET_CLI_TIMEOUT: Any = object()
 
 
 class Provider(StrEnum):
@@ -74,6 +79,10 @@ class Client:
         ollama_num_ctx: int | None = None,
         max_retries: int = 3,
         retry_policy: RetryPolicy | None = None,
+        connect_timeout: float = 10.0,
+        read_idle_timeout: float = 120.0,
+        total_timeout: float | None = None,
+        cli_timeout: float | None = _UNSET_CLI_TIMEOUT,
     ) -> None:
         provider_value = Provider(provider)
         self.provider = provider_value
@@ -82,6 +91,7 @@ class Client:
             retry_policy if retry_policy is not None else RetryPolicy(max_retries=max_retries)
         )
         self._max_retries = self._retry_policy.max_retries
+        self._total_timeout = total_timeout
 
         if provider_value == Provider.gemini_code_assist:
             if not access_token:
@@ -94,6 +104,8 @@ class Client:
                 project_id=project_id,
                 model=model,
                 base_url=base_url,
+                connect_timeout=connect_timeout,
+                read_idle_timeout=read_idle_timeout,
             )
         elif provider_value == Provider.openai_chatgpt:
             if not access_token:
@@ -106,13 +118,19 @@ class Client:
                 account_id=account_id,
                 model=model,
                 base_url=base_url,
+                connect_timeout=connect_timeout,
+                read_idle_timeout=read_idle_timeout,
             ).reasoning_effort(reasoning_effort)
         elif provider_value == Provider.codex_cli:
             self.api_key = ""
-            self._provider = CodexCliClient(binary_path=binary_path)
+            self._provider = self._apply_cli_timeout(
+                CodexCliClient(binary_path=binary_path), cli_timeout
+            )
         elif provider_value == Provider.gemini_cli:
             self.api_key = ""
-            self._provider = GeminiCliClient(binary_path=binary_path)
+            self._provider = self._apply_cli_timeout(
+                GeminiCliClient(binary_path=binary_path), cli_timeout
+            )
         elif provider_value == Provider.ollama:
             self.api_key = api_key or ""
             if ollama_native:
@@ -124,12 +142,16 @@ class Client:
                     think=ollama_think,
                     keep_alive=ollama_keep_alive,
                     num_ctx=ollama_num_ctx,
+                    connect_timeout=connect_timeout,
+                    read_idle_timeout=read_idle_timeout,
                 )
             else:
                 self._provider = OpenAIProvider(
                     api_key=self.api_key,
                     model=model or "llama3.2",
                     base_url=base_url or "http://localhost:11434/v1",
+                    connect_timeout=connect_timeout,
+                    read_idle_timeout=read_idle_timeout,
                 )
         else:
             self.api_key = api_key or self._load_api_key(provider_value)
@@ -137,18 +159,35 @@ class Client:
                 raise ConfigError(f"Missing API key for provider: {provider_value.value}")
 
             if provider_value == Provider.anthropic:
-                self._provider = AnthropicProvider(api_key=self.api_key, model=model)
+                self._provider = AnthropicProvider(
+                    api_key=self.api_key,
+                    model=model,
+                    connect_timeout=connect_timeout,
+                    read_idle_timeout=read_idle_timeout,
+                )
             elif provider_value == Provider.openai:
                 self._provider = OpenAIProvider(
-                    api_key=self.api_key, model=model, base_url=base_url
+                    api_key=self.api_key,
+                    model=model,
+                    base_url=base_url,
+                    connect_timeout=connect_timeout,
+                    read_idle_timeout=read_idle_timeout,
                 )
             elif provider_value == Provider.gemini:
                 self._provider = GeminiProvider(
-                    api_key=self.api_key, model=model, base_url=base_url
+                    api_key=self.api_key,
+                    model=model,
+                    base_url=base_url,
+                    connect_timeout=connect_timeout,
+                    read_idle_timeout=read_idle_timeout,
                 )
             else:
                 self._provider = MinimaxProvider(
-                    api_key=self.api_key, model=model, base_url=base_url
+                    api_key=self.api_key,
+                    model=model,
+                    base_url=base_url,
+                    connect_timeout=connect_timeout,
+                    read_idle_timeout=read_idle_timeout,
                 )
 
     @classmethod
@@ -268,6 +307,7 @@ class Client:
         model: str | None = None,
         max_retries: int = 3,
         retry_policy: RetryPolicy | None = None,
+        cli_timeout: float | None = _UNSET_CLI_TIMEOUT,
     ) -> Client:
         return cls(
             provider=Provider.codex_cli,
@@ -275,6 +315,7 @@ class Client:
             model=model,
             max_retries=max_retries,
             retry_policy=retry_policy,
+            cli_timeout=cli_timeout,
         )
 
     @classmethod
@@ -284,6 +325,7 @@ class Client:
         model: str | None = None,
         max_retries: int = 3,
         retry_policy: RetryPolicy | None = None,
+        cli_timeout: float | None = _UNSET_CLI_TIMEOUT,
     ) -> Client:
         return cls(
             provider=Provider.gemini_cli,
@@ -291,6 +333,7 @@ class Client:
             model=model,
             max_retries=max_retries,
             retry_policy=retry_policy,
+            cli_timeout=cli_timeout,
         )
 
     @classmethod
@@ -328,6 +371,32 @@ class Client:
         }
         return os.getenv(env_map[provider])
 
+    @staticmethod
+    def _apply_cli_timeout(
+        cli: CodexCliClient | GeminiCliClient,
+        cli_timeout: float | None,
+    ) -> CodexCliClient | GeminiCliClient:
+        if cli_timeout is _UNSET_CLI_TIMEOUT:
+            return cli
+        if cli_timeout is None:
+            return cli.no_timeout()
+        return cli.timeout(cli_timeout)
+
+    async def aclose(self) -> None:
+        """Close the provider's underlying connection pool (idempotent)."""
+        await self._provider.aclose()
+
+    async def __aenter__(self) -> Client:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.aclose()
+
     def _build_request(
         self,
         messages: Iterable[Message | dict[str, Any]],
@@ -355,10 +424,21 @@ class Client:
         Use this when you need fields that ``chat()`` kwargs do not expose,
         such as tool_choice, thinking, mcp_servers, system_blocks, or
         stop_sequences. If ``request.model`` is None, ``self.model`` is used.
+        ``total_timeout`` bounds blocking calls like this one and ``chat()``
+        (retries included), never stream consumption; ``None`` disables it.
         """
         if request.model is None and self.model is not None:
             request = replace(request, model=self.model)
 
+        if self._total_timeout is None:
+            return await self._dispatch_chat(request)
+        try:
+            async with asyncio.timeout(self._total_timeout):
+                return await self._dispatch_chat(request)
+        except TimeoutError as exc:
+            raise NetworkError(f"total timeout of {self._total_timeout}s exceeded") from exc
+
+    async def _dispatch_chat(self, request: ChatRequest) -> ChatResponse:
         if self._retry_policy.max_retries > 0:
             from motosan_ai.retry import with_retry
 

--- a/sdks/python/motosan_ai/error.py
+++ b/sdks/python/motosan_ai/error.py
@@ -39,3 +39,23 @@ class NetworkError(MotosanError):
 
 class StreamError(MotosanError):
     pass
+
+
+class IncompleteStreamError(StreamError):
+    """The upstream ended without the provider's terminal event.
+
+    Deliberately subclasses StreamError as a migration softener: existing
+    ``except StreamError`` handlers keep catching truncation; catch this type
+    to handle truncation specifically. Message convention:
+    ``"incomplete stream: <provider> ended without a terminal event"``.
+    """
+
+
+class StreamReadTimeoutError(MotosanError):
+    """A streaming response body went idle past ``read_idle_timeout``.
+
+    Raised after response headers arrive when no bytes show up within the
+    idle window. Deliberately not a NetworkError: it is never retried -
+    mid-stream, a retry would replay already-yielded deltas. Mirrors Rust
+    ``StreamReadTimeout`` / TS ``StreamReadTimeoutError``.
+    """

--- a/sdks/python/motosan_ai/providers/anthropic.py
+++ b/sdks/python/motosan_ai/providers/anthropic.py
@@ -7,7 +7,15 @@ from typing import Any
 import httpx
 
 from motosan_ai._stream_collect import collect_stream
-from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
+from motosan_ai.error import (
+    AuthError,
+    IncompleteStreamError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    StreamError,
+    StreamReadTimeoutError,
+)
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
 from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
@@ -94,12 +102,27 @@ class AnthropicProvider(BaseProvider):
         api_key: str,
         model: str | None = None,
         base_url: str | None = None,
+        *,
+        connect_timeout: float = 10.0,
+        read_idle_timeout: float = 120.0,
     ) -> None:
         self.api_key = api_key
         self.model = model or "claude-sonnet-4-6"
         self.base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
         self._is_oauth = api_key.startswith("sk-ant-oat01-")
-        self._http = httpx.AsyncClient(timeout=120.0)
+        self._read_idle_timeout = read_idle_timeout
+        self._http = httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=connect_timeout,
+                read=read_idle_timeout,
+                write=read_idle_timeout,
+                pool=connect_timeout,
+            )
+        )
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._http.aclose()
 
     def _endpoint(self) -> str:
         return f"{self.base_url}/v1/messages"
@@ -512,10 +535,18 @@ class AnthropicProvider(BaseProvider):
                 elif event_type == "message_stop":
                     yield StreamEvent(content="", done=True, stop_reason=current_stop_reason)
                     return
+
+            raise IncompleteStreamError(
+                "incomplete stream: anthropic ended without a terminal event"
+            )
         except StreamError:
             raise
         except (AuthError, RateLimitError, ProviderError, NetworkError):
             raise
+        except httpx.ReadTimeout as exc:
+            raise StreamReadTimeoutError(
+                f"stream read timed out after {self._read_idle_timeout}s"
+            ) from exc
         except httpx.HTTPError as exc:
             raise StreamError(f"stream transport error: {exc}") from exc
         finally:

--- a/sdks/python/motosan_ai/providers/chatgpt_codex.py
+++ b/sdks/python/motosan_ai/providers/chatgpt_codex.py
@@ -10,10 +10,12 @@ import httpx
 from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import (
     AuthError,
+    IncompleteStreamError,
     NetworkError,
     ProviderError,
     RateLimitError,
     StreamError,
+    StreamReadTimeoutError,
 )
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
 from motosan_ai.retry import parse_retry_after_header
@@ -195,13 +197,28 @@ class ChatGptCodexProvider(BaseProvider):
         account_id: str,
         model: str | None = None,
         base_url: str | None = None,
+        *,
+        connect_timeout: float = 10.0,
+        read_idle_timeout: float = 120.0,
     ) -> None:
         self.access_token = access_token
         self.account_id = account_id
         self.model = model or _DEFAULT_MODEL
         self.base_url = base_url or _DEFAULT_BASE_URL
         self._reasoning_effort: str | None = None
-        self._http = httpx.AsyncClient(timeout=120.0)
+        self._read_idle_timeout = read_idle_timeout
+        self._http = httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=connect_timeout,
+                read=read_idle_timeout,
+                write=read_idle_timeout,
+                pool=connect_timeout,
+            )
+        )
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._http.aclose()
 
     def reasoning_effort(self, effort: str | None) -> ChatGptCodexProvider:
         """Set the default reasoning effort emitted as ``reasoning.effort``.
@@ -378,10 +395,22 @@ class ChatGptCodexProvider(BaseProvider):
                             return
                     if state.error is not None:
                         raise StreamError(state.error)
+
+                raise IncompleteStreamError(
+                    "incomplete stream: chatgpt_codex ended without a terminal event"
+                )
             except (StreamError, AuthError, RateLimitError, ProviderError, NetworkError):
                 raise
+            except httpx.ReadTimeout as exc:
+                raise StreamReadTimeoutError(
+                    f"stream read timed out after {self._read_idle_timeout}s"
+                ) from exc
             except httpx.HTTPError as exc:
                 raise StreamError(f"stream transport error: {exc}") from exc
+        except httpx.ReadTimeout as exc:
+            raise StreamReadTimeoutError(
+                f"stream read timed out after {self._read_idle_timeout}s"
+            ) from exc
         finally:
             await resp.aclose()
 

--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -416,6 +416,10 @@ class ClaudeCodeClient:
         self._config.timeout_secs = None
         return self
 
+    async def aclose(self) -> None:
+        """No-op: CLI providers spawn a subprocess per call and hold no pool."""
+        return None
+
     def _subprocess_env(self) -> dict[str, str] | None:
         """Child env: a copy of os.environ overlaid with injected vars.
 

--- a/sdks/python/motosan_ai/providers/codex_cli.py
+++ b/sdks/python/motosan_ai/providers/codex_cli.py
@@ -299,6 +299,10 @@ class CodexCliClient:
         self._config.timeout_secs = None
         return self
 
+    async def aclose(self) -> None:
+        """No-op: CLI providers spawn a subprocess per call and hold no pool."""
+        return None
+
     def _subprocess_env(self) -> dict[str, str] | None:
         if not self._config.envs:
             return None

--- a/sdks/python/motosan_ai/providers/gemini.py
+++ b/sdks/python/motosan_ai/providers/gemini.py
@@ -7,7 +7,15 @@ from typing import Any
 
 import httpx
 
-from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
+from motosan_ai.error import (
+    AuthError,
+    IncompleteStreamError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    StreamError,
+    StreamReadTimeoutError,
+)
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
 from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
@@ -174,11 +182,26 @@ class GeminiProvider(BaseProvider):
         api_key: str,
         model: str | None = None,
         base_url: str | None = None,
+        *,
+        connect_timeout: float = 10.0,
+        read_idle_timeout: float = 120.0,
     ) -> None:
         self.api_key = api_key
         self.model = model or _DEFAULT_MODEL
         self.base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
-        self._http = httpx.AsyncClient(timeout=120.0)
+        self._read_idle_timeout = read_idle_timeout
+        self._http = httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=connect_timeout,
+                read=read_idle_timeout,
+                write=read_idle_timeout,
+                pool=connect_timeout,
+            )
+        )
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._http.aclose()
 
     def _model_for(self, request: ChatRequest) -> str:
         return request.model or self.model
@@ -278,14 +301,15 @@ class GeminiProvider(BaseProvider):
             )
         except httpx.HTTPError as exc:
             raise NetworkError(str(exc)) from exc
-        if not resp.is_success:
-            error_body = await resp.aread()
-            message = self._response_error_message(
-                resp.status_code, resp.headers, error_body.decode()
-            )
-            raise self._map_http_error(resp.status_code, message, resp.headers)
 
         try:
+            if not resp.is_success:
+                error_body = await resp.aread()
+                message = self._response_error_message(
+                    resp.status_code, resp.headers, error_body.decode()
+                )
+                raise self._map_http_error(resp.status_code, message, resp.headers)
+
             async for line in resp.aiter_lines():
                 if not line.startswith("data: "):
                     continue
@@ -349,10 +373,16 @@ class GeminiProvider(BaseProvider):
                         stop_reason=_stop_reason_for(finish_reason, has_tool_calls),
                     )
                     return
+
+            raise IncompleteStreamError("incomplete stream: gemini ended without a terminal event")
         except StreamError:
             raise
         except (AuthError, RateLimitError, ProviderError, NetworkError):
             raise
+        except httpx.ReadTimeout as exc:
+            raise StreamReadTimeoutError(
+                f"stream read timed out after {self._read_idle_timeout}s"
+            ) from exc
         except httpx.HTTPError as exc:
             raise StreamError(f"stream transport error: {exc}") from exc
         finally:

--- a/sdks/python/motosan_ai/providers/gemini_cli.py
+++ b/sdks/python/motosan_ai/providers/gemini_cli.py
@@ -274,6 +274,10 @@ class GeminiCliClient:
         self._config.timeout_secs = None
         return self
 
+    async def aclose(self) -> None:
+        """No-op: CLI providers spawn a subprocess per call and hold no pool."""
+        return None
+
     def _child_env(self) -> dict[str, str] | None:
         if len(self._config.envs) == 0:
             return None

--- a/sdks/python/motosan_ai/providers/gemini_code_assist.py
+++ b/sdks/python/motosan_ai/providers/gemini_code_assist.py
@@ -10,7 +10,15 @@ from typing import Any
 import httpx
 
 from motosan_ai._stream_collect import collect_stream
-from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
+from motosan_ai.error import (
+    AuthError,
+    IncompleteStreamError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    StreamError,
+    StreamReadTimeoutError,
+)
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
 from motosan_ai.providers.gemini import build_gemini_body
 from motosan_ai.retry import parse_retry_after_header
@@ -166,12 +174,27 @@ class GeminiCodeAssistProvider(BaseProvider):
         project_id: str,
         model: str | None = None,
         base_url: str | None = None,
+        *,
+        connect_timeout: float = 10.0,
+        read_idle_timeout: float = 120.0,
     ) -> None:
         self.access_token = access_token
         self.project_id = project_id
         self.model = model or _DEFAULT_MODEL
         self.base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
-        self._http = httpx.AsyncClient(timeout=120.0)
+        self._read_idle_timeout = read_idle_timeout
+        self._http = httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=connect_timeout,
+                read=read_idle_timeout,
+                write=read_idle_timeout,
+                pool=connect_timeout,
+            )
+        )
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._http.aclose()
 
     def _stream_url(self) -> str:
         return f"{self.base_url}/v1internal:streamGenerateContent?alt=sse"
@@ -234,10 +257,22 @@ class GeminiCodeAssistProvider(BaseProvider):
                         yield event
                         if event.done:
                             return
+
+                raise IncompleteStreamError(
+                    "incomplete stream: gemini_code_assist ended without a terminal event"
+                )
             except (StreamError, AuthError, RateLimitError, ProviderError, NetworkError):
                 raise
+            except httpx.ReadTimeout as exc:
+                raise StreamReadTimeoutError(
+                    f"stream read timed out after {self._read_idle_timeout}s"
+                ) from exc
             except httpx.HTTPError as exc:
                 raise StreamError(f"stream transport error: {exc}") from exc
+        except httpx.ReadTimeout as exc:
+            raise StreamReadTimeoutError(
+                f"stream read timed out after {self._read_idle_timeout}s"
+            ) from exc
         finally:
             await resp.aclose()
 

--- a/sdks/python/motosan_ai/providers/minimax.py
+++ b/sdks/python/motosan_ai/providers/minimax.py
@@ -8,11 +8,13 @@ import httpx
 
 from motosan_ai.error import (
     AuthError,
+    IncompleteStreamError,
     InvalidRequestError,
     NetworkError,
     ProviderError,
     RateLimitError,
     StreamError,
+    StreamReadTimeoutError,
 )
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.retry import parse_retry_after_header
@@ -40,11 +42,31 @@ def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, 
 class MinimaxProvider:
     capabilities: ProviderCapabilities = ProviderCapabilities.with_image()
 
-    def __init__(self, api_key: str, model: str | None = None, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str,
+        model: str | None = None,
+        base_url: str | None = None,
+        *,
+        connect_timeout: float = 10.0,
+        read_idle_timeout: float = 120.0,
+    ) -> None:
         self.api_key = api_key
         self.model = model or "MiniMax-Text-01"
         self.base_url = (base_url or "https://api.minimax.chat").rstrip("/")
-        self._client = httpx.AsyncClient(timeout=30)
+        self._read_idle_timeout = read_idle_timeout
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=connect_timeout,
+                read=read_idle_timeout,
+                write=read_idle_timeout,
+                pool=connect_timeout,
+            )
+        )
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._client.aclose()
 
     def _endpoint(self) -> str:
         return f"{self.base_url}/v1/text/chatcompletion_v2"
@@ -241,6 +263,10 @@ class MinimaxProvider:
                         message = f"Retry-After: {retry_after}\n{message}"
                     self._raise_for_status(response.status_code, message, response.headers)
 
+                # M3 (amended): any finish_reason chunk marks the stream
+                # semantically complete (either-suffices terminal rule).
+                saw_finish_reason = False
+
                 async for line in response.aiter_lines():
                     if not line.startswith("data:"):
                         continue
@@ -286,11 +312,28 @@ class MinimaxProvider:
                             )
 
                     finish_reason = choice.get("finish_reason")
-                    if finish_reason == "tool_calls":
-                        yielded = True
-                        yield StreamEvent(content="", done=False, event_type="tool_call_end")
+                    if finish_reason:
+                        saw_finish_reason = True
+                        if finish_reason == "tool_calls":
+                            yielded = True
+                            yield StreamEvent(content="", done=False, event_type="tool_call_end")
+
+                if saw_finish_reason:
+                    # Semantic terminal seen: emit the same no-stop_reason done
+                    # event as the [DONE] branch; collect_stream fills it.
+                    yielded = True
+                    yield StreamEvent(content="", done=True)
+                    return
+
+                raise IncompleteStreamError(
+                    "incomplete stream: minimax ended without a terminal event"
+                )
         except (AuthError, RateLimitError, InvalidRequestError, ProviderError, StreamError):
             raise
+        except httpx.ReadTimeout as exc:
+            raise StreamReadTimeoutError(
+                f"stream read timed out after {self._read_idle_timeout}s"
+            ) from exc
         except httpx.HTTPError as exc:
             if yielded:
                 raise StreamError(f"stream transport error: {exc}") from exc

--- a/sdks/python/motosan_ai/providers/ollama.py
+++ b/sdks/python/motosan_ai/providers/ollama.py
@@ -7,7 +7,13 @@ from typing import Any
 
 import httpx
 
-from motosan_ai.error import NetworkError, ProviderError, StreamError
+from motosan_ai.error import (
+    IncompleteStreamError,
+    NetworkError,
+    ProviderError,
+    StreamError,
+    StreamReadTimeoutError,
+)
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
@@ -41,13 +47,28 @@ class OllamaProvider:
         think: bool = False,
         keep_alive: str | None = None,
         num_ctx: int | None = None,
+        *,
+        connect_timeout: float = 10.0,
+        read_idle_timeout: float = 120.0,
     ) -> None:
         self.model = model
         self.base_url = base_url.rstrip("/")
         self.think = think
         self.keep_alive = keep_alive
         self.num_ctx = num_ctx
-        self._http = httpx.AsyncClient(timeout=120.0)
+        self._read_idle_timeout = read_idle_timeout
+        self._http = httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=connect_timeout,
+                read=read_idle_timeout,
+                write=read_idle_timeout,
+                pool=connect_timeout,
+            )
+        )
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._http.aclose()
 
     @staticmethod
     def _serialize_messages(
@@ -224,8 +245,16 @@ class OllamaProvider:
                             tool_call_id=tc_id,
                             event_type="tool_call_end",
                         )
+
+                raise IncompleteStreamError(
+                    "incomplete stream: ollama ended without a terminal event"
+                )
         except (ProviderError, StreamError):
             raise
+        except httpx.ReadTimeout as exc:
+            raise StreamReadTimeoutError(
+                f"stream read timed out after {self._read_idle_timeout}s"
+            ) from exc
         except httpx.HTTPError as exc:
             if yielded:
                 raise StreamError(f"stream transport error: {exc}") from exc

--- a/sdks/python/motosan_ai/providers/openai.py
+++ b/sdks/python/motosan_ai/providers/openai.py
@@ -6,7 +6,15 @@ from typing import Any
 
 import httpx
 
-from motosan_ai.error import AuthError, NetworkError, ProviderError, RateLimitError, StreamError
+from motosan_ai.error import (
+    AuthError,
+    IncompleteStreamError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    StreamError,
+    StreamReadTimeoutError,
+)
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
@@ -45,11 +53,31 @@ def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, 
 class OpenAIProvider:
     capabilities: ProviderCapabilities = ProviderCapabilities.with_image()
 
-    def __init__(self, api_key: str, model: str | None = None, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str,
+        model: str | None = None,
+        base_url: str | None = None,
+        *,
+        connect_timeout: float = 10.0,
+        read_idle_timeout: float = 120.0,
+    ) -> None:
         self.api_key = api_key
         self.model = model or "gpt-4o"
         self.base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
-        self._http = httpx.AsyncClient(timeout=120.0)
+        self._read_idle_timeout = read_idle_timeout
+        self._http = httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=connect_timeout,
+                read=read_idle_timeout,
+                write=read_idle_timeout,
+                pool=connect_timeout,
+            )
+        )
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._http.aclose()
 
     def _endpoint(self) -> str:
         return f"{self.base_url}/v1/chat/completions"
@@ -245,6 +273,9 @@ class OpenAIProvider:
             # index -> (id, name); only one tool call is open at a time.
             tool_buffer: dict[int, tuple[str, str]] = {}
             open_tool_index: int | None = None
+            # M3 (amended): stop_reason is stashed from finish_reason chunks,
+            # the semantic terminal, then emitted with done at [DONE] or EOF.
+            current_stop_reason: StopReason | None = None
 
             async for line in resp.aiter_lines():
                 if not line.startswith("data: "):
@@ -260,7 +291,7 @@ class OpenAIProvider:
                                 event_type="tool_call_end",
                             )
                             open_tool_index = None
-                        yield StreamEvent(content="", done=True)
+                        yield StreamEvent(content="", done=True, stop_reason=current_stop_reason)
                         return
                     continue
                 try:
@@ -320,16 +351,26 @@ class OpenAIProvider:
                                 event_type="tool_call_end",
                             )
                             open_tool_index = None
-                        yield StreamEvent(
-                            content="",
-                            done=True,
-                            stop_reason=_FINISH_REASON_TO_STOP.get(finish_reason, StopReason.other),
+                        # Semantic terminal: stash; [DONE] or EOF emits it.
+                        current_stop_reason = _FINISH_REASON_TO_STOP.get(
+                            finish_reason, StopReason.other
                         )
-                        return
+
+            if current_stop_reason is not None:
+                # finish_reason arrived: the stream is semantically complete
+                # even if the [DONE] transport epilogue never arrived.
+                yield StreamEvent(content="", done=True, stop_reason=current_stop_reason)
+                return
+
+            raise IncompleteStreamError("incomplete stream: openai ended without a terminal event")
         except StreamError:
             raise
         except (AuthError, RateLimitError, ProviderError, NetworkError):
             raise
+        except httpx.ReadTimeout as exc:
+            raise StreamReadTimeoutError(
+                f"stream read timed out after {self._read_idle_timeout}s"
+            ) from exc
         except httpx.HTTPError as exc:
             raise StreamError(f"stream transport error: {exc}") from exc
         finally:

--- a/sdks/python/tests/test_client_timeouts.py
+++ b/sdks/python/tests/test_client_timeouts.py
@@ -1,0 +1,154 @@
+"""E4+E8 (M3): unified timeout model, StreamReadTimeoutError, client lifecycle."""
+
+import asyncio
+
+import httpx
+import pytest
+import respx
+
+from motosan_ai import Client, Message, Provider
+from motosan_ai.error import NetworkError, StreamReadTimeoutError
+from motosan_ai.providers import (
+    ChatGptCodexProvider,
+    GeminiCodeAssistProvider,
+    GeminiProvider,
+    OpenAIProvider,
+)
+from motosan_ai.retry import RetryPolicy
+from motosan_ai.types import ChatRequest, ChatResponse, StopReason, StreamEvent, Usage
+
+_OPENAI_URL = "https://api.openai.com/v1/chat/completions"
+
+
+class _TimeoutAfterChunks(httpx.AsyncByteStream):
+    """Yield the given chunks, then raise httpx.ReadTimeout (idle expiry)."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+        raise httpx.ReadTimeout("read timed out")
+
+
+def test_provider_timeout_kwargs_map_to_httpx_timeout():
+    provider = OpenAIProvider(api_key="k", connect_timeout=1.5, read_idle_timeout=3.0)
+    assert provider._http.timeout == httpx.Timeout(connect=1.5, read=3.0, write=3.0, pool=1.5)
+
+
+def test_minimax_30s_outlier_is_unified(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "m")
+    client = Client(Provider.minimax)
+    assert client._provider._client.timeout == httpx.Timeout(
+        connect=10.0, read=120.0, write=120.0, pool=10.0
+    )
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_mid_stream_read_timeout_is_distinct_and_never_retried(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    chunk = b'data: {"choices":[{"delta":{"content":"hello-world-after-buffer"}}]}\n\n'
+    route = respx.post(_OPENAI_URL).mock(
+        return_value=httpx.Response(
+            200,
+            stream=_TimeoutAfterChunks([chunk]),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+    client = Client(Provider.openai, retry_policy=RetryPolicy(max_retries=3, base_delay=0.001))
+    seen = []
+    with pytest.raises(StreamReadTimeoutError, match="stream read timed out after 120"):
+        async for event in client.stream([Message.user("hi")]):
+            seen.append(event)
+    assert "hello-world" in "".join(e.content for e in seen)
+    assert route.call_count == 1
+
+
+# Providers whose non-2xx error-body ``await resp.aread()`` sat outside the
+# ReadTimeout-mapping scope at baseline.
+_ERROR_BODY_TIMEOUT_CASES = [
+    pytest.param(
+        lambda: GeminiProvider(api_key="k"),
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+        id="gemini",
+    ),
+    pytest.param(
+        lambda: GeminiCodeAssistProvider("ya29.fake", "myproj"),
+        "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+        id="gemini_code_assist",
+    ),
+    pytest.param(
+        lambda: ChatGptCodexProvider("tok", "acct-123", "gpt-5.5", None),
+        "https://chatgpt.com/backend-api/codex/responses",
+        id="chatgpt_codex",
+    ),
+]
+
+
+@respx.mock
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("make_provider", "url"), _ERROR_BODY_TIMEOUT_CASES)
+async def test_non_2xx_error_body_read_timeout_maps_to_stream_read_timeout(make_provider, url):
+    respx.post(url).mock(return_value=httpx.Response(500, stream=_TimeoutAfterChunks([b"boom"])))
+    with pytest.raises(StreamReadTimeoutError, match="stream read timed out after 120"):
+        async for _ in make_provider().stream(ChatRequest(messages=[Message.user("hi")])):
+            pass
+
+
+class _SlowProvider:
+    async def chat(self, request):
+        await asyncio.sleep(0.5)
+        return ChatResponse(content="late", usage=Usage(1, 1), stop_reason=StopReason.stop)
+
+    async def stream(self, request):
+        await asyncio.sleep(0.1)
+        yield StreamEvent(content="slow", done=False)
+        yield StreamEvent(content="", done=True)
+
+    async def aclose(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_total_timeout_bounds_chat(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    client = Client(Provider.openai, total_timeout=0.05)
+    client._provider = _SlowProvider()
+    with pytest.raises(NetworkError, match="total timeout of 0.05s exceeded"):
+        await client.chat([Message.user("hi")])
+
+
+@pytest.mark.asyncio
+async def test_total_timeout_never_applies_to_streams(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    client = Client(Provider.openai, total_timeout=0.05)
+    client._provider = _SlowProvider()
+    events = [e async for e in client.stream([Message.user("hi")])]
+    assert [e.content for e in events] == ["slow", ""]
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_provider_pool(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    client = Client(Provider.openai)
+    assert client._provider._http.is_closed is False
+    await client.aclose()
+    assert client._provider._http.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_round_trip(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    async with Client(Provider.anthropic) as client:
+        assert client._provider._http.is_closed is False
+    assert client._provider._http.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_cli_timeout_threading():
+    assert Client(Provider.codex_cli, cli_timeout=60.0)._provider._config.timeout_secs == 60.0
+    assert Client(Provider.gemini_cli, cli_timeout=None)._provider._config.timeout_secs is None
+    assert Client(Provider.codex_cli)._provider._config.timeout_secs == 600.0
+    await Client(Provider.gemini_cli).aclose()

--- a/sdks/python/tests/test_incomplete_stream.py
+++ b/sdks/python/tests/test_incomplete_stream.py
@@ -1,0 +1,218 @@
+"""M3 stream-termination contract: EOF without the provider terminal event.
+
+Every HTTP provider stream() must raise IncompleteStreamError (a StreamError
+subclass - deliberate migration softener so existing ``except StreamError``
+handlers keep catching truncation) when the upstream body ends without that
+provider's terminal event. OpenAI wire (openai, minimax): [DONE] or a
+finish_reason-bearing chunk - either suffices (amended 2026-07-17), so only
+EOF with NEITHER signal raises. CLI providers are intentionally not covered:
+since M1 they raise StreamError with returncode/stderr on child-process death.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from motosan_ai._stream_collect import collect_stream
+from motosan_ai.error import IncompleteStreamError, StreamError
+from motosan_ai.providers.anthropic import AnthropicProvider
+from motosan_ai.providers.chatgpt_codex import ChatGptCodexProvider
+from motosan_ai.providers.gemini import GeminiProvider
+from motosan_ai.providers.gemini_code_assist import GeminiCodeAssistProvider
+from motosan_ai.providers.minimax import MinimaxProvider
+from motosan_ai.providers.ollama import OllamaProvider
+from motosan_ai.providers.openai import OpenAIProvider
+from motosan_ai.types import ChatRequest, Message, StopReason, StreamEvent
+
+
+def _sse(*events: dict) -> str:
+    return "\n".join(f"data: {json.dumps(e)}" for e in events) + "\n"
+
+
+# Each case: provider factory, mocked endpoint, body ending after one text
+# delta with NO terminal frame, and the <provider> token in the message.
+_TRUNCATED = [
+    pytest.param(
+        lambda: AnthropicProvider("test-key", base_url="https://mock.anthropic.com"),
+        "https://mock.anthropic.com/v1/messages",
+        _sse(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "par"},
+            }
+        ),
+        "anthropic",
+        id="anthropic",
+    ),
+    pytest.param(
+        lambda: OpenAIProvider("test-key", base_url="https://mock.openai.com"),
+        "https://mock.openai.com/v1/chat/completions",
+        _sse({"choices": [{"delta": {"content": "par"}, "finish_reason": None}]}),
+        "openai",
+        id="openai",
+    ),
+    pytest.param(
+        lambda: MinimaxProvider("test-key"),
+        "https://api.minimax.chat/v1/text/chatcompletion_v2",
+        _sse({"choices": [{"delta": {"content": "par"}}]}),
+        "minimax",
+        id="minimax",
+    ),
+    pytest.param(
+        lambda: GeminiProvider(api_key="test-key"),
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+        _sse({"candidates": [{"content": {"parts": [{"text": "par"}]}}]}),
+        "gemini",
+        id="gemini",
+    ),
+    pytest.param(
+        lambda: GeminiCodeAssistProvider("ya29.fake", "myproj"),
+        "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+        _sse({"response": {"candidates": [{"content": {"parts": [{"text": "par"}]}}]}}),
+        "gemini_code_assist",
+        id="gemini_code_assist",
+    ),
+    pytest.param(
+        lambda: ChatGptCodexProvider("tok", "acct-123", "gpt-5.5", None),
+        "https://chatgpt.com/backend-api/codex/responses",
+        _sse({"type": "response.output_text.delta", "delta": "par"}),
+        "chatgpt_codex",
+        id="chatgpt_codex",
+    ),
+    pytest.param(
+        lambda: OllamaProvider(),
+        "http://localhost:11434/api/chat",
+        '{"message":{"content":"par"},"done":false}\n',
+        "ollama",
+        id="ollama",
+    ),
+]
+
+
+@respx.mock
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("make_provider", "url", "body", "name"), _TRUNCATED)
+async def test_stream_eof_without_terminal_event_raises(make_provider, url, body, name):
+    respx.post(url).mock(
+        return_value=httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+    )
+    seen = []
+    with pytest.raises(
+        IncompleteStreamError,
+        match=f"incomplete stream: {name} ended without a terminal event",
+    ):
+        async for event in make_provider().stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(event)
+    # Deltas received before EOF were still yielded, not swallowed.
+    assert [e.content for e in seen if e.event_type == "text" and not e.done] == ["par"]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_codex_done_sentinel_alone_is_not_terminal():
+    # [DONE] without response.completed is still truncation for chatgpt_codex.
+    body = _sse({"type": "response.output_text.delta", "delta": "par"}) + "data: [DONE]\n"
+    respx.post("https://chatgpt.com/backend-api/codex/responses").mock(
+        return_value=httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+    )
+    p = ChatGptCodexProvider("tok", "acct-123", "gpt-5.5", None)
+    with pytest.raises(IncompleteStreamError, match="chatgpt_codex"):
+        async for _ in p.stream(ChatRequest(messages=[Message.user("hi")])):
+            pass
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_openai_finish_reason_then_eof_completes_with_stashed_stop_reason():
+    # Amended M3 rule (2026-07-17): finish_reason is the SEMANTIC terminal.
+    # EOF after it is a COMPLETE stream even though the [DONE] transport
+    # epilogue never arrived. The stream ends with a done event carrying the
+    # stashed StopReason; no error is raised.
+    body = _sse(
+        {"choices": [{"delta": {"content": "par"}, "finish_reason": None}]},
+        {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+    )
+    respx.post("https://mock.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+    )
+    p = OpenAIProvider("test-key", base_url="https://mock.openai.com")
+    events = [e async for e in p.stream(ChatRequest(messages=[Message.user("hi")]))]
+    assert [e.content for e in events if e.event_type == "text" and not e.done] == ["par"]
+    dones = [e for e in events if e.done]
+    assert len(dones) == 1 and events[-1] is dones[0]
+    assert dones[0].stop_reason == StopReason.stop
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_minimax_finish_reason_then_eof_completes():
+    # MiniMax (Python OpenAI-compatible wire) follows the same either-suffices
+    # rule: a finish_reason chunk is the semantic terminal. Its done event
+    # carries no stop_reason, matching the [DONE] branch; the collector
+    # heuristic fills it (E2).
+    body = _sse(
+        {"choices": [{"delta": {"content": "par"}}]},
+        {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+    )
+    respx.post("https://api.minimax.chat/v1/text/chatcompletion_v2").mock(
+        return_value=httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+    )
+    p = MinimaxProvider("test-key")
+    events = [e async for e in p.stream(ChatRequest(messages=[Message.user("hi")]))]
+    assert [e.content for e in events if e.content] == ["par"]
+    assert events[-1].done and events[-1].stop_reason is None
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_openai_finish_reason_then_done_completes_with_stashed_stop_reason():
+    # Transport-epilogue path: the finish_reason-derived stop_reason is
+    # stashed and emitted with the [DONE] done event (either terminal signal
+    # suffices; here [DONE] arrives and carries the stash).
+    body = (
+        _sse(
+            {"choices": [{"delta": {"content": "hi"}, "finish_reason": None}]},
+            {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+        )
+        + "data: [DONE]\n"
+    )
+    respx.post("https://mock.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+    )
+    p = OpenAIProvider("test-key", base_url="https://mock.openai.com")
+    events = [e async for e in p.stream(ChatRequest(messages=[Message.user("hi")]))]
+    dones = [e for e in events if e.done]
+    assert len(dones) == 1 and events[-1] is dones[0]
+    assert dones[0].stop_reason == StopReason.stop
+
+
+def test_incomplete_stream_error_is_stream_error_subclass():
+    # E1 migration softener: pre-existing ``except StreamError`` call sites keep
+    # catching truncation; MotosanError metadata kwargs are inherited.
+    err = IncompleteStreamError("incomplete stream: openai ended without a terminal event")
+    assert isinstance(err, StreamError)
+    assert err.status_code is None and err.retry_after is None and err.request_id is None
+
+
+def test_incomplete_stream_error_exported_from_top_level():
+    import motosan_ai
+
+    assert motosan_ai.IncompleteStreamError is IncompleteStreamError
+
+
+@pytest.mark.asyncio
+async def test_collect_stream_propagates_incomplete_stream_error():
+    # E2: collector keeps M1 fallible-stream propagation - no fallback, no
+    # partial ChatResponse. Sibling: test_client_stream_collect.py::
+    # test_collect_stream_propagates_mid_stream_raise.
+    async def _truncated():
+        yield StreamEvent(content="partial", done=False)
+        raise IncompleteStreamError("incomplete stream: anthropic ended without a terminal event")
+
+    with pytest.raises(IncompleteStreamError):
+        await collect_stream(_truncated())


### PR DESCRIPTION
## Summary
- add IncompleteStreamError for HTTP stream EOF without provider terminal event
- implement amended OpenAI-wire either-suffices terminal rule for openai/minimax
- add unified Python timeout model, StreamReadTimeoutError, Client lifecycle, and cli_timeout facade

## Tests
- uv run ruff check motosan_ai/ && uv run ruff format --check motosan_ai/ tests/ && uv run pytest tests/ -q --ignore=tests/integration
- pre-push gate passed (Python unit, Rust unit, Python live Anthropic, Rust live Anthropic)

Fixture completions: none.

Generated with Codex.