### PR TITLE
refactor: replace pinned Cargo install snippets with cargo add

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ response = await client.chat([Message.user("Hello")])
 
 ## Install
 
-```toml
-# Rust (Cargo.toml)
-[dependencies]
-motosan-ai = { version = "0.27.0", features = ["anthropic"] }
+```bash
+# Rust
+cargo add motosan-ai --features anthropic
 # features: anthropic | openai | minimax | ollama | ollama_native (alias: ollama-native) | full
 #           gemini | gemini-code-assist | chatgpt-codex | claude-code | codex-cli | gemini-cli
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -21,10 +21,9 @@ pip install "motosan-ai[gemini]"
 pip install "motosan-ai[anthropic,openai,ollama,minimax,gemini]"
 ```
 
-```toml
-# Rust — pick features in Cargo.toml
-[dependencies]
-motosan-ai = { version = "0.27.0", features = ["anthropic"] }
+```bash
+# Rust — pick features when adding the dependency
+cargo add motosan-ai --features anthropic
 # features: anthropic | openai | minimax | ollama | ollama_native (alias: ollama-native) | full
 #           gemini | gemini-code-assist | chatgpt-codex
 # CLI backends (Rust features; Python has built-in ClaudeCodeClient/CodexCliClient/GeminiCliClient):
@@ -976,14 +975,14 @@ Python, Rust, and TypeScript SDKs are versioned and released **independently**.
 
 ### Tag Convention
 
-| SDK          | Tag format            | Example               |
-|--------------|-----------------------|-----------------------|
-| Python       | `python-vX.Y.Z`       | `python-v0.4.2`       |
-| Rust         | `rust-vX.Y.Z`         | `rust-v0.3.3`         |
-| TypeScript   | `ts-vX.Y.Z`           | `ts-v0.15.0`          |
-| motosan-ai-oauth | `motosan-ai-oauth-vX.Y.Z` | `motosan-ai-oauth-v0.2.0` |
-| codex-oauth  | `codex-oauth-vX.Y.Z`  | `codex-oauth-v0.1.0`  |
-| anthropic-oauth | `anthropic-oauth-vX.Y.Z` | `anthropic-oauth-v0.1.0` |
+| SDK              | Tag format                |
+|------------------|---------------------------|
+| Python           | `python-vX.Y.Z`           |
+| Rust             | `rust-vX.Y.Z`             |
+| TypeScript       | `ts-vX.Y.Z`               |
+| motosan-ai-oauth | `motosan-ai-oauth-vX.Y.Z` |
+| codex-oauth      | `codex-oauth-vX.Y.Z`      |
+| anthropic-oauth  | `anthropic-oauth-vX.Y.Z`  |
 
 ### Release Steps (Python)
 

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -393,8 +393,8 @@ Error handling policy reference: `docs/error-handling-policy.md`.
 
 The `claude-code` feature enables `ClaudeCodeProvider`, which shells out to the `claude` CLI binary. The provider exposes a builder covering every SDK-relevant flag that the `claude --print` mode accepts.
 
-```toml
-motosan-ai = { version = "0.27.0", features = ["claude-code"] }
+```bash
+cargo add motosan-ai --features claude-code
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0, unified with HTTP providers). Build the provider with all the claude-specific flags, then hand it to the `Client` setter:
@@ -503,8 +503,8 @@ Notes:
 
 The `codex-cli` feature enables `CodexCliProvider`, which shells out to OpenAI's `codex exec --json` and parses the JSONL event stream.
 
-```toml
-motosan-ai = { version = "0.27.0", features = ["codex-cli"] }
+```bash
+cargo add motosan-ai --features codex-cli
 ```
 
 **Option A — via `Client::builder()`** (since v0.11.0). Build the provider with all the codex-specific flags, then hand it to the `Client` setter:
@@ -566,8 +566,8 @@ Notes:
 
 The `gemini-cli` feature enables `GeminiCliProvider`, which shells out to Google's `gemini -p "" -o stream-json` and parses the NDJSON event stream. Auth is handled by the `gemini` CLI itself (`gemini auth` once; personal Google account or API key) — motosan-ai does not pass any credentials through.
 
