### PR TITLE
feat(python)!: typed thinking events, CLI end_turn contract, token_source, claude_code (M4, BREAKING)

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `motosan-ai` Python SDK are documented in this file.
 
+## [Unreleased]
+
+### Added
+- `Provider.claude_code` + `Client.claude_code(binary_path=None, model=None, max_retries=3, retry_policy=None, cli_timeout=...)`: the `claude` CLI backend is now reachable through unified `Client` dispatch (previously direct `ClaudeCodeClient()` only). `binary_path` falls back to `CLAUDE_CODE_PATH` then `claude` in `PATH`; `cli_timeout` threads to `.timeout()` / `.no_timeout()` exactly like `Client.codex_cli()` (claude default remains 300s). Richer knobs (`permission_mode`, `effort`, `agent_mode`, session flags, ...) remain builder methods on the underlying `ClaudeCodeClient`.
+
 ## [0.17.0] - 2026-07-17
 
 ### Breaking

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -261,9 +261,10 @@ async for event in client.stream(
 
 Notes:
 - Uses `CLAUDE_CODE_PATH` env var or `claude` in `PATH`.
+- Available through both direct `ClaudeCodeClient()` and unified `Client.claude_code()` / `Provider.claude_code` dispatch (`binary_path`, `model`, `cli_timeout`; richer flags via the `ClaudeCodeClient` builder).
 - Live tests are opt-in: set `MOTOSAN_RUN_CLAUDE_CODE_LIVE=1`.
-- `tool_calls` is always empty (tools run inside CLI).
-- `agent_mode(True)` enables `--dangerously-skip-permissions` + JSON output parsing.
+- Blocking `chat()` delegates to `stream()` + collect: `tool_calls` records tools the CLI already executed, and a completed turn always reports `stop_reason="end_turn"`.
+- `agent_mode(True)` enables `--dangerously-skip-permissions`; `chat()` still uses the stream-JSON path because it delegates to `stream()`.
 - Python v0.9.0 adds full Rust-compatible Claude Code flag coverage: `bare`, `system_prompt`, `permission_mode`, `effort`, `fallback_model`, `add_dir(s)`, `allow_tool` / `allowed_tools`, `disallow_tool` / `disallowed_tools`, `mcp_config(s)`, `strict_mcp_config`, `settings`, `setting_source(s)`, `session_id`, `resume`, `continue_latest`, `fork_session`, `plugin_dir(s)`, `agent`, `no_session_persistence`, and `max_budget_usd`.
 - `system_prompt(...)` maps to `--system-prompt`; system messages / `ChatRequest.system` are appended with `--append-system-prompt`.
 - `allowed_tools`, `disallowed_tools`, and `mcp_configs` are variadic CLI arguments, matching Rust (`--allowed-tools Read Bash`, not comma-joined).

--- a/sdks/python/motosan_ai/_stream_collect.py
+++ b/sdks/python/motosan_ai/_stream_collect.py
@@ -40,7 +40,7 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
 
     async for event in events:
         # last-wins on session_id (HTTP providers never set it, so usually None);
-        # CLI readback uses the provider chat()/stream() first-wins path, not this.
+        # CLI providers emit exactly one session event per stream.
         if event.session_id is not None:
             session_id = event.session_id
         if event.event_type == "text" and event.content:

--- a/sdks/python/motosan_ai/_stream_collect.py
+++ b/sdks/python/motosan_ai/_stream_collect.py
@@ -12,11 +12,13 @@ from motosan_ai.types import ChatResponse, StopReason, StreamEvent, ToolCall, Us
 async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
     """Collect a stream into one ChatResponse.
 
-    Handles text, thinking, tool-call start/args/end, usage, and terminal
-    stop_reason events. Malformed streamed tool arguments are treated as an
-    empty object to match provider collector behavior. A mid-stream provider
-    error (StreamError / NetworkError / ProviderError) raised by ``events``
-    propagates out of this function uncollected.
+    Handles text, thinking_delta/thinking_done, tool-call start/args/end,
+    usage, and terminal stop_reason events. thinking_done text takes
+    priority over concatenated thinking_delta fallback. Malformed streamed
+    tool arguments are treated as an empty object to match provider
+    collector behavior. A mid-stream provider error (StreamError /
+    NetworkError / ProviderError) raised by ``events`` propagates out of
+    this function uncollected.
     """
     content = ""
     tool_calls: list[ToolCall] = []
@@ -43,11 +45,6 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
             session_id = event.session_id
         if event.event_type == "text" and event.content:
             content += event.content
-        elif event.event_type == "thinking" and event.content:
-            # Legacy ad-hoc event; kept for one commit so provider
-            # migration lands green. Removed in the last step of this
-            # task (M4/F3 BREAKING).
-            thinking_delta_buf += event.content
         elif event.event_type == "thinking_delta" and event.content:
             thinking_delta_buf += event.content
         elif event.event_type == "thinking_done":

--- a/sdks/python/motosan_ai/_stream_collect.py
+++ b/sdks/python/motosan_ai/_stream_collect.py
@@ -19,7 +19,6 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
     propagates out of this function uncollected.
     """
     content = ""
-    thinking = ""
     tool_calls: list[ToolCall] = []
     usage = Usage(0, 0)
     stop_reason: StopReason | None = None
@@ -29,6 +28,14 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
     current_tc_args = ""
     session_id: str | None = None
 
+    # Thinking accumulation (mirrors Rust stream.rs). thinking_delta_buf
+    # collects every thinking_delta as a fallback in case the provider
+    # does not emit thinking_done. thinking_done_buf holds the explicit
+    # final text from the most recent thinking_done and takes priority
+    # on assembly.
+    thinking_delta_buf = ""
+    thinking_done_buf: str | None = None
+
     async for event in events:
         # last-wins on session_id (HTTP providers never set it, so usually None);
         # CLI readback uses the provider chat()/stream() first-wins path, not this.
@@ -37,7 +44,17 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
         if event.event_type == "text" and event.content:
             content += event.content
         elif event.event_type == "thinking" and event.content:
-            thinking += event.content
+            # Legacy ad-hoc event; kept for one commit so provider
+            # migration lands green. Removed in the last step of this
+            # task (M4/F3 BREAKING).
+            thinking_delta_buf += event.content
+        elif event.event_type == "thinking_delta" and event.content:
+            thinking_delta_buf += event.content
+        elif event.event_type == "thinking_done":
+            # thinking_done carries the full text; it wins over the delta
+            # accumulator. Clear deltas so a second block starts fresh.
+            thinking_done_buf = event.content
+            thinking_delta_buf = ""
         elif event.event_type == "tool_call_start":
             current_tc_id = event.tool_call_id or ""
             current_tc_name = event.tool_call_name or ""
@@ -77,12 +94,18 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
     if stop_reason is None:
         stop_reason = StopReason.tool_use if tool_calls else StopReason.end_turn
 
+    if thinking_done_buf is not None:
+        # Explicit empty thinking block -> treat as none (Rust parity).
+        thinking = thinking_done_buf or None
+    else:
+        thinking = thinking_delta_buf or None
+
     return ChatResponse(
         content=content,
         tool_calls=tool_calls,
         model="",
         usage=usage,
         stop_reason=stop_reason,
-        thinking=thinking or None,
+        thinking=thinking,
         session_id=session_id,
     )

--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -13,6 +13,7 @@ from motosan_ai.error import ConfigError, MotosanError, NetworkError, ProviderEr
 from motosan_ai.providers import (
     AnthropicProvider,
     ChatGptCodexProvider,
+    ClaudeCodeClient,
     CodexCliClient,
     GeminiCliClient,
     GeminiCodeAssistProvider,
@@ -37,6 +38,7 @@ class Provider(StrEnum):
     minimax = "minimax"
     ollama = "ollama"
     gemini = "gemini"
+    claude_code = "claude_code"
     codex_cli = "codex_cli"
     gemini_cli = "gemini_cli"
     gemini_code_assist = "gemini_code_assist"
@@ -123,6 +125,11 @@ class Client:
                 connect_timeout=connect_timeout,
                 read_idle_timeout=read_idle_timeout,
             ).reasoning_effort(reasoning_effort)
+        elif provider_value == Provider.claude_code:
+            self.api_key = ""
+            self._provider = self._apply_cli_timeout(
+                ClaudeCodeClient(binary_path=binary_path), cli_timeout
+            )
         elif provider_value == Provider.codex_cli:
             self.api_key = ""
             self._provider = self._apply_cli_timeout(
@@ -323,6 +330,24 @@ class Client:
         )
 
     @classmethod
+    def claude_code(
+        cls,
+        binary_path: str | None = None,
+        model: str | None = None,
+        max_retries: int = 3,
+        retry_policy: RetryPolicy | None = None,
+        cli_timeout: float | None = _UNSET_CLI_TIMEOUT,
+    ) -> Client:
+        return cls(
+            provider=Provider.claude_code,
+            binary_path=binary_path,
+            model=model,
+            max_retries=max_retries,
+            retry_policy=retry_policy,
+            cli_timeout=cli_timeout,
+        )
+
+    @classmethod
     def gemini_cli(
         cls,
         binary_path: str | None = None,
@@ -377,9 +402,9 @@ class Client:
 
     @staticmethod
     def _apply_cli_timeout(
-        cli: CodexCliClient | GeminiCliClient,
+        cli: ClaudeCodeClient | CodexCliClient | GeminiCliClient,
         cli_timeout: float | None,
-    ) -> CodexCliClient | GeminiCliClient:
+    ) -> ClaudeCodeClient | CodexCliClient | GeminiCliClient:
         if cli_timeout is _UNSET_CLI_TIMEOUT:
             return cli
         if cli_timeout is None:

--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from dataclasses import replace
 from enum import StrEnum
 from types import TracebackType
@@ -73,6 +73,7 @@ class Client:
         account_id: str | None = None,
         *,
         reasoning_effort: str | None = None,
+        token_source: Callable[[], Awaitable[str]] | None = None,
         ollama_native: bool = False,
         ollama_think: bool = False,
         ollama_keep_alive: str | None = None,
@@ -108,8 +109,8 @@ class Client:
                 read_idle_timeout=read_idle_timeout,
             )
         elif provider_value == Provider.openai_chatgpt:
-            if not access_token:
-                raise ConfigError("openai_chatgpt requires access_token")
+            if not access_token and token_source is None:
+                raise ConfigError("openai_chatgpt requires access_token or token_source")
             if not account_id:
                 raise ConfigError("openai_chatgpt requires account_id")
             self.api_key = ""
@@ -118,6 +119,7 @@ class Client:
                 account_id=account_id,
                 model=model,
                 base_url=base_url,
+                token_source=token_source,
                 connect_timeout=connect_timeout,
                 read_idle_timeout=read_idle_timeout,
             ).reasoning_effort(reasoning_effort)
@@ -270,6 +272,7 @@ class Client:
         reasoning_effort: str | None = None,
         max_retries: int = 3,
         retry_policy: RetryPolicy | None = None,
+        token_source: Callable[[], Awaitable[str]] | None = None,
     ) -> Client:
         return cls(
             provider=Provider.openai_chatgpt,
@@ -280,6 +283,7 @@ class Client:
             reasoning_effort=reasoning_effort,
             max_retries=max_retries,
             retry_policy=retry_policy,
+            token_source=token_source,
         )
 
     @classmethod

--- a/sdks/python/motosan_ai/providers/anthropic.py
+++ b/sdks/python/motosan_ai/providers/anthropic.py
@@ -25,6 +25,7 @@ from motosan_ai.types import (
     Role,
     StopReason,
     StreamEvent,
+    StreamEventType,
     ToolCall,
     Usage,
     content_block_to_dict,
@@ -428,6 +429,11 @@ class AnthropicProvider(BaseProvider):
 
         current_tool_id: str | None = None
         current_stop_reason: StopReason | None = None
+        # Accumulates the text of an open `thinking` content block; None
+        # when no thinking block is open (redacted_thinking never opens
+        # it). content_block_stop drains it into a thinking_done event
+        # (mirrors the Rust adapter, anthropic.rs).
+        current_thinking: str | None = None
 
         try:
             if not resp.is_success:
@@ -497,6 +503,12 @@ class AnthropicProvider(BaseProvider):
                             tool_call_name=block.get("name", ""),
                             event_type="tool_call_start",
                         )
+                    elif block.get("type") == "thinking":
+                        # Open the thinking accumulator. No event is
+                        # emitted at start; redacted_thinking blocks
+                        # intentionally leave current_thinking as None so
+                        # their block_stop is a no-op.
+                        current_thinking = ""
 
                 elif event_type == "content_block_delta":
                     delta = payload.get("delta") or {}
@@ -508,8 +520,12 @@ class AnthropicProvider(BaseProvider):
                     elif delta_type == "thinking_delta":
                         thinking_text = delta.get("thinking", "")
                         if thinking_text:
+                            if current_thinking is not None:
+                                current_thinking += thinking_text
                             yield StreamEvent(
-                                content=thinking_text, done=False, event_type="thinking"
+                                content=thinking_text,
+                                done=False,
+                                event_type=StreamEventType.thinking_delta,
                             )
                     elif delta_type == "input_json_delta":
                         partial = delta.get("partial_json", "")
@@ -531,6 +547,16 @@ class AnthropicProvider(BaseProvider):
                             event_type="tool_call_end",
                         )
                         current_tool_id = None
+                    elif current_thinking is not None:
+                        # Emit even when empty: presence of thinking_done
+                        # tells consumers a thinking block existed (Rust
+                        # parity, anthropic.rs content_block_stop).
+                        yield StreamEvent(
+                            content=current_thinking,
+                            done=False,
+                            event_type=StreamEventType.thinking_done,
+                        )
+                        current_thinking = None
 
                 elif event_type == "message_stop":
                     yield StreamEvent(content="", done=True, stop_reason=current_stop_reason)

--- a/sdks/python/motosan_ai/providers/chatgpt_codex.py
+++ b/sdks/python/motosan_ai/providers/chatgpt_codex.py
@@ -25,6 +25,7 @@ from motosan_ai.types import (
     Role,
     StopReason,
     StreamEvent,
+    StreamEventType,
     Usage,
 )
 
@@ -82,7 +83,13 @@ def _parse_sse_event(data: str, state: _ChatGptCodexAdapterState) -> list[Stream
     ):
         delta = chunk.get("delta")
         if isinstance(delta, str) and delta:
-            out.append(StreamEvent(content=delta, done=False, event_type="thinking"))
+            out.append(
+                StreamEvent(
+                    content=delta,
+                    done=False,
+                    event_type=StreamEventType.thinking_delta,
+                )
+            )
 
     elif event_type == "response.output_item.added":
         item = chunk.get("item")

--- a/sdks/python/motosan_ai/providers/chatgpt_codex.py
+++ b/sdks/python/motosan_ai/providers/chatgpt_codex.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -10,6 +10,7 @@ import httpx
 from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import (
     AuthError,
+    ConfigError,
     IncompleteStreamError,
     NetworkError,
     ProviderError,
@@ -200,15 +201,21 @@ class ChatGptCodexProvider(BaseProvider):
 
     def __init__(
         self,
-        access_token: str,
-        account_id: str,
+        access_token: str | None = None,
+        account_id: str | None = None,
         model: str | None = None,
         base_url: str | None = None,
         *,
+        token_source: Callable[[], Awaitable[str]] | None = None,
         connect_timeout: float = 10.0,
         read_idle_timeout: float = 120.0,
     ) -> None:
+        if access_token is None and token_source is None:
+            raise ConfigError("chatgpt_codex requires access_token or token_source")
+        if not account_id:
+            raise ConfigError("chatgpt_codex requires account_id")
         self.access_token = access_token
+        self.token_source = token_source
         self.account_id = account_id
         self.model = model or _DEFAULT_MODEL
         self.base_url = base_url or _DEFAULT_BASE_URL
@@ -243,9 +250,23 @@ class ChatGptCodexProvider(BaseProvider):
     def _stream_url(self) -> str:
         return self.base_url
 
-    def _headers(self) -> dict[str, str]:
+    async def _bearer(self) -> str:
+        """Resolve the bearer token for the current request attempt (F5).
+
+        When ``token_source`` is set it is awaited on every call. The retry
+        loops live in ``Client`` (``_dispatch_chat`` / ``stream_with``) and
+        re-enter ``stream()`` once per attempt, so each attempt fetches a
+        fresh token.
+        """
+        if self.token_source is not None:
+            return await self.token_source()
+        if self.access_token is None:  # pragma: no cover — guarded in __init__
+            raise ConfigError("chatgpt_codex requires access_token or token_source")
+        return self.access_token
+
+    def _headers(self, bearer: str) -> dict[str, str]:
         return {
-            "authorization": f"Bearer {self.access_token}",
+            "authorization": f"Bearer {bearer}",
             "chatgpt-account-id": self.account_id,
             "originator": _ORIGINATOR,
             "openai-beta": "responses=experimental",
@@ -371,10 +392,15 @@ class ChatGptCodexProvider(BaseProvider):
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:
         self.validate_request(request)
         body = self._build_responses_body(request)
+        # F5: resolved at the top of the attempt. Client retry loops re-invoke
+        # stream() per attempt (chat() delegates here too), so a token_source
+        # is consulted once per attempt. Token-source failures propagate
+        # verbatim — they are auth plumbing, not transport errors.
+        bearer = await self._bearer()
         try:
             resp = await self._http.send(
                 self._http.build_request(
-                    "POST", self._stream_url(), headers=self._headers(), json=body
+                    "POST", self._stream_url(), headers=self._headers(bearer), json=body
                 ),
                 stream=True,
             )

--- a/sdks/python/motosan_ai/providers/claude_code.py
+++ b/sdks/python/motosan_ai/providers/claude_code.py
@@ -7,6 +7,7 @@ import os
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 
+from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.types import (
@@ -111,34 +112,6 @@ def _raise_on_error_result(event: dict) -> None:
     parts = [p for p in (subtype, result_text) if isinstance(p, str) and p]
     detail = ": ".join(parts) if parts else "unknown error"
     raise StreamError(f"claude CLI reported an error result: {detail}")
-
-
-def _parse_agent_json(raw: str) -> tuple[str, Usage, str | None]:
-    """Parse JSON output from agent mode: ``result``, ``usage``, ``session_id``.
-
-    Raises :class:`~motosan_ai.error.StreamError` when the payload reports an
-    error result (``is_error: true`` or an ``error_*`` subtype).
-    """
-    try:
-        v = json.loads(raw)
-    except json.JSONDecodeError as e:
-        raise ProviderError(f"failed to parse claude JSON output: {e}") from e
-
-    if isinstance(v, dict):
-        _raise_on_error_result(v)
-
-    text = v.get("result", "")
-    u = v.get("usage", {})
-    sid = v.get("session_id")
-    session_id = sid if isinstance(sid, str) and sid else None
-    return (
-        text,
-        Usage(
-            input_tokens=int(u.get("input_tokens", 0)),
-            output_tokens=int(u.get("output_tokens", 0)),
-        ),
-        session_id,
-    )
 
 
 def _parse_ndjson_line(line: str) -> list[StreamEvent]:
@@ -446,8 +419,6 @@ class ClaudeCodeClient:
             args.extend(["--output-format", output_format])
             if output_format == "stream-json":
                 args.append("--verbose")
-        elif self._config.agent_mode:
-            args.extend(["--output-format", "json"])
 
         if self._config.bare:
             args.append("--bare")
@@ -541,62 +512,21 @@ class ClaudeCodeClient:
         return args
 
     async def chat(self, request: ChatRequest) -> ChatResponse:
-        """Invoke ``claude --print`` and collect the output."""
-        msg_system, user_prompt = _messages_to_prompt(request.messages)
-        system_prompt = request.system or msg_system
+        """Collect :meth:`stream` into one response (F4 delegation).
 
-        args = self._build_args(
-            model=request.model,
-            system_prompt=system_prompt,
-        )
-
-        proc = await asyncio.create_subprocess_exec(
-            *args,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=self._config.cwd,
-            env=self._subprocess_env(),
-        )
-
-        timeout = self._config.timeout_secs
-        try:
-            if timeout is None:
-                stdout, stderr = await proc.communicate(user_prompt.encode())
-            else:
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(user_prompt.encode()),
-                    timeout=timeout,
-                )
-        except TimeoutError as exc:
-            proc.kill()
-            await proc.wait()
-            raise ProviderError(f"claude CLI timed out after {timeout} seconds") from exc
-
-        if proc.returncode != 0:
-            raise ProviderError(
-                f"claude CLI exited with {proc.returncode}: {stderr.decode().strip()}"
-            )
-
-        raw = stdout.decode()
-
-        if self._agent_mode:
-            text, usage, session_id = _parse_agent_json(raw)
-        else:
-            text = raw.strip()
-            usage = Usage(input_tokens=0, output_tokens=0)
-            session_id = None
-
-        effective_model = request.model or self._config.model or ""
-
-        return ChatResponse(
-            content=text,
-            tool_calls=[],
-            model=effective_model,
-            usage=usage,
-            stop_reason=StopReason.end_turn,
-            session_id=session_id,
-        )
+        content / thinking / tool_calls / usage / session_id / stop_reason
+        are identical to collecting :meth:`stream` by construction;
+        ``tool_calls`` is the record of tools the CLI already executed, and
+        a completed turn always reports ``StopReason.end_turn``. The one
+        documented parity exception: ``model`` is backfilled from the
+        request or client config because CLI transcripts do not echo a
+        model name. Error mapping follows the stream path: per-read stalls
+        raise ``ProviderError``; CLI error results and early child death
+        raise ``StreamError``.
+        """
+        response = await collect_stream(self.stream(request))
+        response.model = request.model or self._config.model or ""
+        return response
 
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:
         """Stream via ``claude --print --output-format stream-json``, yielding NDJSON events.
