### PR TITLE
chore(release): M3 — rust-v0.24.0 / python-v0.17.0 / ts-v0.14.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`) + TypeScript (`sdks/typescript/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.23.0 · Python v0.16.0 (PyPI) · TypeScript v0.13.0 (npm)
+Rust v0.24.0 · Python v0.17.0 (PyPI) · TypeScript v0.14.0 (npm)
 
 Python 0.13.0 adds CLI-runtime setters (`.cwd()`, session continuity via `session_id` + `resume()`, per-run `.env()/.envs()`, CLI tool-call stream events, configurable `.timeout()/.no_timeout()`) and a **breaking** fallible stream: HTTP provider `stream()` now raises `motosan_ai.error.StreamError` mid-stream instead of swallowing transport/parse faults (`collect_stream` propagates it; `Client.stream_with` does not retry after a mid-stream raise).
 
@@ -11,6 +11,8 @@ Python 0.14.0 and TypeScript 0.11.0 add the **chatgpt-codex** provider — a nat
 The M1 reliability releases: retry survives non-JSON 5xx bodies, mid-stream error frames, Claude Code terminal error results, and CLI child-process death surface as errors, parallel tool-call `index` and chatgpt-codex `item_id`→`call_id` are handled correctly, Rust/TypeScript streamed usage merges by replacement, Python streamed tool turns report the tool-use stop reason, and the TypeScript SSE reader cancels on abort and accepts CRLF.
 
 Rust 0.23.0 / Python 0.16.0 / TypeScript 0.13.0 are the M2 retry releases: errors carry structured metadata (`status_code` / `retry_after` / `request_id`; Rust HTTP variants become struct variants — **breaking**), retry classification is status-based (408/409/429/>=500 plus transport errors), Retry-After honors integer-seconds and HTTP-date capped at 60 s, full jitter replaces the deterministic LCG, `RetryPolicy` gains an `on_retry` observer (and lands in Python as a dataclass threaded through chat and stream), Rust providers share one `send_with_retry` helper, and `specs/retry.md` is the normative cross-SDK retry contract (with one conformance suite per SDK).
+
+Rust 0.24.0 / Python 0.17.0 / TypeScript 0.14.0 are the M3 stream-contract + timeout releases: a stream that ends without the provider's terminal event raises a typed error (Rust `MotosanError::IncompleteStream` — **breaking** enum addition; Python `IncompleteStreamError(StreamError)`; TypeScript `IncompleteStreamError extends StreamError`), retiring the v0.10.1 fabricated-terminal-`done` invariant for the neither-signal case (OpenAI-wire streams complete on `[DONE]` or a `finish_reason` chunk — either suffices; only EOF with neither errors); one timeout model (connect 10 s / read-idle 120 s / total opt-in) lands on all three builders; Rust builds the provider once with a shared `reqwest::Client`; TypeScript gains per-request `AbortSignal` + `CancelledError` (never retried) and a `readTimeoutStream` that actually throws; Python gains `Client.aclose()` / async context manager.
 
 ## Current Rust Tool Schema Note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [rust-0.24.0 / python-0.17.0 / ts-0.14.0] — 2026-07-17
