### PR TITLE
Fix Rust publish package artifact path

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -73,7 +73,8 @@ jobs:
           set -euo pipefail
 
           crate_name="motosan-ai"
-          package_file="target/package/${crate_name}-${VERSION}.crate"
+          target_dir="$(cargo metadata --format-version 1 --no-deps | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])')"
+          package_file="${target_dir}/package/${crate_name}-${VERSION}.crate"
 
           cargo package --locked
           if [ ! -f "$package_file" ]; then


### PR DESCRIPTION
## Summary
- derive Cargo target directory via cargo metadata in the Rust publish workflow
- fixes the 0.26.0 publish run failing before upload because it looked for target/package under sdks/rust

## Verification
- target package path shell check
- git diff --check
- scripts/quality-gate-rust.sh
- pre-push gate: Python unit tests, Rust all-feature unit tests, Python live Anthropic tests, Rust live Anthropic tests
