### PR TITLE
fix: path-scoped pre-push gate + opt-in live + Rust nightly live CI

### DIFF
--- a/.github/workflows/ci-rust-nightly.yml
+++ b/.github/workflows/ci-rust-nightly.yml
@@ -1,0 +1,29 @@
+name: ci-rust-nightly
+
+on:
+  schedule:
+    # Daily at 08:30 UTC (16:30 Asia/Taipei), offset from ci-python-nightly's 08:00
+    - cron: "30 8 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  live:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Require ANTHROPIC_API_KEY secret
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # The live tests early-return SUCCESS when the key is unset/empty
+          # (anthropic_live.rs: `let Some(client) = client() else { return }`),
+          # so an empty secret would make this job green while testing nothing.
+          test -n "$ANTHROPIC_API_KEY" || { echo "::error::ANTHROPIC_API_KEY secret is empty — nightly would silently test nothing"; exit 1; }
+      - name: Run live Anthropic integration tests
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: cargo test --features full --test anthropic_live -- --test-threads=1

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -1,84 +1,130 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Pre-push gate: runs unit tests + live Anthropic integration tests.
-# Requires ANTHROPIC_API_KEY env var for live tests.
-# If ANTHROPIC_API_KEY is not set, attempts to read from macOS Keychain.
+# Pre-push gate: path-scoped unit tests for the SDKs touched by the pushed range.
+# Live tests are OPT-IN: RUN_LIVE=1 git push
+# (scheduled live coverage: ci-python-nightly.yml + ci-rust-nightly.yml).
+#
+# git invokes pre-push with one line per ref on stdin:
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+ZERO=0000000000000000000000000000000000000000
+
+block() {
+    echo "PUSH BLOCKED: $1" >&2
+    exit 1
+}
+
+# ---- Determine which SDKs the pushed ranges touch -------------------------
+CHANGED=""
+if [ -t 0 ]; then
+    # Manual invocation without stdin: behave conservatively, test everything.
+    CHANGED="ALL"
+else
+    while read -r _local_ref local_sha _remote_ref remote_sha; do
+        [ "$local_sha" = "$ZERO" ] && continue # branch deletion: nothing to test
+        if [ "$remote_sha" = "$ZERO" ]; then
+            # New remote branch: diff against merge-base with origin/main.
+            base=$(git merge-base "$local_sha" origin/main 2>/dev/null) || base=""
+        else
+            base="$remote_sha"
+        fi
+        if [ -n "$base" ]; then
+            CHANGED+="$(git diff --name-only "$base" "$local_sha" 2>/dev/null || echo ALL)"$'\n'
+        else
+            CHANGED+="ALL"$'\n'
+        fi
+    done
+fi
+
+if [ -z "$CHANGED" ]; then
+    echo "=== Pre-push gate PASSED (deletion-only push — nothing to test) ==="
+    exit 0
+fi
+
+NEED_PYTHON=0
+NEED_RUST=0
+NEED_TS=0
+if grep -qx "ALL" <<<"$CHANGED"; then
+    NEED_PYTHON=1 NEED_RUST=1 NEED_TS=1
+else
+    if grep -qE '^sdks/python/' <<<"$CHANGED"; then NEED_PYTHON=1; fi
+    if grep -qE '^sdks/rust/' <<<"$CHANGED"; then NEED_RUST=1; fi
+    if grep -qE '^sdks/typescript/' <<<"$CHANGED"; then NEED_TS=1; fi
+    # Root workspace manifests affect SDK builds without living under sdks/:
+    # Cargo.toml is the Rust workspace root; pyproject.toml + uv.lock are the
+    # uv workspace (members = ["sdks/python"]) and its tracked lockfile.
+    if grep -qxE 'Cargo\.toml' <<<"$CHANGED"; then NEED_RUST=1; fi
+    if grep -qxE 'pyproject\.toml|uv\.lock' <<<"$CHANGED"; then NEED_PYTHON=1; fi
+fi
+
 echo "=== Pre-push gate ==="
 
-# Skip gracefully if tools are not available (no nix/direnv environment)
-if ! command -v cargo &>/dev/null; then
-    echo "ℹ️  cargo not found — skipping Rust tests. Install via nix develop or rustup."
-    SKIP_RUST=1
-else
-    SKIP_RUST=0
-fi
-
-if ! command -v uv &>/dev/null; then
-    echo "ℹ️  uv not found — skipping Python tests. Install via nix develop or https://astral.sh/uv"
-    SKIP_PYTHON=1
-else
-    SKIP_PYTHON=0
-fi
-
-if [ "$SKIP_RUST" = "1" ] && [ "$SKIP_PYTHON" = "1" ]; then
-    echo "ℹ️  No tools available — skipping all checks."
-    echo "=== Pre-push gate SKIPPED ==="
+if [ "$NEED_PYTHON$NEED_RUST$NEED_TS" = "000" ] && [ "${RUN_LIVE:-0}" != "1" ]; then
+    echo "=== Pre-push gate PASSED (no SDK paths in pushed range — suites skipped) ==="
     exit 0
 fi
 