+
+M3 stream-termination + timeout/lifecycle release. **Breaking for all three SDKs**: a stream that ends without the provider's terminal event is now a typed error, not a fabricated clean `done`.
+
+### Breaking
+
+- **Stream termination contract** (Rust · Python · TypeScript): when the upstream byte/event stream ends without the provider terminal event (OpenAI-wire: `[DONE]` or a `finish_reason`-bearing chunk — either suffices; Anthropic `message_stop`; Gemini / chatgpt-codex terminal frames), the stream adapter yields a typed error — message `"incomplete stream: <provider> ended without a terminal event"` — instead of fabricating a terminal `done`. OpenAI-wire streams complete on `[DONE]` or a `finish_reason` chunk (`finish_reason` is the semantic terminal; a stream whose finish_reason arrived is complete even if the connection drops before `[DONE]`); truncation with neither signal raises the error. This retires the v0.10.1 fabricated-`done` invariant for that neither-signal case. Collectors keep propagating errors and keep the stop-reason heuristic only for a real terminal event that lacks a reason. See `specs/types.md` § stream termination.
+- **`MotosanError::IncompleteStream(String)`** (Rust): new enum variant — breaking for exhaustive matches. Migration example in `sdks/rust/CHANGELOG.md`.
+- **Migration softeners** (Python · TypeScript): Python `IncompleteStreamError` subclasses `StreamError`; TypeScript `IncompleteStreamError extends StreamError`, so existing `except StreamError:` / `instanceof StreamError` handlers keep catching truncation.
+- **Caller cancellation classification** (TypeScript): a request aborted by a caller-supplied `AbortSignal` throws `CancelledError extends MotosanError` and is never retried; fetch-internal aborts with no caller signal aborted remain retryable.
+
+### Added
+
+- **One timeout model** (Rust · Python · TypeScript): connect = 10 s default, read-idle = 120 s default, total = off by default (opt-in; blocking `chat()` only, never silently applied to streams). Rust exposes `ClientBuilder::connect_timeout(Duration)`, `.read_idle_timeout(Duration)`, and `.total_timeout(Duration)`; Python exposes `Client(..., connect_timeout=10.0, read_idle_timeout=120.0, total_timeout=None)`; TypeScript exposes `ClientBuilder.timeouts({ connectMs?, readIdleMs?, totalMs? })`.
+- **Python client lifecycle** (Python): `Client.aclose()` and `async with Client(...)` close every provider `httpx.AsyncClient`; `cli_timeout` threads the CLI `.timeout()` / `.no_timeout()` knobs through the `Client` facade.
+- **Specs and conformance** (all SDKs): `specs/types.md` now defines the stream-termination contract and retired fabricated-`done` invariant; `specs/retry.md` documents `CancelledError` and non-retryable read-idle timeout behavior; Rust, Python, and TypeScript add M3 conformance tests for stream truncation and read-idle timeout.
+
+### Changed
+
+- **Rust build-once providers** (Rust): `ClientBuilder::build()` constructs the provider once with one shared `reqwest::Client` configured with `connect_timeout`; `dispatch_chat` / `dispatch_stream` no longer rebuild the provider and connection pool per request. `read_idle_timeout` supersedes the deprecated `stream_read_timeout_secs` alias.
+- **Python MiniMax timeout outlier** (Python): the hardcoded 30 s `httpx` timeout joins the shared timeout model.
+- **TypeScript runtime floor** (TypeScript): `engines.node` is now `>=20.3`, matching the `AbortSignal.any` / `AbortSignal.timeout` APIs used by the timeout and cancellation model.
+
+### Fixed
+
+- **`readTimeoutStream` throws** (TypeScript): idle expiry now throws `StreamReadTimeoutError` instead of silently ending the stream; read-idle default 120 s is wired through providers.
+- **`gemini_code_assist` retry policy** (Rust): the pre-built provider path applies `ClientBuilder::retry_policy` instead of silently discarding it.
+
+Per-SDK detail: [`sdks/rust/CHANGELOG.md`](sdks/rust/CHANGELOG.md), [`sdks/python/CHANGELOG.md`](sdks/python/CHANGELOG.md), [`sdks/typescript/CHANGELOG.md`](sdks/typescript/CHANGELOG.md).
+
 ## [rust-0.23.0 / python-0.16.0 / ts-0.13.0] — 2026-07-16
 
 M2 retry release — structured error metadata, status-based retry classification, one retry engine per SDK, and a normative retry spec. **Breaking for Rust** (`MotosanError` enum shape); additive for Python and TypeScript.

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.23.0 |
-| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.16.0 |
-| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) | v0.13.0 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.24.0 |
+| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.17.0 |
+| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) | v0.14.0 |
 
 ## Install
 
 ```toml
 # Rust (Cargo.toml)
 [dependencies]
-motosan-ai = { version = "0.23.0", features = ["anthropic"] }
+motosan-ai = { version = "0.24.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```
@@ -48,7 +48,7 @@ pip install "motosan-ai[full]"   # all Python HTTP providers
 ```
 
 ```bash
