### PR TITLE
fix: pin native model-stream termination contract (spec + message + EOF tests)

### DIFF
--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Native model streams (`model_stream_with`) now report EOF-truncation as
+  `incomplete stream: <provider> ended without a terminal event`
+  (`openai` / `chatgpt-codex`), matching the spec's message convention. The
+  previous payload was `responses stream ended without a terminal event`.
+  Match on the `IncompleteStream` variant, not the message text.
+  `providers::responses::model_stream_adapter` accordingly gained a
+  `provider: &'static str` parameter.
+
 ### Fixed
 - `ThinkStripper` no longer panics on multi-byte UTF-8 content inside an
   unterminated `<think>` block (the buffered-tail cut in the in-think branch

--- a/sdks/rust/src/providers/chatgpt_codex.rs
+++ b/sdks/rust/src/providers/chatgpt_codex.rs
@@ -421,6 +421,7 @@ impl ProviderImpl for ChatGptCodexProvider {
 
         Ok(crate::providers::responses::model_stream_adapter(
             response.bytes_stream().eventsource(),
+            "chatgpt-codex",
         ))
     }
 }

--- a/sdks/rust/src/providers/openai.rs
+++ b/sdks/rust/src/providers/openai.rs
@@ -748,6 +748,7 @@ impl ProviderImpl for OpenAIProvider {
 
         Ok(crate::providers::responses::model_stream_adapter(
             response.bytes_stream().eventsource(),
+            "openai",
         ))
     }
 }

--- a/sdks/rust/src/providers/responses.rs
+++ b/sdks/rust/src/providers/responses.rs
@@ -400,7 +400,7 @@ fn encode_user_content(message: &Message) -> Vec<Value> {
 }
 
 #[cfg(feature = "_http")]
-pub fn model_stream_adapter<S>(sse: S) -> crate::stream::BoxModelStream
+pub fn model_stream_adapter<S>(sse: S, provider: &'static str) -> crate::stream::BoxModelStream
 where
     S: futures_core::Stream<
             Item = Result<
@@ -417,6 +417,7 @@ where
         saw_tool_call: false,
         error: None,
         saw_terminal: false,
+        provider,
     })
 }
 
@@ -437,6 +438,7 @@ struct ResponsesModelStreamAdapter {
     saw_tool_call: bool,
     error: Option<String>,
     saw_terminal: bool,
+    provider: &'static str,
 }
 
 #[cfg(feature = "_http")]