-# 1. Python unit tests (fast, no API needed)
-if [ "$SKIP_PYTHON" = "0" ]; then
-    echo "[1/2] Running Python unit tests..."
-    uv run pytest sdks/python/tests/ -q --ignore=sdks/python/tests/integration/ || {
-        echo "❌ Python unit tests failed. Push blocked."
-        exit 1
-    }
-    echo "✅ Python unit tests passed."
+# ---- Unit suites ----------------------------------------------------------
+# Hermetic: strip provider credentials so the env-gated live tests that live
+# INSIDE the unit suites (tests/*_live.rs, TS integration.*.test.ts — none are
+# #[ignore]d; they fire whenever their key env var is set) cannot run here.
+# RUN_LIVE=1 below is the ONLY live path; it uses the ambient env untouched.
+UNSET_CREDS=(-u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GEMINI_API_KEY
+    -u GOOGLE_API_KEY -u GEMINI_OAUTH_TOKEN -u GEMINI_PROJECT_ID
+    -u MINIMAX_API_KEY -u OLLAMA_API_KEY -u OLLAMA_BASE_URL -u OLLAMA_HOST)
+
+if [ "$NEED_PYTHON" = "1" ]; then
+    if command -v uv &>/dev/null; then
+        echo "[python] unit tests..."
+        env "${UNSET_CREDS[@]}" uv run pytest sdks/python/tests/ -q --ignore=sdks/python/tests/integration/ \
+            || block "Python unit tests failed"
+        echo "✅ Python unit tests passed."
+    else
+        echo "ℹ️  uv not found — skipping Python tests."
+    fi
 fi
 
-# 2. Rust unit tests (mock, no API needed)
-if [ "$SKIP_RUST" = "0" ]; then
-    echo "[2/2] Running Rust unit tests..."
-    cargo test --manifest-path sdks/rust/Cargo.toml --all-features -q || {
-        echo "❌ Rust unit tests failed. Push blocked."
-        exit 1
-    }
-    echo "✅ Rust unit tests passed."
+if [ "$NEED_RUST" = "1" ]; then
+    if command -v cargo &>/dev/null; then
+        echo "[rust] unit tests (--all-features)..."
+        env "${UNSET_CREDS[@]}" cargo test --manifest-path sdks/rust/Cargo.toml --all-features -q \
+            || block "Rust unit tests failed"
+        echo "✅ Rust unit tests passed."
+    else
+        echo "ℹ️  cargo not found — skipping Rust tests."
+    fi
 fi
 
-# 3. Resolve API key for live tests
-if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-    ANTHROPIC_API_KEY=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null \
-        | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['claudeAiOauth']['accessToken'])" 2>/dev/null) || true
+if [ "$NEED_TS" = "1" ]; then
+    if command -v npm &>/dev/null && [ -d sdks/typescript/node_modules ]; then
+        echo "[typescript] build + vitest (pack-smoke needs dist/)..."
+        (cd sdks/typescript && env "${UNSET_CREDS[@]}" npm run build && env "${UNSET_CREDS[@]}" npm run test) \
+            || block "TypeScript tests failed"
+        echo "✅ TypeScript tests passed."
+    else
+        echo "ℹ️  npm or sdks/typescript/node_modules missing — skipping TS tests."
+    fi
 fi
 
-if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-    echo "⚠️  ANTHROPIC_API_KEY not set and not in Keychain. Skipping live tests."
-    echo "=== Pre-push gate PASSED (live tests skipped) ==="
-    exit 0
+# ---- Live tests (opt-in only) ---------------------------------------------
+if [ "${RUN_LIVE:-0}" = "1" ]; then
+    if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+        ANTHROPIC_API_KEY=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null \
+            | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['claudeAiOauth']['accessToken'])" 2>/dev/null) || true
+    fi
+    [ -z "${ANTHROPIC_API_KEY:-}" ] && block "RUN_LIVE=1 but no ANTHROPIC_API_KEY available (env or Keychain)"
+    export ANTHROPIC_API_KEY
+    echo "[live] Python live Anthropic tests..."
+    uv run pytest sdks/python/tests/integration/test_anthropic_live.py -v \
+        || block "Python live tests failed"
+    echo "[live] Rust live Anthropic tests..."
+    cargo test --manifest-path sdks/rust/Cargo.toml --features full --test anthropic_live -- --test-threads=1 \
+        || block "Rust live tests failed"
+    echo "✅ Live tests passed."
 fi