@@ -632,7 +562,6 @@ class ClaudeCodeClient:
 
         assert proc.stdout is not None
         timeout = self._config.timeout_secs
-        saw_tool_call = False
         saw_done = False
         try:
             while True:
@@ -667,17 +596,11 @@ class ClaudeCodeClient:
                 if not line:
                     continue
                 for event in _parse_ndjson_line(line):
-                    if event.event_type in (
-                        "tool_call_start",
-                        "tool_call_args",
-                        "tool_call_end",
-                    ):
-                        saw_tool_call = True
                     if event.done:
                         saw_done = True
-                        event.stop_reason = (
-                            StopReason.tool_use if saw_tool_call else StopReason.end_turn
-                        )
+                        # F4: the CLI executes tools internally; a completed
+                        # turn always ends the turn — never a tool_use request.
+                        event.stop_reason = StopReason.end_turn
                     yield event
                     if event.done:
                         return

--- a/sdks/python/motosan_ai/providers/codex_cli.py
+++ b/sdks/python/motosan_ai/providers/codex_cli.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from enum import StrEnum
 
+from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.types import (
@@ -351,56 +352,18 @@ class CodexCliClient:
         return args
 
     async def chat(self, request: ChatRequest) -> ChatResponse:
-        msg_system, user_prompt = _messages_to_prompt(request.messages)
-        prompt = _compose_prompt(request.system or msg_system, user_prompt)
-        args = self._build_args(model=request.model)
+        """Collect :meth:`stream` into one response (F4 delegation).
 
-        proc = await asyncio.create_subprocess_exec(
-            *args,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=self._subprocess_env(),
-        )
-        timeout = self._config.timeout_secs
-        try:
-            if timeout is None:
-                stdout, stderr = await proc.communicate(prompt.encode())
-            else:
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(prompt.encode()), timeout=timeout
-                )
-        except TimeoutError as exc:
-            proc.kill()
-            await proc.wait()
-            raise ProviderError(f"codex CLI timed out after {timeout}s") from exc
-
-        if proc.returncode != 0:
-            raise ProviderError(
-                f"codex CLI exited with {proc.returncode}: {stderr.decode().strip()}"
-            )
-
-        content_parts: list[str] = []
-        usage = Usage(0, 0)
-        session_id: str | None = None
-        for raw in stdout.decode().splitlines():
-            for event in _parse_jsonl_line(raw):
-                if event.session_id is not None and session_id is None:
-                    session_id = event.session_id
-                elif event.event_type == "text" and event.content:
-                    content_parts.append(event.content)
-                elif event.event_type == "usage" and event.usage is not None:
-                    usage = event.usage
-
-        return ChatResponse(
-            content="".join(content_parts),
-            # Codex CLI runs tools internally and does not surface SDK tool calls.
-            tool_calls=[],
-            model=request.model or self._config.model or "",
-            usage=usage,
-            stop_reason=StopReason.end_turn,
-            session_id=session_id,
-        )
+        ``tool_calls`` is the record of tools the CLI already executed; a
+        completed turn always reports ``StopReason.end_turn``. Parity
+        exception: ``model`` is backfilled from the request or client
+        config. Error mapping follows the stream path: per-read stalls
+        raise ``ProviderError``; turn failures raise ``ProviderError`` via
+        the parser; early child death raises ``StreamError``.
+        """
+        response = await collect_stream(self.stream(request))
+        response.model = request.model or self._config.model or ""
+        return response
 
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:
         msg_system, user_prompt = _messages_to_prompt(request.messages)
@@ -415,7 +378,6 @@ class CodexCliClient:
             env=self._subprocess_env(),
         )
 
