### PR TITLE
test(stream): M3 termination + read-idle conformance gates

### DIFF
--- a/sdks/python/tests/test_m3_stream_conformance.py
+++ b/sdks/python/tests/test_m3_stream_conformance.py
@@ -1,0 +1,84 @@
+"""M3 milestone-Done conformance gates for Anthropic stream termination.
+
+Cross-SDK mirrors:
+- sdks/rust/tests/m3_stream_conformance.rs
+- sdks/typescript/tests/m3-stream-conformance.test.ts
+"""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from motosan_ai.error import IncompleteStreamError, StreamError, StreamReadTimeoutError
+from motosan_ai.providers.anthropic import AnthropicProvider
+from motosan_ai.types import ChatRequest, Message
+
+
+@pytest.fixture
+def provider():
+    return AnthropicProvider("test-key", base_url="https://mock.anthropic.com")
+
+
+def _sse(*events: dict) -> str:
+    return "\n".join(f"data: {json.dumps(e)}" for e in events) + "\n"
+
+
+class _StallThenReadTimeout(httpx.AsyncByteStream):
+    """One SSE chunk, then the socket goes silent past the read deadline."""
+
+    def __init__(self, first_chunk: bytes) -> None:
+        self._first_chunk = first_chunk
+
+    async def __aiter__(self):
+        yield self._first_chunk
+        raise httpx.ReadTimeout("read timed out")
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_eof_without_message_stop_raises_incomplete_stream(provider):
+    sse = _sse(
+        {"type": "message_start", "message": {"usage": {"input_tokens": 3, "output_tokens": 0}}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "par"}},
+    )
+    respx.post("https://mock.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, text=sse, headers={"content-type": "text/event-stream"})
+    )
+
+    seen = []
+    with pytest.raises(
+        IncompleteStreamError,
+        match="incomplete stream: anthropic ended without a terminal event",
+    ):
+        async for event in provider.stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(event)
+
+    assert any(event.content == "par" for event in seen)
+    assert not any(event.done for event in seen)
+    assert issubclass(IncompleteStreamError, StreamError)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_read_idle_timeout_raises_stream_read_timeout_error(provider):
+    first = (
+        b'data: {"type":"content_block_delta","index":0,'
+        b'"delta":{"type":"text_delta","text":"par"}}\n\n'
+    )
+    respx.post("https://mock.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            stream=_StallThenReadTimeout(first),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    seen = []
+    with pytest.raises(StreamReadTimeoutError):
+        async for event in provider.stream(ChatRequest(messages=[Message.user("hi")])):
+            seen.append(event)
+
+    assert any(event.content == "par" for event in seen)
+    assert not any(event.done for event in seen)

--- a/sdks/rust/tests/m3_stream_conformance.rs
+++ b/sdks/rust/tests/m3_stream_conformance.rs
@@ -1,0 +1,123 @@
+#![cfg(feature = "anthropic")]
+
+use motosan_ai::providers::anthropic::AnthropicProvider;
+use motosan_ai::providers::ProviderImpl;
+use motosan_ai::{ChatRequest, Client, Message, MotosanError, Provider};
+use std::time::Duration;
+use tokio_stream::StreamExt;
+
+// M3 milestone-Done conformance gates (specs/types.md stream termination).
+// Cross-SDK mirrors:
+// - sdks/python/tests/test_m3_stream_conformance.py
+// - sdks/typescript/tests/m3-stream-conformance.test.ts
+
+#[tokio::test]
+async fn anthropic_stream_eof_without_terminal_event_yields_incomplete_stream() {
+    let mut server = mockito::Server::new_async().await;
+    let sse_body = concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"partial\"}}\n\n"
+    );
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = AnthropicProvider::new("test-key", None, Some(server.url()));
+    let request = ChatRequest::builder().message(Message::user("hi")).build();
+
+    let mut stream = provider.stream(request).await.expect("stream response");
+    let mut contents = Vec::new();
+    let mut terminal_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(event) => {
+                assert!(!event.done, "no done event may be fabricated on EOF");
+                contents.push(event.content.clone());
+            }
+            Err(err) => {
+                terminal_err = Some(err);
+                break;
+            }
+        }
+    }
+
+    assert!(
+        contents.iter().any(|t| t == "partial"),
+        "text before the drop is still yielded, got {contents:?}"
+    );
+    let err = terminal_err.expect("EOF without message_stop must yield a typed error");
+    assert!(
+        matches!(err, MotosanError::IncompleteStream(_)),
+        "got {err:?}"
+    );
+    assert_eq!(
+        err.to_string(),
+        "incomplete stream: anthropic ended without a terminal event"
+    );
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn client_stream_read_idle_timeout_yields_stream_read_timeout() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("POST", "/v1/messages")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_chunked_body(|w| {
+            w.write_all(b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"tick-tick-tick\"}}\n\n")?;
+            w.flush()?;
+            std::thread::sleep(std::time::Duration::from_secs(2));
+            let _ = w.write_all(b"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n");
+            Ok(())
+        })
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .provider(Provider::Anthropic)
+        .api_key("test-key")
+        .anthropic_base_url(server.url())
+        .read_idle_timeout(Duration::from_millis(250))
+        .build()
+        .expect("client build");
+
+    let mut stream = client
+        .stream(vec![Message::user("hi")])
+        .await
+        .expect("stream open");
+
+    let mut text = String::new();
+    let mut saw_timeout = false;
+    let mut saw_done = false;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(event) => {
+                saw_done |= event.done;
+                text.push_str(&event.content);
+            }
+            Err(MotosanError::StreamReadTimeout(_)) => saw_timeout = true,
+            Err(other) => panic!("expected StreamReadTimeout on read-idle expiry, got {other:?}"),
+        }
+    }
+    assert!(
+        saw_timeout,
+        "idle stall must yield MotosanError::StreamReadTimeout"
+    );
+    assert!(
+        !saw_done,
+        "no fabricated terminal done after an idle timeout"
+    );
+    assert!(
+        text.starts_with("tick"),
+        "pre-stall content must be delivered, got {text:?}"
+    );
+}