-```toml
-motosan-ai = { version = "0.27.0", features = ["gemini-cli"] }
+```bash
+cargo add motosan-ai --features gemini-cli
 ```
 
 **Option A — via `Client::builder()`**:

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -483,8 +483,8 @@ Automated via `publish-typescript.yml` on a `ts-v*` tag push → npm.
 
 ```bash
 # Bump sdks/typescript/package.json version + CHANGELOG, then:
-git tag ts-v0.15.0
-git push origin ts-v0.15.0
+git tag ts-vX.Y.Z
+git push origin ts-vX.Y.Z
 ```
 
 The Rust, Python, and TypeScript SDKs are versioned and released independently.

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -20,15 +20,15 @@ pip install "motosan-ai[gemini]"             # Gemini HTTP provider
 pip install "motosan-ai[anthropic,openai,gemini]"   # multiple providers
 ```
 
-```toml
-# Rust (Cargo.toml)
-motosan-ai = { version = "0.27.0", features = ["anthropic"] }
+```bash
+# Rust
+cargo add motosan-ai --features anthropic
 # features: anthropic | openai | minimax | ollama | ollama_native (alias: ollama-native) | full
 #           gemini | gemini-code-assist | chatgpt-codex
 # CLI backends (shell out to a local binary): claude-code | codex-cli | gemini-cli
 
 # Codex OAuth (standalone — get a token for chatgpt.com/backend-api)
-codex-oauth = "0.1"
+cargo add codex-oauth
 ```
 
 ```bash

--- a/skills/motosan-ai/references/rust-api.md
+++ b/skills/motosan-ai/references/rust-api.md
@@ -1,10 +1,9 @@
 # motosan-ai Rust API Reference
 
-## Cargo.toml
+## Install
 
-```toml
-[dependencies]
-motosan-ai = { version = "0.27.0", features = ["anthropic"] }
+```bash
+cargo add motosan-ai --features anthropic
 # features: anthropic | openai | minimax | ollama | ollama_native (alias: ollama-native) | full
 #           gemini | gemini-code-assist | chatgpt-codex | claude-code | codex-cli | gemini-cli
 ```


### PR DESCRIPTION
Closes #254. First step of the release-process work: shrink the set of places a release has to touch.

The 2026-07-28 release (13c8d32) updated 15 version-coupled locations across 10 derived files. Seven were Cargo install snippets whose only job was to be copy-pasted — they pin the current version and rot on every release (this is the class that went stale in the M1 release and had to be fixed afterwards in #219). `cargo add` resolves the latest compatible version at run time, so the docs stop carrying a version at all — which is already how the Python (`pip install`) and TypeScript (`npm install`) instructions work.

- Four snippets → `cargo add motosan-ai --features anthropic` (root README, llms.txt, skills/motosan-ai/SKILL.md, skills/motosan-ai/references/rust-api.md). The feature-list comments are preserved; the fences become `bash`. SKILL.md's fence also carried `codex-oauth = "0.1"`, now `cargo add codex-oauth`. rust-api.md's section heading changes from "Cargo.toml" to "Install" since it no longer shows a manifest.
- Three snippets → `cargo add motosan-ai --features claude-code` / `codex-cli` / `gemini-cli` (sdks/rust/README.md). These are per-CLI-backend, not `anthropic`.
- Two remaining current-version examples removed: the `ts-v0.15.0` tag example in sdks/typescript/README.md becomes `ts-vX.Y.Z`, and llms.txt's Tag Convention table drops its Example column (the Tag format column already shows the pattern; the examples were a mix of stale and rot-prone).

Remaining version-coupled locations: 8 — three manifests, two lockfiles (uv.lock, package-lock.json), four version banners, and three CHANGELOG headings. The CHANGELOG headings are legitimate history; the banners and lockfiles are the next target, to be pinned by a metadata checker that also forbids re-introducing version-pinned Cargo snippets.

Verification: `grep -rn 'motosan-ai = { version'` over `*.md`/`*.txt` now matches only `docs/superpowers/plans/` (historical planning records of past releases, correctly excluded). `treefmt --fail-on-change`: 211 files, 0 changed. Docs-only, so no CI checks will appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)