-        saw_tool_call = False
         saw_done = False
         try:
             assert proc.stdin is not None and proc.stdout is not None
@@ -456,16 +418,11 @@ class CodexCliClient:
                     )
                 line = raw.decode().rstrip("\n")
                 for event in _parse_jsonl_line(line):
-                    if event.event_type in (
-                        "tool_call_start",
-                        "tool_call_args",
-                        "tool_call_end",
-                    ):
-                        saw_tool_call = True
                     if event.done:
                         saw_done = True
-                    if event.done and saw_tool_call:
-                        event.stop_reason = StopReason.tool_use
+                        # F4: the CLI executes tools internally; a completed
+                        # turn always ends the turn — never a tool_use request.
+                        event.stop_reason = StopReason.end_turn
                     yield event
                     if event.done:
                         return

--- a/sdks/python/motosan_ai/providers/gemini_cli.py
+++ b/sdks/python/motosan_ai/providers/gemini_cli.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from enum import StrEnum
 
+from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.provider_base import ProviderCapabilities
 from motosan_ai.types import (
@@ -314,58 +315,18 @@ class GeminiCliClient:
         return args
 
     async def chat(self, request: ChatRequest) -> ChatResponse:
-        system, user_prompt = _messages_to_prompt(request.messages)
-        if request.system:
-            system = request.system
-        stdin_payload = _merge_system_into_prompt(system, user_prompt)
-        args = self._build_args(model=request.model)
+        """Collect :meth:`stream` into one response (F4 delegation).
 
-        proc = await asyncio.create_subprocess_exec(
-            *args,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=self._config.cwd,
-            env=self._child_env(),
-        )
-        try:
-            if self._config.timeout_secs is None:
-                stdout, stderr = await proc.communicate(stdin_payload.encode())
-            else:
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(stdin_payload.encode()),
-                    timeout=self._config.timeout_secs,
-                )
-        except TimeoutError as exc:
-            proc.kill()
-            await proc.wait()
-            raise ProviderError(f"gemini CLI timed out after {self._config.timeout_secs}s") from exc
-
-        if proc.returncode != 0:
-            raise ProviderError(
-                f"gemini CLI exited with {proc.returncode}: {stderr.decode().strip()}"
-            )
-
-        content_parts: list[str] = []
-        usage = Usage(0, 0)
-        session_id: str | None = None
-        for raw in stdout.decode().splitlines():
-            for event in _parse_jsonl_line(raw):
-                if event.session_id and session_id is None:
-                    session_id = event.session_id
-                elif event.event_type == "text" and event.content:
-                    content_parts.append(event.content)
-                elif event.event_type == "usage" and event.usage is not None:
-                    usage = event.usage
-
-        return ChatResponse(
-            content="".join(content_parts),
-            tool_calls=[],
-            model=request.model or self._config.model or "",
-            usage=usage,
-            stop_reason=StopReason.end_turn,
-            session_id=session_id,
-        )
+        ``tool_calls`` is the record of tools the CLI already executed; a
+        completed turn always reports ``StopReason.end_turn``. Parity
+        exception: ``model`` is backfilled from the request or client
+        config. Error mapping follows the stream path: per-read stalls
+        raise ``ProviderError``; result failures raise ``ProviderError``
+        via the parser; early child death raises ``StreamError``.
+        """
+        response = await collect_stream(self.stream(request))
+        response.model = request.model or self._config.model or ""
+        return response
 
     async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:
         system, user_prompt = _messages_to_prompt(request.messages)
@@ -382,7 +343,6 @@ class GeminiCliClient:
             cwd=self._config.cwd,
             env=self._child_env(),
         )