--- a/sdks/typescript/tests/m3-stream-conformance.test.ts
+++ b/sdks/typescript/tests/m3-stream-conformance.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Client } from '../src/client.js'
+import { IncompleteStreamError, StreamError, StreamReadTimeoutError } from '../src/error.js'
+import type { StreamEvent } from '../src/types.js'
+
+// M3 milestone-Done conformance gates (specs/types.md stream termination).
+// Cross-SDK mirrors:
+// - sdks/rust/tests/m3_stream_conformance.rs
+// - sdks/python/tests/test_m3_stream_conformance.py
+
+function sseStream(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text))
+      controller.close()
+    },
+  })
+}
+
+function stubSseFetch(transcript: string): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(sseStream(transcript), {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    ),
+  )
+}
+
+async function drainStream(stream: AsyncIterable<StreamEvent>) {
+  const events: StreamEvent[] = []
+  let error: unknown
+  try {
+    for await (const event of stream) {
+      events.push(event)
+    }
+  } catch (caught) {
+    error = caught
+  }
+  return { events, error }
+}
+
+describe('M3 stream termination conformance', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('kill-the-connection mid-stream rejects with IncompleteStreamError', async () => {
+    const transcript =
+      'event: message_start\n' +
+      'data: {"type":"message_start","message":{"usage":{"input_tokens":5,"output_tokens":0}}}\n\n' +
+      'event: content_block_start\n' +
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+      'event: content_block_delta\n' +
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial-partial"}}\n\n'
+    stubSseFetch(transcript)
+
+    const client = Client.builder().provider('anthropic').apiKey('sk-ant-api03-x').build()
+    const { events, error } = await drainStream(
+      client.stream({ messages: [{ role: 'user', content: 'hi' }] }),
+    )
+
+    expect(error).toBeInstanceOf(IncompleteStreamError)
+    expect(error).toBeInstanceOf(StreamError)
+    expect((error as Error).message).toBe(
+      'incomplete stream: anthropic ended without a terminal event',
+    )
+    const text = events
+      .filter((event) => event.eventType === 'text' && !event.done)
+      .map((event) => event.content)
+      .join('')
+    expect(text.startsWith('partial')).toBe(true)
+    expect(events.some((event) => event.done)).toBe(false)
+  })
+
+  it('hung stream read-idle expiry rejects with StreamReadTimeoutError', async () => {
+    const firstChunk =
+      'event: content_block_start\n' +
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+      'event: content_block_delta\n' +
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"tick-tick-tick"}}\n\n'
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode(firstChunk))
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+    )
+
+    const client = Client.builder()
+      .provider('anthropic')
+      .apiKey('sk-ant-api03-x')
+      .timeouts({ readIdleMs: 50 })
+      .build()
+    const { events, error } = await drainStream(
+      client.stream({ messages: [{ role: 'user', content: 'hi' }] }),
+    )
+
+    expect(error).toBeInstanceOf(StreamReadTimeoutError)
+    const text = events
+      .filter((event) => event.eventType === 'text' && !event.done)
+      .map((event) => event.content)
+      .join('')
+    expect(text.startsWith('tick')).toBe(true)
+    expect(events.some((event) => event.done)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add Rust/Python/TypeScript M3 milestone-Done conformance tests for Anthropic stream truncation and read-idle timeout behavior.
- Test-only branch: adds three new test files only; no production code and no existing tests changed.
- Rust/Python M2 retry conformance suites verified unchanged; their transport tables were not amended by M3.
- TS CancelledError row verified present in sdks/typescript/tests/retry-conformance.test.ts and remains owned by the TS timeout/cancellation task.

M3 PR-C: docs/superpowers/plans/2026-07-16-stream-retry-m3-implementation.md

## Verification
- Rust: cargo fmt && cargo clippy --all-features --all-targets -- -D warnings && cargo test --all-features
- Python: uv run pytest tests/test_m3_stream_conformance.py -v
- TypeScript: npm run typecheck && npm run build && npm test
- Pre-push gate passed: Python unit, Rust unit, Python live Anthropic, Rust live Anthropic

Do not merge here; no tag or publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)