### PR TITLE
fix: pin native model-stream termination contract (spec + message + EOF tests)

### DIFF
--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Native model streams (`model_stream_with`) now report EOF-truncation as
+  `incomplete stream: <provider> ended without a terminal event`
+  (`openai` / `chatgpt-codex`), matching the spec's message convention. The
+  previous payload was `responses stream ended without a terminal event`.
+  Match on the `IncompleteStream` variant, not the message text.
+  `providers::responses::model_stream_adapter` accordingly gained a
+  `provider: &'static str` parameter.
+
 ## [0.26.0] - 2026-07-21
 
 ### Added

--- a/sdks/rust/src/providers/chatgpt_codex.rs
+++ b/sdks/rust/src/providers/chatgpt_codex.rs
@@ -421,6 +421,7 @@ impl ProviderImpl for ChatGptCodexProvider {
 
         Ok(crate::providers::responses::model_stream_adapter(
             response.bytes_stream().eventsource(),
+            "chatgpt-codex",
         ))
     }
 }

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -748,6 +748,7 @@ impl ProviderImpl for OpenAIProvider {
 
         Ok(crate::providers::responses::model_stream_adapter(
             response.bytes_stream().eventsource(),
+            "openai",
         ))
     }
 }

--- a/sdks/rust/src/providers/responses.rs
+++ b/sdks/rust/src/providers/responses.rs
@@ -400,7 +400,7 @@ fn encode_user_content(message: &Message) -> Vec<Value> {
 }
 
 #[cfg(feature = "_http")]
-pub fn model_stream_adapter<S>(sse: S) -> crate::stream::BoxModelStream
+pub fn model_stream_adapter<S>(sse: S, provider: &'static str) -> crate::stream::BoxModelStream
 where
     S: futures_core::Stream<
             Item = Result<
@@ -417,6 +417,7 @@ where
         saw_tool_call: false,
         error: None,
         saw_terminal: false,
+        provider,
     })
 }
 
@@ -437,6 +438,7 @@ struct ResponsesModelStreamAdapter {
     saw_tool_call: bool,
     error: Option<String>,
     saw_terminal: bool,
+    provider: &'static str,
 }
 
 #[cfg(feature = "_http")]