-        saw_tool_call = False
         saw_done = False
         try:
             assert proc.stdin is not None and proc.stdout is not None
@@ -424,13 +384,11 @@ class GeminiCliClient:
                     )
                 line = raw.decode().rstrip("\n")
                 for event in _parse_jsonl_line(line):
-                    if event.event_type == "tool_call_start":
-                        saw_tool_call = True
                     if event.done:
                         saw_done = True
-                        event.stop_reason = (
-                            StopReason.tool_use if saw_tool_call else StopReason.end_turn
-                        )
+                        # F4: the CLI executes tools internally; a completed
+                        # turn always ends the turn — never a tool_use request.
+                        event.stop_reason = StopReason.end_turn
                     yield event
                     if event.done:
                         return

--- a/sdks/python/motosan_ai/types.py
+++ b/sdks/python/motosan_ai/types.py
@@ -27,6 +27,14 @@ class StreamEventType(StrEnum):
     tool_call_args = "tool_call_args"
     tool_call_end = "tool_call_end"
     usage = "usage"
+    # Partial extended-thinking delta; StreamEvent.content carries the
+    # delta text. Emitted by anthropic and chatgpt_codex streams.
+    thinking_delta = "thinking_delta"
+    # End of a thinking block; StreamEvent.content carries the FULL
+    # concatenated thinking text. Emitted by anthropic on
+    # content_block_stop of a thinking block, always after that block's
+    # thinking_delta events and before any final-answer text events.
+    thinking_done = "thinking_done"
 
 
 @dataclass(frozen=True)

--- a/sdks/python/tests/integration/test_anthropic_live.py
+++ b/sdks/python/tests/integration/test_anthropic_live.py
@@ -16,7 +16,16 @@ import os
 
 import pytest
 
-from motosan_ai import ChatRequest, Client, Message, Provider, SystemBlock, ThinkingConfig, Tool
+from motosan_ai import (
+    ChatRequest,
+    Client,
+    Message,
+    Provider,
+    StreamEventType,
+    SystemBlock,
+    ThinkingConfig,
+    Tool,
+)
 from motosan_ai.providers.anthropic import AnthropicProvider
 
 API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
@@ -247,7 +256,9 @@ async def test_live_opus_4_8_adaptive_thinking():
             break
 
     assert any(event.done for event in events)
-    assert any(event.event_type == "thinking" and event.content for event in events)
+    assert any(
+        event.event_type == StreamEventType.thinking_delta and event.content for event in events
+    )
     assert "".join(event.content for event in events if event.event_type == "text").strip()
     await _cooldown()
 

--- a/sdks/python/tests/test_anthropic_thinking.py
+++ b/sdks/python/tests/test_anthropic_thinking.py
@@ -5,7 +5,7 @@ import pytest
 import respx
 
 from motosan_ai.providers.anthropic import AnthropicProvider
-from motosan_ai.types import ChatRequest, Message, ThinkingConfig
+from motosan_ai.types import ChatRequest, Message, StreamEventType, ThinkingConfig
 
 
 @pytest.fixture
