### PR TITLE
fix: central Python capability enforcement — Minimax was silently dropping images

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `motosan-ai` Python SDK are documented in this file.
 
 ## [Unreleased]
 
+### Breaking
+- Capability enforcement is now central (mirrors Rust/TS): `Client.chat*` /
+  `Client.stream*` raise `InvalidRequestError` before any network or CLI I/O
+  when a message carries content blocks the provider does not support.
+  Previously `openai` (documents), `minimax` (images), native `ollama`
+  (images) and the CLI backends (images/documents) silently dropped them.
+- `MinimaxProvider.capabilities` corrected `with_image()` → `text_only()`:
+  its wire serializer never transmitted images, so requests that previously
+  "succeeded" with the image silently discarded now raise. (Matches the
+  TypeScript SDK's declared Minimax capabilities.)
+
 ## [0.18.0] - 2026-07-17
 
 ### Breaking

--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -10,6 +10,7 @@ from types import TracebackType
 from typing import Any
 
 from motosan_ai.error import ConfigError, MotosanError, NetworkError, ProviderError, RateLimitError
+from motosan_ai.provider_base import validate_request as _validate_request
 from motosan_ai.providers import (
     AnthropicProvider,
     ChatGptCodexProvider,
@@ -459,6 +460,10 @@ class Client:
         if request.model is None and self.model is not None:
             request = replace(request, model=self.model)
 
+        caps = getattr(self._provider, "capabilities", None)
+        if caps is not None:
+            _validate_request(request, caps)
+
         if self._total_timeout is None:
             return await self._dispatch_chat(request)
         try:
@@ -505,6 +510,10 @@ class Client:
         """
         if request.model is None and self.model is not None:
             request = replace(request, model=self.model)
+
+        caps = getattr(self._provider, "capabilities", None)
+        if caps is not None:
+            _validate_request(request, caps)
 
         policy = self._retry_policy
         last_error: MotosanError | None = None

--- a/sdks/python/motosan_ai/provider_base.py
+++ b/sdks/python/motosan_ai/provider_base.py
@@ -26,17 +26,25 @@ class ProviderCapabilities:
         return cls(supports_image=True, supports_document=True)
 
 
+def validate_request(request: ChatRequest, capabilities: ProviderCapabilities) -> None:
+    """Raise InvalidRequestError for content blocks the capabilities do not support.
+
+    Central choke point mirroring Rust's ``validate_for_dispatch`` and the TS
+    ``validateRequest``: runs before any network/CLI dispatch.
+    """
+    for message in request.messages:
+        for block in message.content_blocks:
+            if isinstance(block, ImageBlock) and not capabilities.supports_image:
+                raise InvalidRequestError("provider does not support image input")
+            if isinstance(block, DocumentBlock) and not capabilities.supports_document:
+                raise InvalidRequestError("provider does not support document input")
+
+
 class BaseProvider(ABC):
     capabilities: ProviderCapabilities = ProviderCapabilities.text_only()
 
     def validate_request(self, request: ChatRequest) -> None:
-        caps = self.capabilities
-        for message in request.messages:
-            for block in message.content_blocks:
-                if isinstance(block, ImageBlock) and not caps.supports_image:
-                    raise InvalidRequestError("provider does not support image input")
-                if isinstance(block, DocumentBlock) and not caps.supports_document:
-                    raise InvalidRequestError("provider does not support document input")
+        validate_request(request, self.capabilities)
 
     @abstractmethod
     async def chat(self, request: ChatRequest) -> ChatResponse: ...

--- a/sdks/python/motosan_ai/providers/minimax.py
+++ b/sdks/python/motosan_ai/providers/minimax.py
@@ -40,7 +40,7 @@ def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, 
 
 
 class MinimaxProvider:
-    capabilities: ProviderCapabilities = ProviderCapabilities.with_image()
+    capabilities: ProviderCapabilities = ProviderCapabilities.text_only()
 
     def __init__(
         self,

--- a/sdks/python/tests/test_capability_enforcement.py
+++ b/sdks/python/tests/test_capability_enforcement.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from motosan_ai import Client, Message
+from motosan_ai.error import InvalidRequestError
+from motosan_ai.types import ChatResponse, StopReason, StreamEvent, Usage
+
+IMG = Message.user_with_image("caption", "abc", "image/png")
+PDF = Message.user_with_pdf_base64("caption", "abc")
+
+
+def _block_dispatch(monkeypatch, provider):
+    """Replace the provider's network/CLI entry points with recording fakes.
+
+    Enforcement must fire BEFORE dispatch, so these must never run. If
+    enforcement is missing, the fakes answer instantly and the test fails
+    deterministically — no network, no CLI process, no hangs.
+    """
+    calls: list[str] = []
+
+    async def fake_chat(request):
+        calls.append("chat")
+        return ChatResponse(content="dispatched", usage=Usage(1, 1), stop_reason=StopReason.stop)
+
+    async def fake_stream(request):
+        calls.append("stream")
+        yield StreamEvent(content="dispatched", done=True)
+
+    monkeypatch.setattr(provider, "chat", fake_chat)
+    monkeypatch.setattr(provider, "stream", fake_stream)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_minimax_image_rejected_on_chat(monkeypatch):
+    client = Client(provider="minimax", api_key="k")
+    calls = _block_dispatch(monkeypatch, client._provider)
+    with pytest.raises(InvalidRequestError, match="image"):
+        await client.chat([IMG])
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_minimax_image_rejected_on_stream(monkeypatch):
+    client = Client(provider="minimax", api_key="k")
+    calls = _block_dispatch(monkeypatch, client._provider)
+    with pytest.raises(InvalidRequestError, match="image"):
+        async for _ in client.stream([IMG]):
+            pass
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_openai_document_rejected_on_chat(monkeypatch):
+    client = Client(provider="openai", api_key="k")
+    calls = _block_dispatch(monkeypatch, client._provider)
+    with pytest.raises(InvalidRequestError, match="document"):
+        await client.chat([PDF])
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_ollama_native_image_rejected_on_chat(monkeypatch):
+    client = Client(provider="ollama", ollama_native=True, model="llama3.2")
+    calls = _block_dispatch(monkeypatch, client._provider)
+    with pytest.raises(InvalidRequestError, match="image"):
+        await client.chat([IMG])
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_claude_code_image_rejected_on_chat(monkeypatch):
+    client = Client(provider="claude_code")
+    calls = _block_dispatch(monkeypatch, client._provider)
+    with pytest.raises(InvalidRequestError, match="image"):
+        await client.chat([IMG])
+    assert calls == []
+
+
+class _NoCapsProvider:
+    """LlmClient-Protocol-shaped provider WITHOUT a capabilities attribute."""
+
+    async def chat(self, request):
+        return ChatResponse(content="ok", usage=Usage(1, 1), stop_reason=StopReason.stop)
+
+    async def stream(self, request):
+        if False:
+            yield None
+
+
+@pytest.mark.asyncio
+async def test_provider_without_capabilities_is_not_validated():
+    # The LlmClient Protocol does not require `capabilities`; central
+    # validation must be skipped, not crash, for such providers.
+    client = Client(provider="anthropic", api_key="k")
+    client._provider = _NoCapsProvider()
+    response = await client.chat([IMG])
+    assert response.content == "ok"

--- a/sdks/python/tests/test_provider_capabilities.py
+++ b/sdks/python/tests/test_provider_capabilities.py
@@ -96,9 +96,9 @@ def test_openai_is_with_image():
     assert p.capabilities == ProviderCapabilities.with_image()
 
 
-def test_minimax_is_with_image():
+def test_minimax_is_text_only():
     p = MinimaxProvider(api_key="test")
-    assert p.capabilities == ProviderCapabilities.with_image()
+    assert p.capabilities == ProviderCapabilities.text_only()
 
 
 def test_ollama_native_is_text_only():


### PR DESCRIPTION
Part of #242.

Rust validates provider capabilities centrally (`client.rs` `validate_for_dispatch`) and TypeScript does too (`provider.ts` `dispatchChat`/`dispatchStream`), but Python only validated inside the four providers that subclass or self-call `BaseProvider.validate_request`. `OpenAIProvider`, `MinimaxProvider`, `OllamaProvider` and the three CLI backends declared `capabilities` but never enforced them — most visibly, Minimax declared `with_image()` while `_serialize_messages` only ever transmits `message.content`, so images were **silently discarded** on the wire. This extracts a module-level `validate_request(request, capabilities)` in `provider_base.py` (the `BaseProvider` method now delegates to it, behavior unchanged) and calls it from `Client.chat_with` / `Client.stream_with` before any network or CLI dispatch, guarded with `getattr(self._provider, "capabilities", None)` so the `LlmClient` Protocol is unchanged and providers without a `capabilities` attribute (motosan-chat, test fakes) keep working. Minimax's declared capability is corrected to `text_only()` — its native wire has no image serialization at all, matching the TypeScript SDK's deliberate `minimaxCaps()` decision (Rust routes Minimax through the Anthropic adapter, a different wire, so no Rust change).

**Test evidence:** new `tests/test_capability_enforcement.py` (6 tests) — five monkeypatch-guarded rejection cases (minimax image on chat + stream, openai document, native ollama image, claude_code image) that replace the provider's `chat`/`stream` with recording fakes and assert they are never reached, plus one case proving a provider without a `capabilities` attribute is skipped rather than crashing. All five were observed RED (`DID NOT RAISE InvalidRequestError`) before the fix and green after. `tests/test_provider_capabilities.py::test_minimax_is_with_image` is flipped to `test_minimax_is_text_only` — the only planned test flip; a sweep of `tests/` found no other test pinning Minimax image support. Full unit suite `uv run pytest tests/ -q --ignore=tests/integration/` is green with **zero unplanned flips**; `ruff check motosan_ai/` and `ruff format --check motosan_ai/ tests/` clean.

**Breaking:** requests that previously "succeeded" with content silently dropped now raise `InvalidRequestError`. Documented under `## [Unreleased]` → `### Breaking` in `sdks/python/CHANGELOG.md`; no version bump (rides the next release wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)