-
-export ANTHROPIC_API_KEY
-
-# 4. Python live Anthropic integration tests
-echo "[3/4] Running Python live Anthropic tests..."
-uv run pytest sdks/python/tests/integration/test_anthropic_live.py -v || {
-    echo "❌ Python live tests failed. Push blocked."
-    exit 1
-}
-echo "✅ Python live tests passed."
-
-# 5. Rust live Anthropic integration tests
-echo "[4/4] Running Rust live Anthropic tests..."
-cargo test --manifest-path sdks/rust/Cargo.toml --features full --test anthropic_live -- --test-threads=1 || {
-    echo "❌ Rust live tests failed. Push blocked."
-    exit 1
-}
-echo "✅ Rust live tests passed."
 
 echo "=== Pre-push gate PASSED ==="


### PR DESCRIPTION
Rewrites `scripts/pre-push-gate.sh` so the hook reads git's pre-push stdin ranges and only runs the unit suites for the SDKs the pushed range actually touches (root `Cargo.toml` → Rust; root `pyproject.toml`/`uv.lock` → Python), adds the missing TypeScript step, and runs every unit suite credential-stripped — the "unit" suites contain env-gated live tests that are *not* `#[ignore]`d (`sdks/rust/tests/*_live.rs`, TS `tests/integration.*.test.ts`), so stripping is what makes `RUN_LIVE=1` the only live path. Part of #242.

Key points for review:

1. **Live tests are now opt-in** via `RUN_LIVE=1 git push`. Previously the hook auto-ran live Anthropic tests (Python + Rust) whenever `ANTHROPIC_API_KEY` resolved — including silently pulling the Claude Code OAuth token out of the macOS Keychain and spending real API quota on mere keychain presence. Because the hook was also the repo's **only** automated Rust live runner (`ci-python-nightly.yml` covers Python only), this PR adds `.github/workflows/ci-rust-nightly.yml` (daily 08:30 UTC + `workflow_dispatch`) to close that coverage hole; it hard-fails when the `ANTHROPIC_API_KEY` secret is empty, since `anthropic_live.rs` early-returns *success* on a missing key and would otherwise be green while testing nothing.
2. **Block messages go to stderr** with a `PUSH BLOCKED: <reason>` prefix. The old hook printed them on stdout, where the rtk wrapper swallowed them — a documented incident had a push report exit 0 while the hook had actually blocked it.
3. **No hook reinstall needed.** The installed `pre-push` hook is a 2-line shim that resolves `git rev-parse --show-toplevel` at push time and `exec`s that tree's `scripts/pre-push-gate.sh` (`scripts/setup-hooks.sh` lines 21-25), so the rewrite deploys instantly to every clone that has already run setup.
4. **This PR triggers NO CI checks by design** — every PR workflow is path-filtered to `sdks/**`, and neither `scripts/**` nor the new nightly workflow file matches. Do not wait for status checks. The verification is local (below) plus the post-merge `gh workflow run ci-rust-nightly` / `gh run list --workflow=ci-rust-nightly`.

Test evidence (all local, from a fresh worktree off `origin/main`):

- Deletion-only stdin (`local_sha` = 40 zeros) → `Pre-push gate PASSED (deletion-only push — nothing to test)`, exit 0.
- Docs-only historical range (`d6d5f9b`, found by scanning `git log … -- docs/` for a commit touching no `sdks/` path) → `Pre-push gate PASSED (no SDK paths in pushed range — suites skipped)`, exit 0.
- Rust-only range `a5329ab~2..a5329ab` → only `[rust] unit tests (--all-features)` ran, full suite green, no `[python]`/`[typescript]`/`[live]` steps. This is the plan's `origin/main~2..origin/main` (PRs #240+#241, the range that touches only `sdks/rust/**` under `sdks/`): the plan pins its baseline as `origin/main @ a5329ab`, and `a5329ab` is today's `origin/main~1` because the docs-only `d6d5f9b` has since landed on main — so the `~N` offsets shifted by one while the commits under test did not (`git rev-parse a5329ab` == `origin/main~1` == `a5329ab9a1…`, `a5329ab~2` == `origin/main~3` == `e8f24a51…`).
- Gates: `bash -n` clean, `shellcheck scripts/pre-push-gate.sh` zero findings, `actionlint .github/workflows/ci-rust-nightly.yml` zero findings, `treefmt --fail-on-change` exit 0 (210 files, 0 changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