@@ -131,9 +131,11 @@ def _sse_lines(*events: dict) -> str:
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_stream_emits_thinking_deltas_as_thinking_event(provider):
-    """Regression: `thinking_delta` events were silently dropped in the stream path,
-    so OAuth chat() (which collects from stream) never populated ChatResponse.thinking.
+async def test_stream_emits_typed_thinking_events(provider):
+    """M4/F3: thinking blocks stream as thinking_delta events, then exactly one
+    thinking_done event carrying the full concatenated text fires on
+    content_block_stop — before any final-answer text events (mirrors the Rust
+    Anthropic adapter).
     """
     sse = _sse_lines(
         {
@@ -170,11 +172,23 @@ async def test_stream_emits_thinking_deltas_as_thinking_event(provider):
     req = ChatRequest(messages=[Message.user("q")], thinking=ThinkingConfig(budget_tokens=1024))
     events = [e async for e in provider.stream(req)]
 
-    thinking_events = [e for e in events if e.event_type == "thinking" and not e.done]
-    assert [e.content for e in thinking_events] == ["Let me ", "reason..."]
+    deltas = [e for e in events if e.event_type == StreamEventType.thinking_delta]
+    assert [e.content for e in deltas] == ["Let me ", "reason..."]
 
-    text_events = [e for e in events if e.event_type == "text" and not e.done]
-    assert [e.content for e in text_events] == ["42"]
+    dones = [e for e in events if e.event_type == StreamEventType.thinking_done]
+    assert [e.content for e in dones] == ["Let me reason..."]
+    assert all(not e.done for e in deltas + dones)
+
+    idx_done = next(
+        i for i, e in enumerate(events) if e.event_type == StreamEventType.thinking_done
+    )
+    idx_first_text = next(
+        i for i, e in enumerate(events) if e.event_type == StreamEventType.text and e.content
+    )
+    assert idx_done < idx_first_text
+    assert [e.content for e in events if e.event_type == StreamEventType.text and e.content] == [
+        "42"
+    ]
 
 
 @respx.mock

--- a/sdks/python/tests/test_chatgpt_codex_dispatch.py
+++ b/sdks/python/tests/test_chatgpt_codex_dispatch.py
@@ -51,3 +51,26 @@ def test_client_chatgpt_codex_threads_reasoning_effort_default():
 def test_client_chatgpt_codex_reasoning_effort_defaults_none():
     c = Client.chatgpt_codex(access_token="tok", account_id="acct-123")
     assert c._provider._reasoning_effort is None
+
+
+def test_client_chatgpt_codex_accepts_token_source_without_access_token():
+    async def source() -> str:
+        return "tok"
+
+    c = Client.chatgpt_codex(account_id="acct-123", token_source=source)
+    assert isinstance(c._provider, ChatGptCodexProvider)
+    assert c._provider.token_source is source
+    assert c._provider.access_token is None
+
+
+def test_client_chatgpt_codex_token_source_still_requires_account_id():
+    async def source() -> str:
+        return "tok"
+
+    with pytest.raises(ConfigError, match="account_id"):
+        Client.chatgpt_codex(token_source=source)
+
+
+def test_client_chatgpt_codex_error_mentions_token_source():
+    with pytest.raises(ConfigError, match="access_token or token_source"):
+        Client.chatgpt_codex(account_id="acct-123")

--- a/sdks/python/tests/test_chatgpt_codex_http.py
+++ b/sdks/python/tests/test_chatgpt_codex_http.py
@@ -241,3 +241,77 @@ async def test_stream_5xx_message_has_status_and_retry_after():
     msg = str(exc_info.value)
     assert "HTTP 503: overloaded" in msg
     assert "Retry-After: 7" in msg
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_chat_token_source_resolved_per_attempt():
+    from motosan_ai.retry import with_retry
+
+    awaited: list[str] = []
+
+    async def source() -> str:
+        tok = f"tok-{len(awaited) + 1}"
+        awaited.append(tok)
+        return tok
+
+    seen_auth: list[str] = []
+    replies = iter(
+        [
+            httpx.Response(500, json={"error": {"message": "boom"}}),
+            httpx.Response(200, text=_text_stream(), headers={"content-type": "text/event-stream"}),
+        ]
+    )
+
+    def _respond(request: httpx.Request) -> httpx.Response:
+        seen_auth.append(request.headers["authorization"])
+        return next(replies)
+
+    route = respx.post(_URL).mock(side_effect=_respond)
+    p = ChatGptCodexProvider(account_id="acct-123", model="gpt-5.5", token_source=source)
+    resp = await with_retry(
+        lambda: p.chat(ChatRequest(messages=[Message.user("hi")])),
+        max_retries=2,
+        initial_backoff=0.001,
+    )
+    assert resp.content == "Hello world."
+    assert route.call_count == 2
+    assert awaited == ["tok-1", "tok-2"]
+    assert seen_auth == ["Bearer tok-1", "Bearer tok-2"]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_stream_token_source_resolved_per_call():
+    awaited: list[str] = []
+
+    async def source() -> str:
+        tok = f"tok-{len(awaited) + 1}"
+        awaited.append(tok)
+        return tok
+
+    seen_auth: list[str] = []
+    replies = iter(
+        [
+            httpx.Response(500, json={"error": {"message": "boom"}}),
+            httpx.Response(200, text=_text_stream(), headers={"content-type": "text/event-stream"}),
+        ]
+    )
+
+    def _respond(request: httpx.Request) -> httpx.Response:
+        seen_auth.append(request.headers["authorization"])
+        return next(replies)
+
+    respx.post(_URL).mock(side_effect=_respond)
+    p = ChatGptCodexProvider(account_id="acct-123", token_source=source)
+
+    # Each stream() invocation resolves the token anew — this is exactly what
+    # Client._dispatch_chat / Client.stream_with do once per retry attempt.
+    with pytest.raises(ProviderError):
+        async for _ in p.stream(ChatRequest(messages=[Message.user("hi")])):
+            pass
+
+    events = [e async for e in p.stream(ChatRequest(messages=[Message.user("hi")]))]
+    assert events[-1].done is True
+    assert awaited == ["tok-1", "tok-2"]
+    assert seen_auth == ["Bearer tok-1", "Bearer tok-2"]

--- a/sdks/python/tests/test_chatgpt_codex_http.py
+++ b/sdks/python/tests/test_chatgpt_codex_http.py
@@ -315,3 +315,41 @@ async def test_stream_token_source_resolved_per_call():
     assert events[-1].done is True
     assert awaited == ["tok-1", "tok-2"]
     assert seen_auth == ["Bearer tok-1", "Bearer tok-2"]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_client_stream_retry_uses_fresh_token_per_attempt():
+    from motosan_ai import Client
+    from motosan_ai.retry import RetryPolicy
+
+    awaited: list[str] = []
+
+    async def source() -> str:
+        tok = f"tok-{len(awaited) + 1}"
+        awaited.append(tok)
+        return tok
+
+    seen_auth: list[str] = []
+    replies = iter(
+        [
+            httpx.Response(500, json={"error": {"message": "boom"}}),
+            httpx.Response(200, text=_text_stream(), headers={"content-type": "text/event-stream"}),
+        ]
+    )
+
+    def _respond(request: httpx.Request) -> httpx.Response:
+        seen_auth.append(request.headers["authorization"])
+        return next(replies)
+
+    respx.post(_URL).mock(side_effect=_respond)
+    c = Client.chatgpt_codex(
+        account_id="acct-123",
+        token_source=source,
+        retry_policy=RetryPolicy(max_retries=1, base_delay=0.001, jitter=False),
+    )
+    events = [e async for e in c.stream([{"role": "user", "content": "hi"}])]
+    text = "".join(e.content for e in events if not e.done)
+    assert text == "Hello world."
+    assert awaited == ["tok-1", "tok-2"]
+    assert seen_auth == ["Bearer tok-1", "Bearer tok-2"]

--- a/sdks/python/tests/test_chatgpt_codex_request.py
+++ b/sdks/python/tests/test_chatgpt_codex_request.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
+from motosan_ai.error import ConfigError
 from motosan_ai.providers.chatgpt_codex import ChatGptCodexProvider
 from motosan_ai.types import (
     ChatRequest,
@@ -36,7 +39,7 @@ def test_stream_url_returns_base_url_verbatim():
 
 
 def test_auth_headers_present_and_lowercase():
-    h = ChatGptCodexProvider("tok", "acct-123")._headers()
+    h = ChatGptCodexProvider("tok", "acct-123")._headers("tok")
     assert h["authorization"] == "Bearer tok"
     assert h["chatgpt-account-id"] == "acct-123"
     assert h["originator"] == "codex_cli_rs"
@@ -227,3 +230,28 @@ def test_reasoning_effort_none_clears_default():
     p = _provider().reasoning_effort("high").reasoning_effort(None)
     body = p._build_responses_body(ChatRequest(messages=[Message.user("hi")]))
     assert "reasoning" not in body
+
+
+def test_constructor_requires_access_token_or_token_source():
+    with pytest.raises(ConfigError, match="access_token or token_source"):
+        ChatGptCodexProvider(account_id="acct-123")
+
+
+def test_constructor_requires_account_id():
+    with pytest.raises(ConfigError, match="account_id"):
+        ChatGptCodexProvider(access_token="tok")
+
+
+def test_constructor_accepts_token_source_without_access_token():
+    async def source() -> str:
+        return "tok"
+
+    p = ChatGptCodexProvider(account_id="acct-123", token_source=source)
+    assert p.access_token is None
+    assert p.token_source is source
+
+
+def test_static_access_token_leaves_token_source_none():
+    p = ChatGptCodexProvider("tok", "acct-123")
+    assert p.access_token == "tok"
+    assert p.token_source is None

--- a/sdks/python/tests/test_chatgpt_codex_stream.py
+++ b/sdks/python/tests/test_chatgpt_codex_stream.py
@@ -12,7 +12,7 @@ from motosan_ai.providers.chatgpt_codex import (
     _ChatGptCodexAdapterState,
     _parse_sse_event,
 )
-from motosan_ai.types import ChatRequest, Message, StopReason
+from motosan_ai.types import ChatRequest, Message, StopReason, StreamEventType
 
 _URL = "https://chatgpt.com/backend-api/codex/responses"
 
@@ -118,8 +118,11 @@ def test_adapter_maps_reasoning_delta_to_thinking():
             {"type": "response.reasoning_summary_text.delta", "delta": "more"},
         ]
     )
-    thinking = "".join(e.content for e in events if e.event_type == "thinking")
-    assert thinking == "think more"
+    deltas = [e for e in events if e.event_type == StreamEventType.thinking_delta]
+    assert "".join(e.content for e in deltas) == "think more"
+    # Rust parity: the codex adapter emits ThinkingDelta only, never
+    # ThinkingDone — the Responses wire has no thinking block boundary.
+    assert not [e for e in events if e.event_type == StreamEventType.thinking_done]
 
 
 def test_adapter_handles_function_call_lifecycle():

--- a/sdks/python/tests/test_claude_code.py
+++ b/sdks/python/tests/test_claude_code.py
@@ -10,7 +10,6 @@ from motosan_ai.providers.claude_code import (
     ClaudeCodeClient,
     _messages_to_prompt,
     _model_to_forward,
-    _parse_agent_json,
     _parse_ndjson_line,
 )
 from motosan_ai.types import Message
@@ -75,54 +74,6 @@ class TestMessagesToPrompt:
         sys, prompt = _messages_to_prompt([])
         assert sys is None
         assert prompt == ""
-
-
-# ---------------------------------------------------------------------------
-# parse_agent_json
-# ---------------------------------------------------------------------------
-
-
-class TestParseAgentJson:
-    def test_with_usage(self):
-        raw = json.dumps(
-            {
-                "result": "hello world",
-                "usage": {"input_tokens": 10, "output_tokens": 5},
-            }
-        )
-        text, usage, _sid = _parse_agent_json(raw)
-        assert text == "hello world"
-        assert usage.input_tokens == 10
-        assert usage.output_tokens == 5
-
-    def test_without_usage(self):
-        raw = json.dumps({"result": "hello"})
-        text, usage, _sid = _parse_agent_json(raw)
-        assert text == "hello"
-        assert usage.input_tokens == 0
-        assert usage.output_tokens == 0
-
-    def test_invalid_json(self):
-        from motosan_ai.error import ProviderError
-
-        with pytest.raises(ProviderError, match="failed to parse"):
-            _parse_agent_json("not json")
-
-    def test_returns_session_id(self):
-        text, usage, sid = _parse_agent_json('{"result":"hi","session_id":"s1"}')
-        assert text == "hi"
-        assert sid == "s1"
-
-    def test_session_id_none_when_absent(self):
-        text, usage, sid = _parse_agent_json('{"result":"hi"}')
-        assert sid is None
-
-    def test_error_result_raises_stream_error(self):
-        from motosan_ai.error import StreamError
-
-        raw = json.dumps({"type": "result", "subtype": "error_max_turns", "is_error": True})
-        with pytest.raises(StreamError, match="error_max_turns"):
-            _parse_agent_json(raw)
 
 
 # ---------------------------------------------------------------------------
@@ -390,8 +341,9 @@ class TestBuildArgs:
         client = ClaudeCodeClient().agent_mode(True)
         args = client._build_args(model=None, system_prompt=None)
         assert "--dangerously-skip-permissions" in args
-        idx = args.index("--output-format")
-        assert args[idx + 1] == "json"
+        # F4: the single-shot `--output-format json` mode is gone; chat()
+        # delegates to stream(), which always passes "stream-json".
+        assert "--output-format" not in args
 
     def test_stream_format(self):
         client = ClaudeCodeClient()

--- a/sdks/python/tests/test_claude_code_dispatch.py
+++ b/sdks/python/tests/test_claude_code_dispatch.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from motosan_ai import Client, Provider
+from motosan_ai.providers.claude_code import ClaudeCodeClient
+
+
+def test_provider_enum_has_claude_code():
+    assert Provider.claude_code == "claude_code"
+
+
+def test_claude_code_does_not_require_api_key(monkeypatch):
+    for env in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_PATH"):
+        monkeypatch.delenv(env, raising=False)
+    client = Client(provider=Provider.claude_code)
+    assert isinstance(client._provider, ClaudeCodeClient)
+    assert client.api_key == ""
+
+
+def test_claude_code_routing_with_explicit_binary_path():
+    client = Client(provider="claude_code", binary_path="/opt/claude")
+    assert isinstance(client._provider, ClaudeCodeClient)
+    assert client._provider._config.binary_path == "/opt/claude"
+
+
+def test_claude_code_path_env_var_resolved(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_PATH", "/env/claude")
+    client = Client(provider=Provider.claude_code)
+    assert client._provider._config.binary_path == "/env/claude"
+
+
+def test_claude_code_routing_cli_timeout_passthrough():
+    client = Client(provider=Provider.claude_code, cli_timeout=5.0)
+    assert client._provider._config.timeout_secs == 5.0
+
+
+def test_claude_code_routing_cli_timeout_none_disables():
+    client = Client(provider=Provider.claude_code, cli_timeout=None)
+    assert client._provider._config.timeout_secs is None
+
+
+def test_claude_code_routing_default_timeout_preserved():
+    client = Client(provider=Provider.claude_code)
+    assert client._provider._config.timeout_secs == 300.0
+
+
+def test_client_claude_code_classmethod_resolves_to_provider():
+    client = Client.claude_code()
+    assert client.provider == Provider.claude_code
+    assert isinstance(client._provider, ClaudeCodeClient)
+
+
+def test_client_claude_code_classmethod_params_pass_through():
+    client = Client.claude_code(binary_path="/opt/claude", model="sonnet", cli_timeout=7.5)
+    assert client._provider._config.binary_path == "/opt/claude"
+    assert client.model == "sonnet"
+    assert client._provider._config.timeout_secs == 7.5

--- a/sdks/python/tests/test_claude_code_runtime.py
+++ b/sdks/python/tests/test_claude_code_runtime.py
@@ -3,9 +3,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import StreamError
 from motosan_ai.providers.claude_code import ClaudeCodeClient
-from motosan_ai.types import ChatRequest, Message, Role, StopReason
+from motosan_ai.types import ChatRequest, Message, Role, StopReason, ToolCall
 
 
 def _make_proc(stdout: bytes = b'{"type":"result","result":"hi","is_error":false}\n'):
@@ -63,7 +64,7 @@ async def test_chat_env_none_when_empty(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_stream_tool_use_sets_terminal_stop_reason(monkeypatch):
+async def test_stream_tool_use_terminal_is_end_turn(monkeypatch):
     stdout = (
         b'{"type":"assistant","message":{"content":['
         b'{"type":"tool_use","id":"toolu_01","name":"Read","input":{}}]}}\n'
@@ -81,7 +82,9 @@ async def test_stream_tool_use_sets_terminal_stop_reason(monkeypatch):
         )
     ]
     done = [e for e in events if e.done][-1]
-    assert done.stop_reason == StopReason.tool_use
+    # F4: CLI backends execute tools internally; a completed turn is
+    # always end_turn, never a tool_use request.
+    assert done.stop_reason == StopReason.end_turn
 
 
 @pytest.mark.asyncio
@@ -160,3 +163,42 @@ async def test_chat_agent_mode_error_result_raises_stream_error(monkeypatch):
     client = ClaudeCodeClient().agent_mode(True)
     with pytest.raises(StreamError, match="error_during_execution"):
         await client.chat(ChatRequest(messages=[Message(role=Role.user, content="hi")]))
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_parity_tool_turn_is_end_turn(monkeypatch):
+    """F4: chat() == collect_stream(stream()) for a text + tool-call + terminal
+    transcript. Both paths report stop_reason end_turn and surface the
+    executed-tool record; model backfill is the one allowed difference."""
+    stdout = (
+        b'{"type":"assistant","message":{"content":['
+        b'{"type":"text","text":"let me read it"},'
+        b'{"type":"tool_use","id":"toolu_01","name":"Read","input":{"path":"/tmp/x"}}]}}\n'
+        b'{"type":"result","result":"done","session_id":"sess_1",'
+        b'"usage":{"input_tokens":7,"output_tokens":3}}\n'
+    )
+    monkeypatch.setattr(
+        "motosan_ai.providers.claude_code.asyncio.create_subprocess_exec",
+        AsyncMock(side_effect=[_make_proc(stdout=stdout), _make_proc(stdout=stdout)]),
+    )
+    client = ClaudeCodeClient()
+    request = ChatRequest(messages=[Message(role=Role.user, content="hi")])
+
+    chat_resp = await client.chat(request)
+    streamed = await collect_stream(client.stream(request))
+
+    expected_tool_calls = [ToolCall(id="toolu_01", name="Read", input={"path": "/tmp/x"})]
+    assert chat_resp.tool_calls == expected_tool_calls
+    assert chat_resp.stop_reason == StopReason.end_turn
+    assert streamed.stop_reason == StopReason.end_turn
+    # Parity, field by field (model exempt: chat backfills it from config).
+    assert chat_resp.content == streamed.content
+    assert chat_resp.thinking == streamed.thinking
+    assert chat_resp.tool_calls == streamed.tool_calls
+    assert chat_resp.stop_reason == streamed.stop_reason
+    assert chat_resp.usage == streamed.usage
+    assert chat_resp.session_id == streamed.session_id
+    assert chat_resp.content == "let me read it"
+    assert chat_resp.usage.input_tokens == 7
+    assert chat_resp.usage.output_tokens == 3
+    assert chat_resp.session_id == "sess_1"

--- a/sdks/python/tests/test_client_stream_collect.py
+++ b/sdks/python/tests/test_client_stream_collect.py
@@ -9,7 +9,14 @@ import respx
 from motosan_ai import Client, Provider
 from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import StreamError
-from motosan_ai.types import ChatRequest, Message, StopReason, StreamEvent, Usage
+from motosan_ai.types import (
+    ChatRequest,
+    Message,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    Usage,
+)
 
 
 async def _events_to_iter(events):
@@ -157,6 +164,51 @@ async def test_collect_thinking_content_concatenated():
     resp = await collect_stream(_events_to_iter(events))
     assert resp.thinking == "reasoning step 1 step 2"
     assert resp.content == "answer"
+
+
+@pytest.mark.asyncio
+async def test_collect_thinking_done_takes_priority():
+    # Mirrors Rust stream.rs: ThinkingDone carries the authoritative full
+    # text and wins over the delta accumulator at assembly.
+    events = [
+        StreamEvent(content="a", done=False, event_type=StreamEventType.thinking_delta),
+        StreamEvent(content="b", done=False, event_type=StreamEventType.thinking_delta),
+        StreamEvent(
+            content="ab-final",
+            done=False,
+            event_type=StreamEventType.thinking_done,
+        ),
+        StreamEvent(content="answer", done=False),
+        StreamEvent(content="", done=True, stop_reason=StopReason.end_turn),
+    ]
+    resp = await collect_stream(_events_to_iter(events))
+    assert resp.thinking == "ab-final"
+    assert resp.content == "answer"
+
+
+@pytest.mark.asyncio
+async def test_collect_thinking_deltas_only_concatenated():
+    # No thinking_done (e.g. chatgpt_codex): concatenated deltas are the
+    # fallback.
+    events = [
+        StreamEvent(content="a", done=False, event_type=StreamEventType.thinking_delta),
+        StreamEvent(content="b", done=False, event_type=StreamEventType.thinking_delta),
+        StreamEvent(content="", done=True, stop_reason=StopReason.end_turn),
+    ]
+    resp = await collect_stream(_events_to_iter(events))
+    assert resp.thinking == "ab"
+
+
+@pytest.mark.asyncio
+async def test_collect_empty_thinking_done_yields_none():
+    # Explicit empty thinking block -> treat as none (Rust parity,
+    # stream.rs assembly match arm Some(_) => None).
+    events = [
+        StreamEvent(content="", done=False, event_type=StreamEventType.thinking_done),
+        StreamEvent(content="", done=True, stop_reason=StopReason.end_turn),
+    ]
+    resp = await collect_stream(_events_to_iter(events))
+    assert resp.thinking is None
 
 
 def _sse(*events):

--- a/sdks/python/tests/test_client_stream_collect.py
+++ b/sdks/python/tests/test_client_stream_collect.py
@@ -156,8 +156,12 @@ async def test_collect_default_stop_reason_when_done_lacks_one():
 @pytest.mark.asyncio
 async def test_collect_thinking_content_concatenated():
     events = [
-        StreamEvent(content="reasoning step 1", done=False, event_type="thinking"),
-        StreamEvent(content=" step 2", done=False, event_type="thinking"),
+        StreamEvent(
+            content="reasoning step 1",
+            done=False,
+            event_type=StreamEventType.thinking_delta,
+        ),
+        StreamEvent(content=" step 2", done=False, event_type=StreamEventType.thinking_delta),
         StreamEvent(content="answer", done=False),
         StreamEvent(content="", done=True),
     ]
@@ -205,6 +209,18 @@ async def test_collect_empty_thinking_done_yields_none():
     # stream.rs assembly match arm Some(_) => None).
     events = [
         StreamEvent(content="", done=False, event_type=StreamEventType.thinking_done),
+        StreamEvent(content="", done=True, stop_reason=StopReason.end_turn),
+    ]
+    resp = await collect_stream(_events_to_iter(events))
+    assert resp.thinking is None
+
+
+@pytest.mark.asyncio
+async def test_collect_ignores_legacy_thinking_string():
+    # BREAKING (M4/F3): the ad-hoc "thinking" event_type is gone from the
+    # stream vocabulary; collect_stream must not accumulate it.
+    events = [
+        StreamEvent(content="legacy", done=False, event_type="thinking"),
         StreamEvent(content="", done=True, stop_reason=StopReason.end_turn),
     ]
     resp = await collect_stream(_events_to_iter(events))

--- a/sdks/python/tests/test_codex_cli_stream.py
+++ b/sdks/python/tests/test_codex_cli_stream.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.providers.codex_cli import (
     CodexCliClient,
@@ -13,7 +14,7 @@ from motosan_ai.providers.codex_cli import (
     _messages_to_prompt,
     _parse_jsonl_line,
 )
-from motosan_ai.types import ChatRequest, Message, StopReason
+from motosan_ai.types import ChatRequest, Message, StopReason, ToolCall
 
 
 def test_agent_message_emits_text_event():
@@ -260,7 +261,9 @@ async def test_chat_prefers_request_system_over_message_system(monkeypatch):
 async def test_chat_raises_on_nonzero_returncode(monkeypatch):
     _stub_subprocess(monkeypatch, _FakeProc("", returncode=2, stderr="codex: bad config\n"))
     client = CodexCliClient(binary_path="codex")
-    with pytest.raises(ProviderError, match="bad config"):
+    # F4: chat() delegates to stream(); a child that dies without a terminal
+    # event surfaces as StreamError (was ProviderError on the single-shot path).
+    with pytest.raises(StreamError, match="bad config"):
         await client.chat(ChatRequest(messages=[Message.user("hi")]))
 
 
@@ -333,7 +336,7 @@ async def test_chat_passes_env_to_subprocess(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_chat_does_not_surface_tool_calls(monkeypatch):
+async def test_chat_surfaces_executed_tool_record(monkeypatch):
     jsonl = (
         '{"type": "item.completed", "item": {"id": "i0", "type": "command_execution", '
         '"command": "ls"}}\n'
@@ -344,12 +347,16 @@ async def test_chat_does_not_surface_tool_calls(monkeypatch):
     resp = await CodexCliClient(binary_path="codex").chat(
         ChatRequest(messages=[Message.user("hi")])
     )
-    assert resp.tool_calls == []
+    # F4: tool_calls records what the CLI already executed — never a
+    # request for the caller to execute tools.
+    expected = [ToolCall(id="i0", name="command_execution", input={"command": "ls"})]
+    assert resp.tool_calls == expected
+    assert resp.stop_reason == StopReason.end_turn
     assert "done" in resp.content
 
 
 @pytest.mark.asyncio
-async def test_stream_tool_call_sets_tool_use_stop_reason(monkeypatch):
+async def test_stream_tool_call_terminal_is_end_turn(monkeypatch):
     jsonl = (
         '{"type": "item.completed", "item": {"id": "i0", "type": "command_execution", '
         '"command": "ls"}}\n'
@@ -363,7 +370,8 @@ async def test_stream_tool_call_sets_tool_use_stop_reason(monkeypatch):
         )
     ]
     done = [e for e in events if e.done][-1]
-    assert done.stop_reason == StopReason.tool_use
+    # F4: CLI backends never report tool_use.
+    assert done.stop_reason == StopReason.end_turn
 
 
 @pytest.mark.asyncio
@@ -404,3 +412,41 @@ async def test_stream_read_stall_raises(monkeypatch):
     with pytest.raises(ProviderError, match="timed out"):
         async for _ in client.stream(ChatRequest(messages=[Message.user("hi")])):
             pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_parity_tool_turn_is_end_turn(monkeypatch):
+    """F4: chat() == collect_stream(stream()) for a text + tool-call + terminal
+    transcript; both end_turn, tool record populated (model exempt)."""
+    jsonl = (
+        '{"type": "thread.started", "thread_id": "th_1"}\n'
+        '{"type": "item.completed", "item": {"type": "agent_message", "text": "running ls"}}\n'
+        '{"type": "item.completed", "item": {"id": "i0", "type": "command_execution", '
+        '"command": "ls"}}\n'
+        '{"type": "turn.completed", "usage": {"input_tokens": 9, "output_tokens": 4}}\n'
+    )
+    monkeypatch.setattr(asyncio.subprocess, "PIPE", -1, raising=False)
+    monkeypatch.setattr(
+        "asyncio.create_subprocess_exec",
+        AsyncMock(side_effect=[_FakeProc(jsonl), _FakeProc(jsonl, returncode=None)]),
+    )
+    client = CodexCliClient(binary_path="codex")
+    request = ChatRequest(messages=[Message.user("hi")])
+
+    chat_resp = await client.chat(request)
+    streamed = await collect_stream(client.stream(request))
+
+    expected = [ToolCall(id="i0", name="command_execution", input={"command": "ls"})]
+    assert chat_resp.tool_calls == expected
+    assert chat_resp.stop_reason == StopReason.end_turn
+    assert streamed.stop_reason == StopReason.end_turn
+    assert chat_resp.content == streamed.content
+    assert chat_resp.thinking == streamed.thinking
+    assert chat_resp.tool_calls == streamed.tool_calls
+    assert chat_resp.stop_reason == streamed.stop_reason
+    assert chat_resp.usage == streamed.usage
+    assert chat_resp.session_id == streamed.session_id
+    assert chat_resp.content == "running ls"
+    assert chat_resp.usage.input_tokens == 9
+    assert chat_resp.usage.output_tokens == 4
+    assert chat_resp.session_id == "th_1"

--- a/sdks/python/tests/test_gemini_cli_stream.py
+++ b/sdks/python/tests/test_gemini_cli_stream.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from motosan_ai._stream_collect import collect_stream
 from motosan_ai.error import ProviderError, StreamError
 from motosan_ai.providers.gemini_cli import (
     GeminiCliClient,
@@ -13,7 +14,7 @@ from motosan_ai.providers.gemini_cli import (
     _messages_to_prompt,
     _parse_jsonl_line,
 )
-from motosan_ai.types import ChatRequest, Message, StopReason
+from motosan_ai.types import ChatRequest, Message, StopReason, ToolCall
 
 
 def test_init_event_without_session_id_dropped():
@@ -260,7 +261,9 @@ async def test_chat_captures_session_id(monkeypatch):
 async def test_chat_raises_on_nonzero_returncode(monkeypatch):
     _stub_subprocess(monkeypatch, _FakeProc("", returncode=2, stderr="gemini: bad config\n"))
     client = GeminiCliClient(binary_path="gemini")
-    with pytest.raises(ProviderError, match="bad config"):
+    # F4: chat() delegates to stream(); a child that dies without a terminal
+    # event surfaces as StreamError (was ProviderError on the single-shot path).
+    with pytest.raises(StreamError, match="bad config"):
         await client.chat(ChatRequest(messages=[Message.user("hi")]))
 
 
@@ -334,7 +337,7 @@ async def test_chat_merges_env(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_blocking_chat_tool_calls_empty(monkeypatch):
+async def test_chat_surfaces_executed_tool_record(monkeypatch):
     jsonl = (
         '{"type": "tool_use", "tool_id": "t1", "tool_name": "read_file", "parameters": {}}\n'
         '{"type": "message", "role": "assistant", "content": "hi", "delta": true}\n'
@@ -344,12 +347,15 @@ async def test_blocking_chat_tool_calls_empty(monkeypatch):
     resp = await GeminiCliClient(binary_path="gemini").chat(
         ChatRequest(messages=[Message.user("hi")])
     )
-    assert resp.tool_calls == []
+    # F4: tool_calls records what the CLI already executed — never a
+    # request for the caller to execute tools.
+    assert resp.tool_calls == [ToolCall(id="t1", name="read_file", input={})]
+    assert resp.stop_reason == StopReason.end_turn
     assert "hi" in resp.content
 
 
 @pytest.mark.asyncio
-async def test_stream_tool_call_terminal_is_tool_use(monkeypatch):
+async def test_stream_tool_call_terminal_is_end_turn(monkeypatch):
     jsonl = (
         '{"type": "tool_use", "tool_id": "t1", "tool_name": "read_file", "parameters": {}}\n'
         '{"type": "result", "status": "success"}\n'
@@ -362,7 +368,8 @@ async def test_stream_tool_call_terminal_is_tool_use(monkeypatch):
         )
     ]
     done = [e for e in events if e.done][-1]
-    assert done.stop_reason == StopReason.tool_use
+    # F4: CLI backends never report tool_use.
+    assert done.stop_reason == StopReason.end_turn
 
 
 @pytest.mark.asyncio
@@ -403,3 +410,42 @@ async def test_stream_stall_raises(monkeypatch):
     with pytest.raises(ProviderError, match="timed out"):
         async for _ in client.stream(ChatRequest(messages=[Message.user("hi")])):
             pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_parity_tool_turn_is_end_turn(monkeypatch):
+    """F4: chat() == collect_stream(stream()) for a text + tool-call + terminal
+    transcript; both end_turn, tool record populated (model exempt)."""
+    jsonl = (
+        '{"type": "init", "session_id": "s1"}\n'
+        '{"type": "message", "role": "assistant", "content": "reading", "delta": true}\n'
+        '{"type": "tool_use", "tool_id": "t1", "tool_name": "read_file", '
+        '"parameters": {"file_path": "Cargo.toml"}}\n'
+        '{"type": "result", "status": "success", '
+        '"stats": {"input_tokens": 5, "output_tokens": 2}}\n'
+    )
+    monkeypatch.setattr(asyncio.subprocess, "PIPE", -1, raising=False)
+    monkeypatch.setattr(
+        "asyncio.create_subprocess_exec",
+        AsyncMock(side_effect=[_FakeProc(jsonl), _FakeProc(jsonl, returncode=None)]),
+    )
+    client = GeminiCliClient(binary_path="gemini")
+    request = ChatRequest(messages=[Message.user("hi")])
+
+    chat_resp = await client.chat(request)
+    streamed = await collect_stream(client.stream(request))
+
+    expected = [ToolCall(id="t1", name="read_file", input={"file_path": "Cargo.toml"})]
+    assert chat_resp.tool_calls == expected
+    assert chat_resp.stop_reason == StopReason.end_turn
+    assert streamed.stop_reason == StopReason.end_turn
+    assert chat_resp.content == streamed.content
+    assert chat_resp.thinking == streamed.thinking
+    assert chat_resp.tool_calls == streamed.tool_calls
+    assert chat_resp.stop_reason == streamed.stop_reason
+    assert chat_resp.usage == streamed.usage
+    assert chat_resp.session_id == streamed.session_id
+    assert chat_resp.content == "reading"
+    assert chat_resp.usage.input_tokens == 5
+    assert chat_resp.usage.output_tokens == 2
+    assert chat_resp.session_id == "s1"

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -81,6 +81,22 @@ def test_stream_event_type_values():
     assert StreamEventType.usage == "usage"
 
 
+def test_stream_event_type_thinking_members():
+    assert StreamEventType.thinking_delta == "thinking_delta"
+    assert StreamEventType.thinking_done == "thinking_done"
+    # Full M4/F2 vocabulary. Note: NO "done" member — done is a bool field
+    # on StreamEvent, never an event_type.
+    assert {m.value for m in StreamEventType} == {
+        "text",
+        "tool_call_start",
+        "tool_call_args",
+        "tool_call_end",
+        "usage",
+        "thinking_delta",
+        "thinking_done",
+    }
+
+
 def test_stream_event_new_optional_fields_default_none():
     ev = StreamEvent(content="hi", done=False)
     assert ev.stop_reason is None


### PR DESCRIPTION
## Summary

- replace legacy thinking stream strings with typed thinking_delta / thinking_done events
- align Claude Code, Codex CLI, and Gemini CLI blocking chat with stream collection and end_turn terminals
- resolve ChatGPT Codex token_source per retry attempt and add Provider.claude_code routing
- apply the amended Task 5 live adaptive-thinking assertion flip in its own commit

## Verification

- ruff check motosan_ai/: passed
- ruff format --check motosan_ai/ tests/: 106 files already formatted
- pytest tests/ -q --ignore=tests/integration: passed
- pre-push Python unit tests: passed
- pre-push Rust unit tests: passed
- pre-push Python live Anthropic: 10 passed, 1 skipped
- pre-push Rust live Anthropic: 11 passed
- forbidden legacy grep checks: zero matches
- retry token freshness and claude_code routing/classmethod targeted tests: 4 passed

## Plan

Implements PR-P from docs/superpowers/plans/2026-07-17-stream-retry-m4-implementation.md, including the main@98582a8 amendment.