### PR TITLE
feat(ts): per-attempt token source for chatgpt_codex (M4)

### DIFF
--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@motosan-ai/sdk` TypeScript SDK are documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+- `ChatGptCodexProvider` and `ClientBuilder.chatgptCodex` accept an async token
+  source: `accessToken: string | TokenSource` where `TokenSource = () => Promise<string>`
+  (exported from the package root). The source is resolved once per request
+  attempt, so a retry after 5xx/429 sends a freshly resolved Bearer token.
+  Plain-string tokens are unchanged. (F5)
+
 ## [0.14.0] - 2026-07-17
 
 ### Breaking

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -17,7 +17,7 @@ import { MinimaxProvider } from './providers/minimax.js'
 import { OllamaProvider } from './providers/ollama.js'
 import { OpenAIProvider, type OpenAIAuthStyle } from './providers/openai.js'
 import { GeminiProvider } from './providers/gemini.js'
-import { ChatGptCodexProvider } from './providers/chatgpt_codex.js'
+import { ChatGptCodexProvider, type TokenSource } from './providers/chatgpt_codex.js'
 import { DEFAULT_OLLAMA_MODEL } from './models.js'
 import type { ChatRequest, ChatResponse, StreamEvent } from './types.js'
 
@@ -101,7 +101,7 @@ export class ClientBuilder {
   protected _ollamaThink?: string
   protected _ollamaKeepAlive?: string
   protected _ollamaNumCtx?: number
-  protected _chatgptAccessToken?: string
+  protected _chatgptAccessToken?: string | TokenSource
   protected _chatgptAccountId?: string
   protected _chatgptReasoningEffort?: string
 
@@ -210,12 +210,14 @@ export class ClientBuilder {
 
   /**
    * Configure the no-api-key ChatGPT-Codex provider with a caller-supplied OAuth
-   * `accessToken` + `accountId`. Optional `model` overrides the default
-   * (`gpt-5.5`); `opts.reasoningEffort` sets the provider-default reasoning
-   * effort (per-request `providerOptions.reasoning_effort` still wins).
+   * `accessToken` + `accountId`. `accessToken` is a static string or an async
+   * `TokenSource` resolved once per request attempt, so a retry can pick up a
+   * refreshed token. Optional `model` overrides the default (`gpt-5.5`);
+   * `opts.reasoningEffort` sets the provider-default reasoning effort
+   * (per-request `providerOptions.reasoning_effort` still wins).
    */
   chatgptCodex(
-    accessToken: string,
+    accessToken: string | TokenSource,
     accountId: string,
     model?: string,
     opts?: { reasoningEffort?: string },

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -8,9 +8,10 @@ export * from './providers/openai.js'
 export * from './providers/minimax.js'
 export * from './providers/ollama.js'
 export * from './providers/gemini.js'
-// chatgpt_codex: exports ChatGptCodexProvider + DEFAULT_CHATGPT_CODEX_MODEL.
+// chatgpt_codex: exports ChatGptCodexProvider + DEFAULT_CHATGPT_CODEX_URL + TokenSource.
 // `chatGptCodexErrorMessage` is @internal and NOT re-exported.
 export { ChatGptCodexProvider, DEFAULT_CHATGPT_CODEX_URL } from './providers/chatgpt_codex.js'
+export type { TokenSource } from './providers/chatgpt_codex.js'
 
 export { RetryPolicy } from './retry.js'
 export type { RetryPolicyOptions, RetryEvent } from './retry.js'

--- a/sdks/typescript/src/providers/chatgpt_codex.ts
+++ b/sdks/typescript/src/providers/chatgpt_codex.ts
@@ -52,9 +52,17 @@ export function chatGptCodexErrorMessage(chunk: any): string {
 }
 
 /**
+ * A caller-supplied async bearer-token source, consulted once per request
+ * attempt. Each retry re-resolves it, so a refreshed OAuth access token is
+ * picked up mid-retry.
+ */
+export type TokenSource = () => Promise<string>
+
+/**
  * No-api-key OAuth-Bearer HTTP provider over the OpenAI Responses API.
  * Constructor `(accessToken, accountId, model?, baseUrl?)` mirrors Python
- * `ChatGptCodexProvider.__init__`. Text-only capabilities.
+ * `ChatGptCodexProvider.__init__`; `accessToken` is a static string or an
+ * async `TokenSource` resolved once per attempt. Text-only capabilities.
  */
 export class ChatGptCodexProvider {
   private readonly model: string
@@ -63,7 +71,7 @@ export class ChatGptCodexProvider {
   private _reasoningEffort?: string
 
   constructor(
-    private readonly accessToken: string,
+    private readonly accessToken: string | TokenSource,
     private readonly accountId: string,
     model?: string,
     baseUrl: string = DEFAULT_CHATGPT_CODEX_URL,
@@ -98,9 +106,14 @@ export class ChatGptCodexProvider {
     return textOnly()
   }
 
-  private headers(): Record<string, string> {
+  /** Resolve the bearer token for one attempt: static string, or one TokenSource call. */
+  private async resolveToken(): Promise<string> {
+    return typeof this.accessToken === 'function' ? this.accessToken() : this.accessToken
+  }
+
+  private headers(token: string): Record<string, string> {
     return {
-      authorization: `Bearer ${this.accessToken}`,
+      authorization: `Bearer ${token}`,
       'chatgpt-account-id': this.accountId,
       originator: CHATGPT_CODEX_ORIGINATOR,
       'openai-beta': 'responses=experimental',
@@ -222,15 +235,16 @@ export class ChatGptCodexProvider {
   ): AsyncGenerator<StreamEvent> {
     const model = request.model ?? this.model
     const body = this.buildResponsesBody(request, model)
-    const headers = this.headers()
 
     // Retry ONLY the initial fetch via the shared engine (same guard as the
     // other providers: nothing is retried after the first emitted event).
+    // Headers are rebuilt inside the attempt closure so a TokenSource is
+    // re-resolved on every attempt while the shared retry engine stays intact.
     const responseBody = await withRetry(
       this.retryPolicy,
       async () =>
-        attemptWithCancellation(opts?.callerSignal, () =>
-          postStream(this.baseUrl, headers, body, {
+        attemptWithCancellation(opts?.callerSignal, async () =>
+          postStream(this.baseUrl, this.headers(await this.resolveToken()), body, {
             signal: opts?.signal,
             preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
           }),

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -112,8 +112,9 @@ export type StopReason =
   | 'other'
 
 /**
- * The kind of a streaming event. `thinking_delta`/`thinking_done` are emitted
- * by Anthropic only; `collectStream` concatenates them into `ChatResponse.thinking`.
+ * The kind of a streaming event. Anthropic emits `thinking_delta` and
+ * `thinking_done`; ChatGPT Codex emits `thinking_delta` reasoning deltas.
+ * `collectStream` concatenates them into `ChatResponse.thinking`.
  */
 export type StreamEventType =
   | 'text'

--- a/sdks/typescript/tests/client-builder.test.ts
+++ b/sdks/typescript/tests/client-builder.test.ts
@@ -585,6 +585,53 @@ describe('ClientBuilder.chatgptCodex', () => {
   })
 })
 
+describe('ClientBuilder.chatgptCodex token source (F5)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('accepts an async token source and resolves it per attempt through Client.chat()', async () => {
+    let tokenCalls = 0
+    const source = async (): Promise<string> => {
+      tokenCalls += 1
+      return `tok-${tokenCalls}`
+    }
+    const authHeaders: string[] = []
+    let fetches = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, options?: RequestInit) => {
+        fetches += 1
+        const headers = (options?.headers as Record<string, string>) ?? {}
+        authHeaders.push(headers.authorization ?? '')
+        return fetches === 1
+          ? new Response(JSON.stringify({ error: { message: 'overloaded' } }), { status: 500 })
+          : new Response(
+              'data: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+              { status: 200, headers: { 'content-type': 'text/event-stream' } },
+            )
+      }),
+    )
+
+    const client = new ClientBuilder()
+      .chatgptCodex(source, 'acct')
+      .retryPolicy(
+        new RetryPolicy({
+          maxRetries: 2,
+          baseDelayMs: 0,
+          maxDelayMs: 0,
+          jitter: false,
+          respectRetryAfter: false,
+        }),
+      )
+      .build()
+    const resp = await client.chat({ messages: [{ role: 'user', content: 'hi' }] })
+
+    expect(resp.stopReason).toBe('end_turn')
+    expect(fetches).toBe(2)
+    expect(tokenCalls).toBe(2)
+    expect(authHeaders).toEqual(['Bearer tok-1', 'Bearer tok-2'])
+  })
+})
+
 describe('ClientBuilder Ollama api-key-not-required seam', () => {
   beforeEach(() => {
     delete process.env.OLLAMA_API_KEY

--- a/sdks/typescript/tests/providers-chatgpt-codex.test.ts
+++ b/sdks/typescript/tests/providers-chatgpt-codex.test.ts
@@ -541,3 +541,73 @@ describe('ChatGptCodexProvider HTTP', () => {
     ).rejects.toBeInstanceOf(NetworkError)
   })
 })
+
+// ---------------------------------------------------------------------------
+// F5 — per-attempt TokenSource resolution
+// ---------------------------------------------------------------------------
+
+describe('ChatGptCodexProvider token source (F5)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const OK_SSE = 'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+
+  function immediateRetry(): RetryPolicy {
+    return new RetryPolicy({
+      maxRetries: 2,
+      baseDelayMs: 0,
+      maxDelayMs: 0,
+      jitter: false,
+      respectRetryAfter: false,
+    })
+  }
+
+  function fetch500Then200(authHeaders: string[]): () => number {
+    let fetches = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, options?: RequestInit) => {
+        fetches += 1
+        const headers = (options?.headers as Record<string, string>) ?? {}
+        authHeaders.push(headers.authorization ?? '')
+        return fetches === 1
+          ? new Response(JSON.stringify({ error: { message: 'overloaded' } }), { status: 500 })
+          : new Response(OK_SSE, {
+              status: 200,
+              headers: { 'content-type': 'text/event-stream' },
+            })
+      }),
+    )
+    return () => fetches
+  }
+
+  it('mock fetch 500-then-200 makes exactly 2 fetches and sends Bearer tok-2 on the retry', async () => {
+    let tokenCalls = 0
+    const source = async (): Promise<string> => {
+      tokenCalls += 1
+      return `tok-${tokenCalls}`
+    }
+    const authHeaders: string[] = []
+    const fetchCount = fetch500Then200(authHeaders)
+
+    const prov = new ChatGptCodexProvider(source, 'acct').withRetryPolicy(immediateRetry())
+    for await (const _ of prov.stream(REQ)) {
+      /* drain */
+    }
+
+    expect(fetchCount()).toBe(2)
+    expect(tokenCalls).toBe(2)
+    expect(authHeaders).toEqual(['Bearer tok-1', 'Bearer tok-2'])
+  })
+
+  it('plain string accessToken compatibility regression keeps the same Bearer token', async () => {
+    const authHeaders: string[] = []
+    const fetchCount = fetch500Then200(authHeaders)
+
+    const prov = new ChatGptCodexProvider('static-tok', 'acct').withRetryPolicy(immediateRetry())
+    const resp = await prov.chat(REQ)
+
+    expect(resp.stopReason).toBe('end_turn')
+    expect(fetchCount()).toBe(2)
+    expect(authHeaders).toEqual(['Bearer static-tok', 'Bearer static-tok'])
+  })
+})


### PR DESCRIPTION
## Summary
- Add exported TypeScript TokenSource type for ChatGPT-Codex access tokens.
- Resolve string-or-async accessToken once per retry attempt so refreshed tokens are used after retryable failures.
- Add provider and ClientBuilder regression coverage for 500-then-200 token refresh plus plain string accessToken compatibility.

## Verification
- Format: treefmt via nix shell, 205 files processed, 0 changed.
- Lint: project lint helper passed (cargo clippy, ruff check, treefmt --fail-on-change).
- TypeScript: npm run typecheck; npm run build; npm test.
- Targeted: providers-chatgpt-codex token source verbose tests passed.
- Export: grep -n "TokenSource" dist/index.d.ts.

Existing test cases were not modified; only new regression tests were appended.