-# TypeScript / Node (ESM, Node >= 18)
+# TypeScript / Node (ESM, Node >= 20.3)
 npm install @motosan-ai/sdk
 ```
 
@@ -229,14 +229,14 @@ use tokio_stream::StreamExt;
 let client = Client::builder()
     .provider(Provider::Anthropic)
     .api_key(std::env::var("ANTHROPIC_API_KEY")?)
-    .stream_read_timeout_secs(30)
+    .read_idle_timeout(std::time::Duration::from_secs(30))
     .build()?;
 
 let mut stream = client.stream(vec![Message::user("Hello")]).await?;
 while let Some(event) = stream.next().await {
     if event.done {
         // Terminal event carries the provider-reported stop reason when available.
-        // Streams emit exactly one `done` event, even on non-conformant proxies.
+        // EOF without a terminal event is Err(MotosanError::IncompleteStream), not a done event.
         if let Some(reason) = event.stop_reason {
             eprintln!("\n[done: {reason:?}]");
         }

--- a/llms.txt
+++ b/llms.txt
@@ -2,9 +2,10 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.16.0 · TypeScript 0.13.0 · Rust 0.23.0
+- Python 0.17.0 · TypeScript 0.14.0 · Rust 0.24.0
 - Python 0.13.0: CLI-runtime setters (`.cwd()`, `session_id` + `resume()`, `.env()/.envs()`, CLI tool-call stream events, `.timeout()/.no_timeout()`) and a **breaking** fallible stream — HTTP provider `stream()` raises `motosan_ai.error.StreamError` mid-stream instead of swallowing transport/parse faults (`collect_stream` propagates it; `Client.stream_with` does not retry after a mid-stream raise).
 - Python 0.14.0 / TypeScript 0.11.0: **chatgpt-codex** provider — native ChatGPT-backend HTTP client over the OpenAI Responses API (`chatgpt.com/backend-api/codex/responses`; pre-obtained OAuth token + account id, no `api_key`). Python `Client.chatgpt_codex(...)`, TypeScript `Client.builder().chatgptCodex(...)`.
+- Rust 0.24.0 / Python 0.17.0 / TypeScript 0.14.0 (M3): **breaking** stream termination — EOF without the provider terminal event (OpenAI wire: `[DONE]` or a `finish_reason` chunk, either suffices) raises Rust `MotosanError::IncompleteStream` / Python `IncompleteStreamError(StreamError)` / TypeScript `IncompleteStreamError extends StreamError`; one timeout model (connect 10 s / read-idle 120 s / total opt-in) on all builders; Rust build-once shared `reqwest::Client`; TypeScript per-request `AbortSignal` + `CancelledError` (never retried); Python `Client.aclose()` / `async with`.
 - GitHub: https://github.com/motosan-dev/motosan-ai
 - PyPI: https://pypi.org/project/motosan-ai/
 - crates.io: https://crates.io/crates/motosan-ai
@@ -21,7 +22,7 @@ pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```toml
 # Rust — pick features in Cargo.toml
 [dependencies]