@@ -633,9 +635,10 @@ impl futures_core::Stream for ResponsesModelStreamAdapter {
                     if !self.saw_terminal {
                         self.saw_terminal = true;
                         return Poll::Ready(Some(Err(
-                            crate::error::MotosanError::IncompleteStream(
-                                "responses stream ended without a terminal event".to_string(),
-                            ),
+                            crate::error::MotosanError::IncompleteStream(format!(
+                                "{} ended without a terminal event",
+                                self.provider
+                            )),
                         )));
                     }
                     return Poll::Ready(None);

--- a/sdks/rust/tests/chatgpt_codex.rs
+++ b/sdks/rust/tests/chatgpt_codex.rs
@@ -97,6 +97,36 @@ async fn custom_tool_stream_decodes_custom_delta_and_done() {
 }
 
 #[tokio::test]
+async fn native_codex_stream_eof_without_terminal_is_incomplete() {
+    let mut server = mockito::Server::new_async().await;
+    let sse = "data: {\"type\":\"response.custom_tool_call_input.delta\",\"call_id\":\"call_js\",\"delta\":\"console.\"}\n\n";
+    let mock = server
+        .mock("POST", Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse)
+        .create_async()
+        .await;
+
+    let provider =
+        ChatGptCodexProvider::new("oauth-token", "acct-123", "gpt-5.5", Some(server.url()));
+    let stream = provider
+        .model_stream(native_custom_request())
+        .await
+        .expect("native stream");
+    let err = collect_model_stream(stream)
+        .await
+        .expect_err("EOF without terminal must yield IncompleteStream");
+    match err {
+        MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "chatgpt-codex ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn custom_tool_chat_collects_native_stream() {
     let mut server = mockito::Server::new_async().await;
     let sse = concat!(

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -274,6 +274,42 @@ async fn native_custom_openai_stream_decodes_custom_delta_and_done() {
 }
 
 #[tokio::test]
+async fn native_openai_stream_eof_without_terminal_is_incomplete() {
+    let mut server = mockito::Server::new_async().await;
+    // Text deltas but NO response.completed / response.incomplete → truncated.
+    let sse = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hel\"}\n\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"lo\"}\n\n"
+    );
+    let mock = server
+        .mock("POST", "/v1/responses")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse)
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None)
+        .with_responses_api(true)
+        .with_responses_url(format!("{}/v1/responses", server.url()));
+
+    let stream = provider
+        .model_stream(native_custom_request())
+        .await
+        .expect("native stream");
+    let err = collect_model_stream(stream)
+        .await
+        .expect_err("EOF without terminal must yield IncompleteStream");
+    match err {
+        MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "openai ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn openai_chat_maps_response() {
     let mut server = mockito::Server::new_async().await;
     let mock = server

--- a/specs/types.md
+++ b/specs/types.md
@@ -208,6 +208,18 @@ Freeform transport through its Responses endpoint by default. Unsupported
 providers reject native Freeform specs or history with
 `MotosanError::UnsupportedFeature` before network I/O.
 
+### Stream termination (native)
+
+`ModelStreamDelta` streams follow the [Stream termination
+contract](#stream-termination-contract): exactly one `Done { stop_reason }`
+delta per successfully completed stream, emitted when the wire delivers a
+`response.completed` or `response.incomplete` terminal event. When the byte
+stream ends (EOF) without either terminal, the adapter yields
+`MotosanError::IncompleteStream` with the standard payload
+`<provider> ended without a terminal event` (provider names: `openai`,
+`chatgpt-codex`). `collect_model_stream` propagates that error; its
+`stop_reason` heuristic applies only to streams that did deliver a terminal.
+
 ## Usage
 
 | Field | Type |
@@ -286,11 +298,12 @@ end of a stream:
 
 | Provider family | Terminal event |
 |-----------------|----------------|
-| OpenAI | `data: [DONE]` SSE sentinel, or a `finish_reason`-bearing chunk (either suffices; `finish_reason` is the semantic terminal, `[DONE]` the transport epilogue) |
+| OpenAI (legacy `stream()` adapter) | `data: [DONE]` SSE sentinel, or a `finish_reason`-bearing chunk (either suffices; `finish_reason` is the semantic terminal, `[DONE]` the transport epilogue) |
 | MiniMax | Python: `data: [DONE]` SSE sentinel, or a `finish_reason`-bearing chunk (either suffices, as for OpenAI — own OpenAI-compatible-wire adapter). Rust / TypeScript: `message_stop` — both delegate to the Anthropic adapter (Rust `build_minimax_provider` constructs an `AnthropicProvider`; TS `MinimaxProvider` wraps one), so the Anthropic rule applies |
 | Anthropic | `message_stop` SSE event (the Python adapter additionally treats a stray `data: [DONE]` as terminal) |
 | Gemini, GeminiCodeAssist | final SSE chunk carrying `finishReason` (a trailing `[DONE]` is tolerated but not required) |
-| ChatGPT Codex | `response.completed` SSE event |
+| ChatGPT Codex (legacy `stream()` adapter) | `response.completed` SSE event |
+| OpenAI Responses mode / ChatGPT Codex — native model API (`model_stream`) | `response.completed` or `response.incomplete` SSE event (either is a received terminal) |
 | Ollama | final NDJSON object with `"done": true` |
 
 **Terminal-event rule.** Enforcement lives in the **stream adapters**,


### PR DESCRIPTION
Part of #242 (correctness quick-wins batch, PR-B).

The M3 truncation-vs-completion contract was unpinned on the 0.26.0 native path: `specs/types.md` had no Responses-mode row in the terminal-event table, `ModelStreamDelta` termination semantics were undocumented, and the shared Responses adapter emitted `"responses stream ended without a terminal event"` — deviating from the `"<provider> ended without a terminal event"` convention every legacy adapter follows (`error.rs:45`, `specs/types.md` "Message convention"). No test exercised native EOF-without-terminal at all.

This threads the provider name through `providers::responses::model_stream_adapter` so the `IncompleteStream` payload reads `openai` / `chatgpt-codex`, and pins the contract in the spec: the two existing OpenAI/Codex rows are relabelled as the legacy `stream()` adapters, a new row covers the native `model_stream` path (`response.completed` **or** `response.incomplete`), and a `### Stream termination (native)` subsection states the `Done { stop_reason }` / EOF-`IncompleteStream` rules. Two new mockito conformance tests (`native_openai_stream_eof_without_terminal_is_incomplete`, `native_codex_stream_eof_without_terminal_is_incomplete`) were observed RED on the message assertion first (left: `"responses stream ended without a terminal event"`), then green after the fix; the full credential-stripped `cargo test --all-features` suite passes with zero failures, alongside `cargo fmt --check` and `cargo clippy --all-features --all-targets -D warnings`.

Notes: `model_stream_adapter` is publicly reachable, so its new `provider: &'static str` parameter is an accepted 0.x public-API change — both in-repo call sites are updated and the CHANGELOG names it. The old message string appeared exactly once in the repo, so nothing else asserted it and no existing test changed. No HTTP semantics change, so the `#[ignore]`d live smokes (`chatgpt_codex_live.rs`, `live_chatgpt_codex_token_refresh.rs`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
