### PR TITLE
fix: python publish gates + typescript dispatch guard

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -13,8 +13,27 @@ jobs:
         working-directory: sdks/python
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
-      - run: uv build --out-dir dist
+      - uses: astral-sh/setup-uv@v5
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+            expected_tag="python-v${version}"
+            if [ "${GITHUB_REF_NAME:-}" != "$expected_tag" ]; then
+              echo "::error::Tag ${GITHUB_REF_NAME:-<none>} does not match pyproject.toml version ${expected_tag}"
+              exit 1
+            fi
+          fi
+      - name: Sync deps
+        run: uv sync --all-extras
+      - name: Lint
+        run: uv run ruff check motosan_ai/
+      - name: Format check
+        run: uv run ruff format --check motosan_ai/ tests/
+      - name: Unit tests
+        run: uv run pytest tests/ -q --ignore=tests/integration/
+      - name: Build
+        run: uv build --out-dir dist
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: sdks/python/dist/

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -27,6 +27,10 @@ jobs:
       - run: npm run test
       - name: Verify tag matches package.json version
         run: |
+          if [ "${GITHUB_REF_TYPE:-}" != "tag" ]; then
+            echo "::notice::Not a tag ref (workflow_dispatch) — skipping tag check; publishing package.json version as-is"
+            exit 0
+          fi
           TAG="${GITHUB_REF_NAME#ts-v}"
           PKG=$(node -p "require('./package.json').version")
           test "$TAG" = "$PKG" || { echo "tag $TAG != package.json $PKG"; exit 1; }


### PR DESCRIPTION
This hardens the Python publish workflow for #242 by adding a tag-vs-pyproject check plus sync/lint/format/unit-test gates before build/upload, while leaving the existing token-based PyPI publish path intact. It also guards the TypeScript tag/version verification so workflow_dispatch skips tag-only validation and can publish the package.json version as-is.

Verification: YAML parsing printed `yaml ok`; `actionlint .github/workflows/publish-python.yml .github/workflows/publish-typescript.yml` exited 0; `nix run nixpkgs#treefmt -- -C /tmp/motosan-ai-issue-242-publish-workflow-guards --fail-on-change` formatted 210 files with 0 changed; `uv sync --all-extras` completed; and the pre-push hook passed Python unit tests, Rust unit tests, Python live Anthropic tests (10 passed, 1 skipped), and Rust live Anthropic tests (11 passed). These publish workflows only execute on the next `python-v*` / `ts-v*` tag push or manual dispatch, and this PR is expected to show no CI checks because PR workflows are path-filtered to `sdks/**`; reviewers should eyeball this against `publish-rust.yml`'s proven `GITHUB_REF_TYPE` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