@@ -633,9 +635,10 @@ impl futures_core::Stream for ResponsesModelStreamAdapter {
                     if !self.saw_terminal {
                         self.saw_terminal = true;
                         return Poll::Ready(Some(Err(
-                            crate::error::MotosanError::IncompleteStream(
-                                "responses stream ended without a terminal event".to_string(),
-                            ),
+                            crate::error::MotosanError::IncompleteStream(format!(
+                                "{} ended without a terminal event",
+                                self.provider
+                            )),
                         )));
                     }
                     return Poll::Ready(None);

--- a/sdks/rust/tests/chatgpt_codex.rs
+++ b/sdks/rust/tests/chatgpt_codex.rs
@@ -97,6 +97,36 @@ async fn custom_tool_stream_decodes_custom_delta_and_done() {
 }
 
 #[tokio::test]
+async fn native_codex_stream_eof_without_terminal_is_incomplete() {
+    let mut server = mockito::Server::new_async().await;
+    let sse = "data: {\"type\":\"response.custom_tool_call_input.delta\",\"call_id\":\"call_js\",\"delta\":\"console.\"}\n\n";
+    let mock = server
+        .mock("POST", Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse)
+        .create_async()
+        .await;
+
+    let provider =
+        ChatGptCodexProvider::new("oauth-token", "acct-123", "gpt-5.5", Some(server.url()));
+    let stream = provider
+        .model_stream(native_custom_request())
+        .await
+        .expect("native stream");
+    let err = collect_model_stream(stream)
+        .await
+        .expect_err("EOF without terminal must yield IncompleteStream");
+    match err {
+        MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "chatgpt-codex ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn custom_tool_chat_collects_native_stream() {
     let mut server = mockito::Server::new_async().await;
     let sse = concat!(

--- a/sdks/rust/tests/openai_provider.rs
+++ b/sdks/rust/tests/openai_provider.rs
@@ -274,6 +274,42 @@ async fn native_custom_openai_stream_decodes_custom_delta_and_done() {
 }
 
 #[tokio::test]
+async fn native_openai_stream_eof_without_terminal_is_incomplete() {
+    let mut server = mockito::Server::new_async().await;
+    // Text deltas but NO response.completed / response.incomplete → truncated.
+    let sse = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hel\"}\n\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"lo\"}\n\n"
+    );
+    let mock = server
+        .mock("POST", "/v1/responses")
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse)
+        .create_async()
+        .await;
+
+    let provider = OpenAIProvider::new("test-key", None)
+        .with_responses_api(true)
+        .with_responses_url(format!("{}/v1/responses", server.url()));
+
+    let stream = provider
+        .model_stream(native_custom_request())
+        .await
+        .expect("native stream");
+    let err = collect_model_stream(stream)
+        .await
+        .expect_err("EOF without terminal must yield IncompleteStream");
+    match err {
+        MotosanError::IncompleteStream(msg) => {
+            assert_eq!(msg, "openai ended without a terminal event")
+        }
+        other => panic!("expected IncompleteStream, got {other:?}"),
+    }
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn openai_chat_maps_response() {
     let mut server = mockito::Server::new_async().await;
     let mock = server

--- a/specs/types.md
+++ b/specs/types.md
@@ -208,6 +208,18 @@ Freeform transport through its Responses endpoint by default. Unsupported
 providers reject native Freeform specs or history with
 `MotosanError::UnsupportedFeature` before network I/O.
 
+### Stream termination (native)
+
+`ModelStreamDelta` streams follow the [Stream termination
+contract](#stream-termination-contract): exactly one `Done { stop_reason }`
+delta per successfully completed stream, emitted when the wire delivers a
+`response.completed` or `response.incomplete` terminal event. When the byte
+stream ends (EOF) without either terminal, the adapter yields
+`MotosanError::IncompleteStream` with the standard payload
+`<provider> ended without a terminal event` (provider names: `openai`,
+`chatgpt-codex`). `collect_model_stream` propagates that error; its
+`stop_reason` heuristic applies only to streams that did deliver a terminal.
+
 ## Usage
 
 | Field | Type |
@@ -286,11 +298,12 @@ end of a stream:
 
 | Provider family | Terminal event |
 |-----------------|----------------|
-| OpenAI | `data: [DONE]` SSE sentinel, or a `finish_reason`-bearing chunk (either suffices; `finish_reason` is the semantic terminal, `[DONE]` the transport epilogue) |
+| OpenAI (legacy `stream()` adapter) | `data: [DONE]` SSE sentinel, or a `finish_reason`-bearing chunk (either suffices; `finish_reason` is the semantic terminal, `[DONE]` the transport epilogue) |
 | MiniMax | Python: `data: [DONE]` SSE sentinel, or a `finish_reason`-bearing chunk (either suffices, as for OpenAI — own OpenAI-compatible-wire adapter). Rust / TypeScript: `message_stop` — both delegate to the Anthropic adapter (Rust `build_minimax_provider` constructs an `AnthropicProvider`; TS `MinimaxProvider` wraps one), so the Anthropic rule applies |
 | Anthropic | `message_stop` SSE event (the Python adapter additionally treats a stray `data: [DONE]` as terminal) |
 | Gemini, GeminiCodeAssist | final SSE chunk carrying `finishReason` (a trailing `[DONE]` is tolerated but not required) |
-| ChatGPT Codex | `response.completed` SSE event |
+| ChatGPT Codex (legacy `stream()` adapter) | `response.completed` SSE event |
+| OpenAI Responses mode / ChatGPT Codex — native model API (`model_stream`) | `response.completed` or `response.incomplete` SSE event (either is a received terminal) |
 | Ollama | final NDJSON object with `"done": true` |
 
 **Terminal-event rule.** Enforcement lives in the **stream adapters**,


### PR DESCRIPTION
Supersedes #244 (accidentally closed when its head branch was deleted during a conflicted merge attempt; the branch has been rebased onto main to resolve the Rust CHANGELOG [Unreleased] conflict with #246 — content otherwise identical and previously CI-green).

Pins the M3 truncation-vs-completion contract on the 0.26.0 native model API for #242: specs/types.md gains a native termination subsection + table row (legacy rows labeled), providers::responses::model_stream_adapter gains a provider name so IncompleteStream reports the conventional `<provider> ended without a terminal event` payload, and two EOF-truncation conformance tests (openai Responses mode + chatgpt-codex) pin the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)