### PR TITLE
feat: script the release version bump across all derived locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ sdks/python/__pycache__/
 sdks/python/**/__pycache__/
 sdks/python/**/.pytest_cache/
 
+# Byte-code from the release scripts in scripts/
+__pycache__/
+
 # TypeScript SDK
 sdks/typescript/node_modules/
 sdks/typescript/dist/

--- a/llms.txt
+++ b/llms.txt
@@ -973,6 +973,18 @@ token.issued_at      // Unix timestamp of issue time
 
 Python, Rust, and TypeScript SDKs are versioned and released **independently**.
 
+The version bump itself is scripted — do not hand-edit the manifests, lockfiles,
+CHANGELOG headings, or doc version banners:
+
+```bash
+python3 scripts/bump-version.py --rust 0.28.0 --python 0.20.0   # add --dry-run to preview
+```
+
+It writes every derived location and then runs `scripts/check-versions.py`, which
+also gates CI (`ci-metadata`) and the pre-push hook. What stays manual: the root
+`CHANGELOG.md` entry, the AGENTS.md release paragraph, and tagging after merge.
+The per-SDK steps below describe what the script automates.
+
 ### Tag Convention
 
 | SDK              | Tag format                |

--- a/scripts/_release_sites.py
+++ b/scripts/_release_sites.py
@@ -1,0 +1,119 @@
+"""Registry of every version-coupled location in the repo.
+
+`check-versions.py` verifies these; `bump-version.py` writes them. They share
+this module so the two can never disagree about where a version lives — a
+drifting list would defeat both tools at once.
+
+Three manifests are the sources of truth; everything else is derived.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SDKS = ("rust", "python", "ts")
+
+MANIFESTS = {
+    "rust": "sdks/rust/Cargo.toml",
+    "python": "sdks/python/pyproject.toml",
+    "ts": "sdks/typescript/package.json",
+}
+
+CHANGELOGS = {
+    "rust": "sdks/rust/CHANGELOG.md",
+    "python": "sdks/python/CHANGELOG.md",
+    "ts": "sdks/typescript/CHANGELOG.md",
+}
+
+UV_LOCK = "uv.lock"
+NPM_LOCK = "sdks/typescript/package-lock.json"
+
+# (path, template, anchor). The anchor locates the line even when its version
+# is stale, so it must contain no version and must match exactly one line —
+# `check_anchor_uniqueness` enforces that.
+BANNERS: tuple[tuple[str, str, str], ...] = (
+    (
+        "AGENTS.md",
+        "Rust v{rust} · Python v{python} (PyPI) · TypeScript v{ts} (npm)",
+        "(PyPI) · TypeScript v",
+    ),
+    (
+        "llms.txt",
+        "- Python {python} · TypeScript {ts} · Rust {rust}",
+        "· Rust ",
+    ),
+    (
+        "skills/motosan-ai/SKILL.md",
+        "Multi-provider LLM SDK — Python {python} / Rust {rust} / TypeScript {ts}",
+        "Multi-provider LLM SDK — Python ",
+    ),
+    (
+        "README.md",
+        "| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v{rust} |",
+        "| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) |",
+    ),
+    (
+        "README.md",
+        "| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v{python} |",
+        "| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) |",
+    ),
+    (
+        "README.md",
+        "| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) | v{ts} |",
+        "| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) |",
+    ),
+)
+
+SDK_LABELS = {"rust": "Rust", "python": "Python", "ts": "TypeScript"}
+
+
+def read_text(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def write_text(rel: str, text: str) -> None:
+    (ROOT / rel).write_text(text, encoding="utf-8")
+
+
+def load_toml(rel: str) -> dict:
+    with (ROOT / rel).open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def load_json(rel: str) -> dict:
+    return json.loads(read_text(rel))
+
+
+def read_versions() -> dict[str, str]:
+    """The three sources of truth."""
+    return {
+        "rust": load_toml(MANIFESTS["rust"])["package"]["version"],
+        "python": load_toml(MANIFESTS["python"])["project"]["version"],
+        "ts": load_json(MANIFESTS["ts"])["version"],
+    }
+
+
+def uv_lock_version() -> str | None:
+    """The workspace member's own version as recorded in uv.lock."""
+    entries = [
+        pkg
+        for pkg in load_toml(UV_LOCK).get("package", [])
+        if pkg.get("name") == "motosan-ai" and "version" in pkg
+    ]
+    return entries[0]["version"] if len(entries) == 1 else None
+
+
+def npm_lock_versions() -> dict[str, str | None]:
+    lock = load_json(NPM_LOCK)
+    return {
+        "top-level version": lock.get("version"),
+        'packages[""].version': lock.get("packages", {}).get("", {}).get("version"),
+    }
+
+
+def anchor_matches(rel: str, anchor: str) -> list[str]:
+    return [line for line in read_text(rel).splitlines() if anchor in line]

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Perform the mechanical half of a release: bump versions everywhere.
+
+    python3 scripts/bump-version.py --rust 0.28.0 --python 0.20.0
+    python3 scripts/bump-version.py --ts 0.16.0 --dry-run
+
+Several SDKs can be bumped in one run — they share the doc banners, so doing
+them separately would rewrite the same lines twice. For each requested SDK it
+updates the manifest, opens a dated CHANGELOG section by renaming the content
+currently under `[Unreleased]`, and refreshes the derived lockfile entry
+(`uv.lock` for Python, `package-lock.json` for TypeScript — a version-only
+bump touches exactly the member's own version fields, which is all `uv lock`
+or `npm install` would change). It then rewrites the shared version banners
+and runs `check-versions.py` to prove the result is consistent.
+
+Re-running with the same versions is a no-op: an already-bumped manifest is
+left alone and an existing CHANGELOG heading is never inserted twice.
+
+What it deliberately does NOT do: write the root CHANGELOG entry. That is
+release prose, not a mechanical edit, and the summary prints a reminder.
+
+Dates default to today in UTC — release commits are made from several
+timezones and the CHANGELOG should not depend on who ran the script.
+
+Needs Python >= 3.11; stdlib only. The locations it writes live in
+`_release_sites.py`, shared with `check-versions.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+import sys
+
+import _release_sites as sites
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.\-]+)?$")
+
+
+class BumpError(Exception):
+    """A problem the caller must fix before the release can proceed."""
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="bump-version.py",
+        description="Bump one or more SDK versions and every location derived from them.",
+    )
+    for sdk in sites.SDKS:
+        parser.add_argument(
+            f"--{sdk}",
+            metavar="X.Y.Z",
+            help=f"new {sites.SDK_LABELS[sdk]} version",
+        )
+    parser.add_argument(
+        "--date",
+        metavar="YYYY-MM-DD",
+        help="CHANGELOG date (default: today in UTC)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print what would change and write nothing",
+    )
+    args = parser.parse_args(argv)
+
+    if not any(getattr(args, sdk) for sdk in sites.SDKS):
+        parser.error("name at least one SDK to bump, e.g. --rust 0.28.0")
+
+    for sdk in sites.SDKS:
+        value = getattr(args, sdk)
+        if value and not SEMVER.match(value):
+            parser.error(f"--{sdk} {value!r} is not a valid X.Y.Z version")
+
+    if args.date and not re.match(r"^\d{4}-\d{2}-\d{2}$", args.date):
+        parser.error(f"--date {args.date!r} is not YYYY-MM-DD")
+
+    return args
+
+
+def replace_unique_line(text: str, predicate, new_line: str, description: str) -> str:
+    """Rewrite the single line matching `predicate`."""
+    lines = text.splitlines(keepends=True)
+    hits = [index for index, line in enumerate(lines) if predicate(line.rstrip("\n"))]
+    if len(hits) != 1:
+        raise BumpError(
+            f"{description}: expected exactly 1 matching line, found {len(hits)}"
+        )
+    ending = "\n" if lines[hits[0]].endswith("\n") else ""
+    lines[hits[0]] = new_line + ending
+    return "".join(lines)
+
+
+def bump_manifest(
+    sdk: str, old: str, new: str, pending: dict[str, str], log: list[str]
+) -> None:
+    rel = sites.MANIFESTS[sdk]
+    if old == new:
+        log.append(f"  = {rel} already at {new}")
+        return
+
+    text = pending.get(rel, sites.read_text(rel))
+    if sdk == "ts":
+        pending[rel] = replace_unique_line(
+            text,
+            lambda line: line.strip() == f'"version": "{old}",',
+            f'  "version": "{new}",',
+            rel,
+        )
+    else:
+        pending[rel] = replace_unique_line(
+            text,
+            lambda line: line == f'version = "{old}"',
+            f'version = "{new}"',
+            rel,
+        )
+    log.append(f"  ✎ {rel}: {old} → {new}")
+
+
+def open_changelog_section(
+    sdk: str, new: str, date: str, pending: dict[str, str], log: list[str]
+) -> None:
+    """Rename the current [Unreleased] content into a dated release heading."""
+    rel = sites.CHANGELOGS[sdk]
+    text = pending.get(rel, sites.read_text(rel))
+    lines = text.splitlines()
+
+    if any(line.startswith(f"## [{new}]") for line in lines):
+        log.append(f"  = {rel} already has a [{new}] section")
+        return
+
+    try:
+        index = next(
+            i for i, line in enumerate(lines) if line.strip() == "## [Unreleased]"
+        )
+    except StopIteration:
+        raise BumpError(
+            f"{rel}: no '## [Unreleased]' heading to release from"
+        ) from None
+
+    rest = lines[index + 1 :]
+    next_heading = next(
+        (offset for offset, line in enumerate(rest) if line.startswith("## ")),
+        len(rest),
+    )
+    if not any(line.strip() for line in rest[:next_heading]):
+        raise BumpError(
+            f"{rel}: nothing under [Unreleased] — write the release notes before bumping {sdk}"
+        )
+
+    heading = f"## [{new}] - {date}"
+    updated = lines[: index + 1] + ["", heading] + rest
+    pending[rel] = "\n".join(updated) + ("\n" if text.endswith("\n") else "")
+    log.append(f"  ✎ {rel}: opened {heading}")
+
+
+def bump_uv_lock(old: str, new: str, pending: dict[str, str], log: list[str]) -> None:
+    """Rewrite the workspace member's version inside its [[package]] block."""
+    if old == new:
+        return
+    rel = sites.UV_LOCK
+    text = pending.get(rel, sites.read_text(rel))
+    lines = text.splitlines(keepends=True)
+
+    member = [
+        index
+        for index, line in enumerate(lines)
+        if line.rstrip("\n") == 'name = "motosan-ai"'
+        and index + 1 < len(lines)
+        and lines[index + 1].rstrip("\n") == f'version = "{old}"'
+    ]
+    if len(member) != 1:
+        raise BumpError(
+            f"{rel}: expected exactly 1 motosan-ai entry at version {old}, found {len(member)}"
+        )
+    lines[member[0] + 1] = f'version = "{new}"\n'
+    pending[rel] = "".join(lines)
+    log.append(f"  ✎ {rel}: motosan-ai {old} → {new}")
+
+
+def bump_npm_lock(old: str, new: str, pending: dict[str, str], log: list[str]) -> None:
+    if old == new:
+        return
+    rel = sites.NPM_LOCK
+    text = pending.get(rel, sites.read_text(rel))
+    lines = text.splitlines(keepends=True)
+
+    hits = [
+        index
+        for index, line in enumerate(lines)
+        if line.strip() in (f'"version": "{old}",', f'"version": "{old}"')
+    ]
+    if len(hits) != 2:
+        raise BumpError(f"{rel}: expected 2 version fields at {old}, found {len(hits)}")
+    for index in hits:
+        lines[index] = lines[index].replace(f'"{old}"', f'"{new}"', 1)
+    pending[rel] = "".join(lines)
+    log.append(f'  ✎ {rel}: {old} → {new} (root + packages[""])')
+
+
+def rewrite_banners(
+    versions: dict[str, str], pending: dict[str, str], log: list[str]
+) -> None:
+    for rel, template, anchor in sites.BANNERS:
+        expected = template.format(**versions)
+        text = pending.get(rel, sites.read_text(rel))
+        if expected in text.splitlines():
+            continue
+        pending[rel] = replace_unique_line(
+            text,
+            lambda line, anchor=anchor: anchor in line,
+            expected,
+            f"{rel} (anchor {anchor!r})",
+        )
+        log.append(f"  ✎ {rel}: {expected}")
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    date = args.date or dt.datetime.now(dt.UTC).strftime("%Y-%m-%d")
+
+    current = sites.read_versions()
+    target = dict(current)
+    for sdk in sites.SDKS:
+        if getattr(args, sdk):
+            target[sdk] = getattr(args, sdk)
+
+    pending: dict[str, str] = {}
+    log: list[str] = []
+
+    try:
+        for sdk in sites.SDKS:
+            if current[sdk] == target[sdk] and not getattr(args, sdk):
+                continue
+            log.append(f"{sites.SDK_LABELS[sdk]} {current[sdk]} → {target[sdk]}")
+            bump_manifest(sdk, current[sdk], target[sdk], pending, log)
+            open_changelog_section(sdk, target[sdk], date, pending, log)
+            if sdk == "python":
+                bump_uv_lock(current[sdk], target[sdk], pending, log)
+            elif sdk == "ts":
+                bump_npm_lock(current[sdk], target[sdk], pending, log)
+        log.append("Version banners")
+        rewrite_banners(target, pending, log)
+    except BumpError as error:
+        print(f"bump-version: {error}", file=sys.stderr)
+        return 1
+
+    for line in log:
+        print(line)
+
+    if not pending:
+        print("\nNothing to do — every location already matches.")
+        return 0
+
+    if args.dry_run:
+        print(f"\n--dry-run: {len(pending)} file(s) would be written, none were.")
+        return 0
+
+    for rel, text in pending.items():
+        sites.write_text(rel, text)
+    print(f"\nWrote {len(pending)} file(s).")
+
+    result = subprocess.run(
+        [sys.executable, str(sites.ROOT / "scripts" / "check-versions.py")],
+        check=False,
+    )
+    if result.returncode != 0:
+        return result.returncode
+
+    changed = ", ".join(
+        f"{sites.SDK_LABELS[sdk]} {target[sdk]}"
+        for sdk in sites.SDKS
+        if getattr(args, sdk)
+    )
+    print(
+        f"\nNext: write the root CHANGELOG.md entry for {changed}, add an AGENTS.md\n"
+        f"release paragraph, then open the release PR. Tags are pushed after it merges."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-versions.py
+++ b/scripts/check-versions.py
@@ -3,8 +3,8 @@
 
 Three manifests are the sources of truth:
 
-    sdks/rust/Cargo.toml        [package] version
-    sdks/python/pyproject.toml  [project] version
+    sdks/rust/Cargo.toml          [package] version
+    sdks/python/pyproject.toml    [project] version
     sdks/typescript/package.json  version
 
 Everything else that carries a version is derived and must agree: the two
@@ -17,18 +17,18 @@ It also forbids re-introducing version-pinned `motosan-ai` Cargo install
 snippets: docs teach `cargo add motosan-ai --features <feature>`, which
 resolves at run time and cannot go stale.
 
+The locations themselves live in `_release_sites.py`, shared with
+`bump-version.py`.
+
 Run: python3 scripts/check-versions.py   (stdlib only, needs Python >= 3.11)
 """
 
 from __future__ import annotations
 
-import json
 import re
 import sys
-import tomllib
-from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+import _release_sites as sites
 
 # Historical planning records legitimately quote the pinned snippets of past
 # releases; they document what was done, and must not be rewritten.
@@ -52,143 +52,86 @@ def fail(message: str) -> None:
     errors.append(message)
 
 
-def read_text(rel: str) -> str:
-    return (ROOT / rel).read_text(encoding="utf-8")
-
-
-def load_toml(rel: str) -> dict:
-    with (ROOT / rel).open("rb") as handle:
-        return tomllib.load(handle)
-
-
-def load_json(rel: str) -> dict:
-    return json.loads(read_text(rel))
-
-
-def manifest_versions() -> dict[str, str]:
-    rust = load_toml("sdks/rust/Cargo.toml")["package"]["version"]
-    python = load_toml("sdks/python/pyproject.toml")["project"]["version"]
-    ts = load_json("sdks/typescript/package.json")["version"]
-    return {"rust": rust, "python": python, "ts": ts}
-
-
 def check_lockfiles(v: dict[str, str]) -> None:
     """Both lockfiles record the workspace member's own version."""
-    uv_packages = [
-        pkg
-        for pkg in load_toml("uv.lock").get("package", [])
-        if pkg.get("name") == "motosan-ai" and "version" in pkg
-    ]
-    if len(uv_packages) != 1:
+    uv_version = sites.uv_lock_version()
+    if uv_version is None:
+        fail(f"{sites.UV_LOCK}: expected exactly one motosan-ai package entry")
+    elif uv_version != v["python"]:
         fail(
-            f"uv.lock: expected exactly one motosan-ai package entry, found {len(uv_packages)}"
-        )
-    elif uv_packages[0]["version"] != v["python"]:
-        fail(
-            f"uv.lock: motosan-ai is {uv_packages[0]['version']}, "
+            f"{sites.UV_LOCK}: motosan-ai is {uv_version}, "
             f"pyproject.toml is {v['python']} — run `uv sync --all-extras` in sdks/python/"
         )
 
-    lock = load_json("sdks/typescript/package-lock.json")
-    for label, found in (
-        ("top-level version", lock.get("version")),
-        ('packages[""].version', lock.get("packages", {}).get("", {}).get("version")),
-    ):
+    for label, found in sites.npm_lock_versions().items():
         if found != v["ts"]:
             fail(
-                f"sdks/typescript/package-lock.json: {label} is {found}, "
+                f"{sites.NPM_LOCK}: {label} is {found}, "
                 f"package.json is {v['ts']} — run `npm install` in sdks/typescript/"
             )
 
 
 def check_banners(v: dict[str, str]) -> None:
     """Each banner line is expected verbatim; the anchor locates near misses."""
-    expectations = [
-        (
-            "AGENTS.md",
-            f"Rust v{v['rust']} · Python v{v['python']} (PyPI) · TypeScript v{v['ts']} (npm)",
-            "(PyPI) · TypeScript v",
-        ),
-        (
-            "llms.txt",
-            f"- Python {v['python']} · TypeScript {v['ts']} · Rust {v['rust']}",
-            "- Python ",
-        ),
-        (
-            "skills/motosan-ai/SKILL.md",
-            f"Multi-provider LLM SDK — Python {v['python']} / Rust {v['rust']} / TypeScript {v['ts']}",
-            "Multi-provider LLM SDK — Python ",
-        ),
-        (
-            "README.md",
-            f"| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v{v['rust']} |",
-            "| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) |",
-        ),
-        (
-            "README.md",
-            f"| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v{v['python']} |",
-            "| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) |",
-        ),
-        (
-            "README.md",
-            f"| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) | v{v['ts']} |",
-            "| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) |",
-        ),
-    ]
+    for rel, template, anchor in sites.BANNERS:
+        expected = template.format(**v)
+        near = sites.anchor_matches(rel, anchor)
 
-    for rel, expected, anchor in expectations:
-        lines = read_text(rel).splitlines()
-        if expected in lines:
+        # An anchor that stops being unique silently weakens both this check
+        # and bump-version.py's rewrite, so treat it as a failure of its own.
+        if len(near) > 1:
+            fail(
+                f"{rel}: anchor {anchor!r} matches {len(near)} lines, expected 1 — "
+                f"choose a more specific anchor in scripts/_release_sites.py"
+            )
             continue
-        near = [line for line in lines if anchor in line]
+
+        if expected in sites.read_text(rel).splitlines():
+            continue
+
         if near:
             fail(
-                f"{rel}: version banner is stale\n    expected: {expected}\n    found:    {near[0]}"
+                f"{rel}: version banner is stale\n"
+                f"    expected: {expected}\n"
+                f"    found:    {near[0]}"
             )
         else:
             fail(
                 f"{rel}: version banner not found (was it reworded?)\n"
                 f"    expected: {expected}\n"
                 f"    no line contains the anchor {anchor!r} — "
-                f"update scripts/check-versions.py if the banner moved on purpose"
+                f"update scripts/_release_sites.py if the banner moved on purpose"
             )
 
 
 def check_changelogs(v: dict[str, str]) -> None:
     """The first released heading after [Unreleased] is the shipped version."""
     heading = re.compile(r"^## \[(?P<version>[^\]]+)\]")
-    for rel, key in (
-        ("sdks/rust/CHANGELOG.md", "rust"),
-        ("sdks/python/CHANGELOG.md", "python"),
-        ("sdks/typescript/CHANGELOG.md", "ts"),
-    ):
+    for sdk, rel in sites.CHANGELOGS.items():
         versions = [
             match.group("version")
-            for line in read_text(rel).splitlines()
+            for line in sites.read_text(rel).splitlines()
             if (match := heading.match(line)) and match.group("version") != "Unreleased"
         ]
         if not versions:
             fail(f"{rel}: no released version heading found")
-        elif versions[0] != v[key]:
+        elif versions[0] != v[sdk]:
             fail(
                 f"{rel}: first released heading is [{versions[0]}], "
-                f"manifest is {v[key]} — the release entry was not renamed from [Unreleased]"
+                f"manifest is {v[sdk]} — the release entry was not renamed from [Unreleased]"
             )
 
 
 def check_no_pinned_snippets() -> None:
     """Docs must teach `cargo add`, never a snippet that pins the version."""
-    for path in sorted(ROOT.rglob("*")):
+    for path in sorted(sites.ROOT.rglob("*")):
         if path.suffix not in SNIPPET_SCAN_SUFFIXES or not path.is_file():
             continue
-        rel = path.relative_to(ROOT).as_posix()
-        if any(
+        parts = path.relative_to(sites.ROOT).parts
+        rel = path.relative_to(sites.ROOT).as_posix()
+        if any(part in SNIPPET_SCAN_EXCLUDED_DIRS for part in parts) or any(
             rel == excluded or rel.startswith(f"{excluded}/")
             for excluded in SNIPPET_SCAN_EXCLUDED_DIRS
-        ):
-            continue
-        if any(
-            part in SNIPPET_SCAN_EXCLUDED_DIRS for part in path.relative_to(ROOT).parts
         ):
             continue
         for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
@@ -202,7 +145,7 @@ def check_no_pinned_snippets() -> None:
 
 
 def main() -> int:
-    versions = manifest_versions()
+    versions = sites.read_versions()
     check_lockfiles(versions)
     check_banners(versions)
     check_changelogs(versions)


### PR DESCRIPTION
Closes #258. Item 3 of the release-process work, after #255 cut the version-coupled locations from 15 to 8 and #257 made the remainder machine-checked.

`scripts/bump-version.py` performs the mechanical half of a release:

```bash
python3 scripts/bump-version.py --rust 0.28.0 --python 0.20.0   # --dry-run to preview
```

- **Multiple SDKs per run** — they share the doc banners, so bumping them separately would rewrite the same lines twice.
- **CHANGELOG** — opens `## [X.Y.Z] - <date>` by renaming whatever sits under `[Unreleased]`, producing exactly the shape the 0.27.0 release was written by hand. It **refuses** to release an SDK whose `[Unreleased]` is empty, which is almost always a forgotten changelog rather than an intentional silent release.
- **Lockfiles** — uv.lock's workspace-member entry and both fields in package-lock.json. A version-only bump changes precisely those lines, which is all `uv lock` / `npm install` would do, so the edit is deterministic and offline.
- **Banners** — rewritten from the resulting version set; lines already correct are skipped.
- **Proof** — after writing it runs `check-versions.py`, so the bump cannot leave the tree in a state CI would reject.
- **Idempotent** — re-running the same command reports `already at …` and writes nothing; no duplicate CHANGELOG heading.
- **UTC dates** by default (`--date` to override), so the CHANGELOG does not depend on the releaser's timezone.

It deliberately does not write the root CHANGELOG entry or the AGENTS.md release paragraph — that is prose, and the summary prints a reminder naming both.

The location registry moves to `scripts/_release_sites.py`, shared by the checker and the bumper so the two can never disagree about where a version lives. Extracting it surfaced a real weakness: llms.txt's banner anchor `- Python ` matched three lines (the banner plus two release-history bullets). It is now `· Rust ` (unique), and the checker gained an explicit anchor-uniqueness check so this class of drift fails loudly instead of silently weakening both tools.

Also: `__pycache__/` is gitignored now that scripts/ holds an importable module, and `llms.txt § Release` points at the script so the next release does not follow the hand-edit steps.

Verified end to end: dry-run wrote nothing while listing all 9 files; the real run produced the expected CHANGELOG shape and a green checker; an immediate re-run was a clean no-op with no duplicate headings; a TypeScript bump updated both package-lock fields and defaulted to today's UTC date; the empty-`[Unreleased]` guard refused; and argument validation rejects a missing SDK, a malformed version, and a malformed date. Every mutation was reverted before commit. Gates: treefmt --fail-on-change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)