-motosan-ai = { version = "0.23.0", features = ["anthropic"] }
+motosan-ai = { version = "0.24.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient):
@@ -451,12 +452,16 @@ event.stop_reason          — StopReason on the terminal `done` event (Optional
                              • None on done events for providers that don't report a reason
 ```
 
-Each provider stream emits **exactly one** `done` event — guaranteed since
-v0.10.1 even when the upstream provider closes the connection without `[DONE]`
-and without a `finish_reason` chunk (some non-conformant proxies do this). If
-the provider reports a stop reason, it lands on that event. `collect_stream`
-honors the explicit `stop_reason` and only falls back to its tool-calls
-heuristic when none was reported.
+A stream is complete only when the provider sends its terminal event (OpenAI
+`[DONE]` or a final `finish_reason` chunk — either suffices, Anthropic
+`message_stop`, Gemini / chatgpt-codex terminal frames). Since rust-0.24.0 /
+python-0.17.0 / ts-0.14.0, EOF without any such event is a typed error — Rust
+`MotosanError::IncompleteStream`, Python `IncompleteStreamError` (subclass of
+`StreamError`), TypeScript `IncompleteStreamError extends StreamError` — message
+`"incomplete stream: <provider> ended without a terminal event"`. If the
+provider reports a stop reason it lands on the terminal event; `collect_stream`
+honors it and falls back to the tool-calls heuristic only on a real terminal
+event that lacks a reason.
 
 ### Event Sequence for Tool Calls
 
@@ -920,7 +925,7 @@ Python, Rust, and TypeScript SDKs are versioned and released **independently**.
 |--------------|-----------------------|-----------------------|
 | Python       | `python-vX.Y.Z`       | `python-v0.4.2`       |
 | Rust         | `rust-vX.Y.Z`         | `rust-v0.3.3`         |
-| TypeScript   | `ts-vX.Y.Z`           | `ts-v0.13.0`          |
+| TypeScript   | `ts-vX.Y.Z`           | `ts-v0.14.0`          |
 | motosan-ai-oauth | `motosan-ai-oauth-vX.Y.Z` | `motosan-ai-oauth-v0.2.0` |
 | codex-oauth  | `codex-oauth-vX.Y.Z`  | `codex-oauth-v0.1.0`  |
 | anthropic-oauth | `anthropic-oauth-vX.Y.Z` | `anthropic-oauth-v0.1.0` |

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -2,17 +2,16 @@
 
 All notable changes to `motosan-ai` Python SDK are documented in this file.
 
-## [Unreleased]
+## [0.17.0] - 2026-07-17
 
 ### Breaking
-- **Streaming:** HTTP provider streams that end without the provider's terminal event (`message_stop` / `[DONE]`-or-`finish_reason` on the OpenAI wire / `finishReason` / `response.completed` / `{"done": true}`) now raise `IncompleteStreamError` instead of ending silently as if complete - truncation is no longer indistinguishable from completion. `IncompleteStreamError` subclasses `StreamError` deliberately (migration softener): existing `except StreamError` handlers keep catching it; catch `IncompleteStreamError` to handle truncation specifically. Not retried (mid-stream errors are never retried, per `specs/retry.md`). CLI providers unchanged - child-process death already raises `StreamError` (M1); child death is not HTTP truncation.
-- **OpenAI-wire streaming (openai, minimax):** per the amended terminal-event contract (`specs/types.md`), a stream completes on `data: [DONE]` OR a `finish_reason`-bearing chunk - either suffices (`finish_reason` is the semantic terminal, `[DONE]` the transport epilogue). openai stashes the finish_reason-derived `stop_reason` and emits it with the terminal done event at `[DONE]` or, failing that, at EOF; minimax emits its usual no-stop_reason done at EOF after a finish_reason chunk. Truncation with NEITHER signal raises `IncompleteStreamError`. Mirrors the Rust 0.24.0 adapter.
+- Stream EOF semantics: an HTTP provider stream that ends without the provider's terminal event now raises `IncompleteStreamError` — `"incomplete stream: <provider> ended without a terminal event"` — instead of ending as if the turn had completed. OpenAI-wire streams (openai, minimax) complete on `[DONE]` or a `finish_reason`-bearing chunk — either suffices; truncation with neither signal raises. Anthropic requires `message_stop`; Gemini / chatgpt-codex require their terminal frames. `IncompleteStreamError` subclasses `StreamError`, so existing `except StreamError:` handlers keep working unchanged; catch `IncompleteStreamError` first to treat truncation specially.
 
 ### Added
-- Unified timeout model (E4): `Client(..., connect_timeout: float = 10.0, read_idle_timeout: float = 120.0, total_timeout: float | None = None)` threaded into every HTTP provider as `httpx.Timeout(connect=connect_timeout, read=read_idle_timeout, write=read_idle_timeout, pool=connect_timeout)`. `total_timeout` (opt-in) bounds `chat()`/`chat_with()` wall clock including retries; it never applies to streams.
-- `StreamReadTimeoutError` (`MotosanError` subclass; mirrors Rust `StreamReadTimeout` / TS `StreamReadTimeoutError`): a streaming body idle past `read_idle_timeout` raises it. Never retried - mid-stream retry would replay already-yielded deltas.
-- Client lifecycle (E8): `await client.aclose()` and `async with Client(...) as client:`; every provider gains `aclose()` (no-op for CLI providers).
-- `cli_timeout` facade kwarg (keyword-only on `Client`; trailing parameter on `Client.codex_cli()`/`Client.gemini_cli()` - pass it by keyword): threads to `CodexCliClient`/`GeminiCliClient` `.timeout()`; `cli_timeout=None` maps to `.no_timeout()`.
+- `Client(..., connect_timeout=10.0, read_idle_timeout=120.0, total_timeout=None)` is threaded into every HTTP provider as `httpx.Timeout(connect=connect_timeout, read=read_idle_timeout, write=read_idle_timeout, pool=connect_timeout)`; `total_timeout` applies to blocking `chat()` / `chat_with()` only, never silently to streams.
+- `StreamReadTimeoutError` (`MotosanError` subclass; mirrors Rust `StreamReadTimeout` / TypeScript `StreamReadTimeoutError`): a streaming body idle past `read_idle_timeout` raises it. Never retried — mid-stream retry would replay already-yielded deltas.
+- `Client.aclose()` and `async with Client(...) as client:` close every provider `AsyncClient`.
+- `cli_timeout` facade kwarg (keyword-only on `Client`; trailing parameter on `Client.codex_cli()` / `Client.gemini_cli()` — pass it by keyword): threads to `CodexCliClient` / `GeminiCliClient` `.timeout()`; `cli_timeout=None` maps to `.no_timeout()`.
 
 ### Changed
 - **MiniMax timeout unified**: the hardcoded `httpx.AsyncClient(timeout=30)` outlier now uses the shared model (connect 10s, read/write 120s) - requests that previously failed at 30s idle now wait 120s.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motosan-ai"
-version = "0.16.0"
+version = "0.17.0"
 description = "Python SDK for Anthropic, OpenAI, MiniMax, Gemini, Ollama, and CLI AI providers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -4,12 +4,53 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-17
+
 ### Breaking
-- **Truncated streams now error instead of ending cleanly.** Every HTTP stream adapter (openai, anthropic, gemini, gemini-code-assist, chatgpt-codex, ollama) yields `Err(MotosanError::IncompleteStream("<provider> ended without a terminal event"))` when the upstream connection closes without the provider terminal event (OpenAI-wire `[DONE]` or a `finish_reason` chunk — either suffices / `message_stop` / `finishReason` / `response.completed` / `"done":true`). OpenAI amendment: `finish_reason` is the semantic terminal — EOF after a stashed finish_reason still emits `done(stop_reason)` and completes cleanly; only EOF with NEITHER signal errors. The v0.10.1 invariant "exactly one terminal done event even when upstream closes without `[DONE]`" is retired for that neither-signal case. New `MotosanError::IncompleteStream(String)` variant — enum addition breaks exhaustive matches.
-- **Timeout API cleanup.** `Client::stream_read_timeout()` getter is removed; `ClientBuilder::stream_read_timeout_secs` is deprecated in favor of `read_idle_timeout(Duration)`. HTTP streams now enforce a 120s default read-idle deadline; idle expiry yields `MotosanError::StreamReadTimeout` and is never retried mid-stream.
+- `MotosanError` gains `#[error("incomplete stream: {0}")] IncompleteStream(String)` — exhaustive `match`es need a new arm:
+
+  ```rust
+  // 0.23 — exhaustive match compiles without the new arm
+  match err {
+      MotosanError::Stream(msg) => eprintln!("stream failed: {msg}"),
+      other => return Err(other),
+  }
+  // 0.24 — add an IncompleteStream arm (or a catch-all)
+  match err {
+      MotosanError::Stream(msg) => eprintln!("stream failed: {msg}"),
+      MotosanError::IncompleteStream(msg) => eprintln!("truncated: {msg}"),
+      other => return Err(other),
+  }
+  ```
+
+- Stream EOF semantics: a provider stream that ends **without** the provider's terminal event now yields `Err(MotosanError::IncompleteStream(_))` — `"incomplete stream: <provider> ended without a terminal event"` — instead of fabricating a final `done` event. OpenAI-wire streams complete on `[DONE]` or a `finish_reason` chunk (either suffices — EOF after a stashed `finish_reason` still emits `done` with the stop reason); truncation with neither signal yields the error. Anthropic requires `message_stop`; Gemini / chatgpt-codex require their terminal frames. This retires the v0.10.1 fabricated-`done` invariant for the neither-signal case. Handling truncation:
+
+  ```rust
+  while let Some(item) = stream.next().await {
+      match item {
+          Ok(event) => {
+              if event.done { break; }              // real provider terminal event
+              print!("{}", event.content);
+          }
+          Err(MotosanError::IncompleteStream(msg)) => {
+              // Upstream closed without its terminal event; events so far are partial.
+              eprintln!("truncated: {msg}");
+              break;
+          }
+          Err(other) => return Err(other),
+      }
+  }
+  ```
+- Timeout API cleanup: `Client::stream_read_timeout()` getter is removed; `ClientBuilder::stream_read_timeout_secs` is deprecated in favor of `read_idle_timeout(Duration)`. HTTP streams now enforce a 120 s default read-idle deadline; idle expiry yields `MotosanError::StreamReadTimeout` and is never retried mid-stream.
 
 ### Added
-- Unified timeout model: `ClientBuilder::connect_timeout(Duration)` (default 10s on the shared reqwest client), `.read_idle_timeout(Duration)` (default 120s), and `.total_timeout(Duration)` (default off; bounds each blocking `chat()` attempt, never streams; expiry surfaces as retryable `MotosanError::Network`).
+- Unified timeout model: `ClientBuilder::connect_timeout(Duration)` (default 10 s on the shared reqwest client), `.read_idle_timeout(Duration)` (default 120 s; same per-chunk semantics as the old stream read timeout), and `.total_timeout(Duration)` (default off; bounds each blocking `chat()` attempt, never streams; expiry surfaces as retryable `MotosanError::Network`).
+
+### Changed
+- `ClientBuilder::build()` constructs the provider once with a single shared `reqwest::Client` (configured with `connect_timeout`); `dispatch_chat` / `dispatch_stream` no longer rebuild the provider per request.
+
+### Fixed
+- Pre-built `gemini_code_assist` provider honors `ClientBuilder::retry_policy` (previously silently discarded).
 
 ## [0.23.0] - 2026-07-16
 

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -47,7 +47,7 @@ while let Some(item) = stream.next().await {
 # }
 ```
 
-Each provider stream emits **exactly one** terminal `done` event — guaranteed since v0.10.1 even when the upstream provider closes the connection without `[DONE]` and without any `finish_reason` chunk. `event.stop_reason` carries the provider's reported reason when present (`Anthropic` `message_delta.stop_reason`, `OpenAI` / `MiniMax` `finish_reason`).
+A stream is complete only when the provider sends its terminal event (OpenAI `[DONE]` or a final `finish_reason` chunk — either suffices, Anthropic `message_stop`, Gemini / chatgpt-codex terminal frames). Since v0.24.0, EOF without any such event yields `Err(MotosanError::IncompleteStream(_))` (`"incomplete stream: <provider> ended without a terminal event"`) rather than reporting completion — truncation is distinguishable from completion. `event.stop_reason` carries the provider's reported reason when present (`Anthropic` `message_delta.stop_reason`, `OpenAI` / `MiniMax` `finish_reason`).
 
 ## Vision / Multimodal
 
@@ -320,7 +320,7 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
 ```toml
-motosan-ai = { version = "0.23.0", features = ["claude-code"] }
+motosan-ai = { version = "0.24.0", features = ["claude-code"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -430,7 +430,7 @@ Notes:
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
 ```toml
-motosan-ai = { version = "0.23.0", features = ["codex-cli"] }
+motosan-ai = { version = "0.24.0", features = ["codex-cli"] }
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -494,7 +494,7 @@ Notes:
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
 ```toml
-motosan-ai = { version = "0.23.0", features = ["gemini-cli"] }
+motosan-ai = { version = "0.24.0", features = ["gemini-cli"] }
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `@motosan-ai/sdk` TypeScript SDK are documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.14.0] - 2026-07-17
+
+### Breaking
+- Stream EOF semantics: a provider stream that ends without the provider's terminal event now throws `IncompleteStreamError` — `"incomplete stream: <provider> ended without a terminal event"` — instead of terminating silently with a partial, success-looking response. OpenAI-wire streams complete on `[DONE]` or a `finish_reason` chunk (either suffices — EOF after a stashed finish_reason still yields `done` with the stop reason); truncation with neither signal throws. `IncompleteStreamError extends StreamError`, so existing `instanceof StreamError` handlers keep working unchanged.
+- Retry classification: a request aborted by a **caller-supplied** `AbortSignal` throws the new `CancelledError extends MotosanError` and is **never retried**; fetch-internal `AbortError` with no caller signal aborted (for example `AbortSignal.timeout`) stays retryable. `specs/retry.md` includes the TypeScript-only `CancelledError` row.
+
+### Added
+- Per-request cancellation: caller `AbortSignal` threads through Client `chat` / `stream` options to provider `ProviderRequestOptions.signal` and then `postJson` / `postStream` fetch options.
+- `ClientBuilder.timeouts({ connectMs?, readIdleMs?, totalMs? })` — connect 10 s and total (opt-in, chat only) via `AbortSignal.timeout` composition on fetch; read-idle 120 s via `readTimeoutStream`.
+
+### Changed
+- `streamReadTimeoutSecs(n)` is retained as a deprecated alias for `timeouts({ readIdleMs: n * 1000 })`.
+- Node engine floor is now `>=20.3` for `AbortSignal.any` / `AbortSignal.timeout`.
+
+### Fixed
+- `readTimeoutStream` actually throws `StreamReadTimeoutError` on idle expiry (previously it silently ended the stream).
+
 ## [0.13.0] - 2026-07-16
 
 ### Added

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -20,7 +20,7 @@ are tree-shaken via ESM (only what you import lands in your bundle).
 
 ## Requirements
 
-- **Node >= 18** (the SDK uses native `fetch`, `ReadableStream`, and `TextDecoder`, stable from Node 18).
+- **Node >= 20.3** (the SDK uses `AbortSignal.any` / `AbortSignal.timeout` for timeout and cancellation composition).
 - An **ESM project** — set `"type": "module"` in your `package.json`, or use `.mjs` files.
 - One provider credential (env var or passed to `.apiKey(...)`):
 
@@ -204,15 +204,16 @@ for await (const event of client.stream({ messages: [user('Write a haiku about r
 }
 ```
 
-Each provider stream emits **exactly one** terminal `done` event, even when the upstream provider closes
-the connection without a sentinel and without a finish-reason chunk. `event.stopReason` carries the
-provider's reported reason when present.
+A stream is complete only when the provider sends its terminal event (OpenAI `[DONE]` or a final
+`finish_reason` chunk — either suffices, Anthropic `message_stop`, Gemini / chatgpt-codex terminal
+frames). Since v0.14.0, if the upstream closes without any such event the stream throws
+`IncompleteStreamError` (subclass of `StreamError`) — `"incomplete stream: <provider> ended without a
+terminal event"`. `event.stopReason` carries the provider's reported reason when present.
 
-> **Mid-stream partial success (important):** if a transport error occurs *after* the stream has started,
-> the stream terminates **silently** — it does NOT throw mid-stream. The events yielded so far form a
-> partial, success-looking response (and `collectStream` will return a `ChatResponse` with a fabricated
-> `stopReason`). Retries apply only to the *initial* fetch, never mid-stream (see Retry). If you need
-> strict completeness, inspect `usage`/`stopReason` on the terminal event.
+> **Mid-stream failures:** provider `error` frames and transport faults reject the stream (since 0.12.0),
+> and truncation (EOF without a terminal event) rejects with `IncompleteStreamError` (since 0.14.0).
+> Retries apply only to the *initial* fetch, never mid-stream (see Retry). Aborting via your own
+> `AbortSignal` throws `CancelledError` and is never retried.
 
 ### Streaming → assembled response
 
@@ -482,8 +483,8 @@ Automated via `publish-typescript.yml` on a `ts-v*` tag push → npm.
 
 ```bash
 # Bump sdks/typescript/package.json version + CHANGELOG, then:
-git tag ts-v0.13.0
-git push origin ts-v0.13.0
+git tag ts-v0.14.0
+git push origin ts-v0.14.0
 ```
 
 The Rust, Python, and TypeScript SDKs are versioned and released independently.

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@motosan-ai/sdk",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@motosan-ai/sdk",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.13.10",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motosan-ai/sdk",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Multi-provider TypeScript/ESM SDK for Anthropic, OpenAI, MiniMax, Ollama, Gemini, and ChatGPT Codex. Self-implemented wire protocol via native fetch — zero official-provider-SDK dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.16.0 / Rust 0.23.0 / TypeScript 0.13.0
+Multi-provider LLM SDK — Python 0.17.0 / Rust 0.24.0 / TypeScript 0.14.0
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI, ChatGPT Codex (Responses API)
 
@@ -22,7 +22,7 @@ pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 
 ```toml
 # Rust (Cargo.toml)
-motosan-ai = { version = "0.23.0", features = ["anthropic"] }
+motosan-ai = { version = "0.24.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli
@@ -32,7 +32,7 @@ codex-oauth = "0.1"
 ```
 
 ```bash
-# TypeScript / Node (ESM, Node >= 18)
+# TypeScript / Node (ESM, Node >= 20.3)
 npm install @motosan-ai/sdk
 ```
 
@@ -128,7 +128,7 @@ if token.is_expired() { /* refresh */ }
 
 - **Python Client API parity (v0.10.0)**: `chat_with(request)` and `stream_with(request)` are the canonical full-`ChatRequest` paths. Use them with `ChatRequest.builder()` for `thinking`, `tool_choice`, `mcp_servers`, `system_blocks`, and `stop_sequences`. `stream_collect(messages, **kwargs)` and `stream_collect_with(request)` drive a stream to completion and return a `ChatResponse`. `chat_sync()` is deprecated; recommend `asyncio.run(client.chat(...))`.
 - **`BoxStream` (Rust 0.20+)**: `Pin<Box<dyn Stream<Item = Result<StreamEvent, MotosanError>> + Send>>` — unwrap each item with `let event = item?`; mid-stream provider/timeout errors surface as `Err(...)`
-- **Stream `done` invariant** (Rust, since v0.10.1): every provider stream emits **exactly one** terminal event with `done == true`, even when the upstream provider closes without `[DONE]` and without any `finish_reason` chunk. Callers can rely on `if event.done { break; }` to terminate cleanly. The terminal event carries `stop_reason: Option<StopReason>` when the provider reports one (Anthropic/MiniMax `message_delta.stop_reason`, OpenAI `choices[0].finish_reason`); `None` otherwise. `collect_stream` honors the explicit reason and only falls back to a tool-calls heuristic when none was reported.
+- **Stream termination contract** (Rust 0.24.0 / Python 0.17.0 / TypeScript 0.14.0; replaces the v0.10.1 fabricated-`done` invariant): a stream is complete only when the provider sends its terminal event (OpenAI `[DONE]` or a final `finish_reason` chunk — either suffices, Anthropic `message_stop`, Gemini/codex terminal frames). EOF without any such event errors with Rust `MotosanError::IncompleteStream` / Python `IncompleteStreamError` (subclass of `StreamError`) / TypeScript `IncompleteStreamError extends StreamError` — message `"incomplete stream: <provider> ended without a terminal event"`. Successful streams still end with one terminal `done == true` event carrying `stop_reason` when reported; `collect_stream` keeps the tool-calls heuristic only for a real terminal event that lacks a reason.
 - **`ChatRequest`**: Use builder pattern in Rust (`ChatRequest::builder().messages(...).build()`), dataclass in Python
 - **ThinkStripper**: Applied automatically in all `stream()` / `stream_with()` calls — no manual setup needed
 - **Anthropic OAuth**: Auto-detected by token prefix (`sk-ant-oat01*`), `chat()` auto-redirects to `stream()` for OAuth tokens. Budget-based thinking sends `display: "summarized"`; Opus 4.8/4.7/4.6 thinking uses adaptive mode and skips the legacy interleaved-thinking beta.

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-motosan-ai = { version = "0.23.0", features = ["anthropic"] }
+motosan-ai = { version = "0.24.0", features = ["anthropic"] }
 # features: anthropic | openai | minimax | ollama | ollama_native | full
 #           gemini | gemini-code-assist | claude-code | codex-cli | gemini-cli
 ```

--- a/uv.lock
+++ b/uv.lock
@@ -95,7 +95,7 @@ wheels = [
 
 [[package]]
 name = "motosan-ai"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "sdks/python" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump Rust/Python/TypeScript release versions to `0.24.0` / `0.17.0` / `0.14.0`.
- Update root + per-SDK changelogs for M3 stream termination, timeout/lifecycle, TS cancellation, and conformance coverage.
- Update release docs/current version references and rewrite the retired fabricated-terminal-done prose.
- Regenerate root `uv.lock` and `sdks/typescript/package-lock.json`; no `Cargo.lock` staged.

## Scope
- Release/docs/manifests/lockfiles only.
- No `src/` production code changes.
- No tag, publish, or merge performed.

## Local gates
- `check-all` passed.
- `cd sdks/typescript && npm run typecheck && npm run build && npm test` passed.
- Pre-push gate passed, including Python/Rust live Anthropic tests.

## Changelog mapping notes
- `ae71bba` / `f7f836a` / `c764c85`: typed incomplete-stream errors and OpenAI-wire either-suffices terminal semantics.
- `e91dc6d` / `3ba07cd` / `c764c85`: unified timeout model and read-idle behavior.
- `0bdf376`: Rust build-once provider/shared reqwest client.
- `3ba07cd`: TypeScript caller cancellation, `CancelledError`, Node `>=20.3`, `readTimeoutStream` throwing.
- `bd9312e`: M3 conformance tests across Rust/Python/TypeScript.

Generated with Codex.
