### PR TITLE
fix: ThinkStripper UTF-8 boundary panic and zero-copy fast path

### DIFF
--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `ThinkStripper` no longer panics on multi-byte UTF-8 content inside an
+  unterminated `<think>` block (the buffered-tail cut in the in-think branch
+  lacked the char-boundary guard the other branch had). The no-tag fast path
+  also stops copying every text delta a second time (the buffer's allocation
+  is handed to the caller; only the tiny partial-tag tail is newly allocated),
+  and the tag-found branches now trim in place instead of reallocating.
+
 ## [0.26.0] - 2026-07-21
 
 ### Added

--- a/sdks/rust/src/think_stripper.rs
+++ b/sdks/rust/src/think_stripper.rs
@@ -33,13 +33,16 @@ impl ThinkStripper {
                 match self.buf.find("</think>") {
                     None => {
                         let keep = "</think>".len() - 1;
-                        if self.buf.len() > keep {
-                            self.buf = self.buf[self.buf.len() - keep..].to_string();
+                        let mut cut = self.buf.len().saturating_sub(keep);
+                        // Ensure we split on a char boundary (important for multi-byte UTF-8)
+                        while cut > 0 && !self.buf.is_char_boundary(cut) {
+                            cut -= 1;
                         }
+                        self.buf.drain(..cut);
                         break;
                     }
                     Some(end) => {
-                        self.buf = self.buf[end + "</think>".len()..].to_string();
+                        self.buf.drain(..end + "</think>".len());
                         self.in_think = false;
                     }
                 }
@@ -52,13 +55,21 @@ impl ThinkStripper {
                         while safe > 0 && !self.buf.is_char_boundary(safe) {
                             safe -= 1;
                         }
+                        if output.is_empty() {
+                            // Fast path: hand the buffer's allocation to the caller;
+                            // self.buf becomes the freshly-split tiny tail. This removes
+                            // the second full-size copy AND the full-size tail realloc
+                            // (the tail alloc is ≤ a few bytes).
+                            let tail = self.buf.split_off(safe);
+                            return std::mem::replace(&mut self.buf, tail);
+                        }
                         output.push_str(&self.buf[..safe]);
-                        self.buf = self.buf[safe..].to_string();
+                        self.buf.drain(..safe);
                         break;
                     }
                     Some(start) => {
                         output.push_str(&self.buf[..start]);
-                        self.buf = self.buf[start + "<think>".len()..].to_string();
+                        self.buf.drain(..start + "<think>".len());
                         self.in_think = true;
                     }
                 }
@@ -138,5 +149,25 @@ mod tests {
         let mut s = ThinkStripper::new();
         s.feed("<think>still thinking");
         assert_eq!(s.flush(), "");
+    }
+
+    #[test]
+    fn multibyte_thinking_content_does_not_panic() {
+        let mut s = ThinkStripper::new();
+        // 8 three-byte chars = 24 bytes; len - 7 = 17 is NOT a char boundary.
+        assert_eq!(s.feed("<think>中文思考中文思考"), "");
+        let mut out = s.feed("</think>答案");
+        out.push_str(&s.flush());
+        assert_eq!(out, "答案");
+    }
+
+    #[test]
+    fn multibyte_passthrough_across_chunks() {
+        let mut s = ThinkStripper::new();
+        let mut out = String::new();
+        out.push_str(&s.feed("回答是："));
+        out.push_str(&s.feed("四十二。"));
+        out.push_str(&s.flush());
+        assert_eq!(out, "回答是：四十二。");
     }
 }


### PR DESCRIPTION
Reproduces and fixes a panic when multi-byte UTF-8 content sits inside an unterminated `<think>` block, where the in-think tail cut was not guarded at a char boundary. The `feed()` rewrite also keeps the behavior-neutral fast path zero-copy by handing the buffer allocation to the caller and using in-place drains for tag trimming; public APIs are unchanged. Test evidence: added `multibyte_thinking_content_does_not_panic` and `multibyte_passthrough_across_chunks`, observed the panic test fail RED first, then passed `cargo test think_stripper::tests` (10/10), clippy/format/treefmt gates, credential-stripped `cargo test --all-features`, and the pre-push Python/Rust gates. References #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)