### PR TITLE
feat: publish through Trusted Publishing instead of stored registry tokens

### DIFF
--- a/.github/workflows/publish-anthropic-oauth.yml
+++ b/.github/workflows/publish-anthropic-oauth.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Trusted Publishing: crates.io mints a short-lived token from this
+    # workflow's OIDC identity, so no long-lived registry secret exists.
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: sdks/rust/crates/anthropic-oauth
@@ -23,7 +28,9 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish

--- a/.github/workflows/publish-codex-oauth.yml
+++ b/.github/workflows/publish-codex-oauth.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Trusted Publishing: crates.io mints a short-lived token from this
+    # workflow's OIDC identity, so no long-lived registry secret exists.
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: sdks/rust/crates/codex-oauth
@@ -23,7 +28,9 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish

--- a/.github/workflows/publish-motosan-ai-oauth.yml
+++ b/.github/workflows/publish-motosan-ai-oauth.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Trusted Publishing: crates.io mints a short-lived token from this
+    # workflow's OIDC identity, so no long-lived registry secret exists.
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: sdks/rust/crates/motosan-ai-oauth
@@ -23,7 +28,9 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Trusted Publishing: PyPI authenticates this workflow's OIDC identity,
+    # so no API token is stored or passed.
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: sdks/python
@@ -37,4 +42,3 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: sdks/python/dist/
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -13,6 +13,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Trusted Publishing: crates.io mints a short-lived token from this
+    # workflow's OIDC identity, so no long-lived registry secret exists.
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: sdks/rust
@@ -65,9 +70,11 @@ jobs:
       - run: cargo clippy --locked --all-features --all-targets -- -D warnings
       - run: cargo test --locked --all-features
       - run: cargo test --locked --doc --all-features
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
@@ -126,7 +133,7 @@ jobs:
           fi
 
           if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
-            echo "::error::CARGO_REGISTRY_TOKEN secret is required to publish ${crate_name} ${VERSION}"
+            echo "::error::crates-io-auth-action produced no token; cannot publish ${crate_name} ${VERSION}"
             exit 1
           fi
 

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -11,17 +11,28 @@ jobs:
     defaults:
       run:
         working-directory: sdks/typescript
+    # Trusted Publishing: npm authenticates this workflow's OIDC identity, so
+    # no NPM_TOKEN is stored or passed, and provenance is attached by default.
     permissions:
       contents: read
-      id-token: write # required for npm provenance
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # Trusted publishing needs Node >= 22.14 AND npm >= 11.5.1. Node 24
+          # satisfies the former; its bundled npm does not always satisfy the
+          # latter, so npm is upgraded and asserted explicitly below.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
           cache-dependency-path: sdks/typescript/package-lock.json
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@11
+          npm --version | awk -F. '{ if ($1 < 11 || ($1 == 11 && ($2 < 5 || ($2 == 5 && $3 < 1)))) {
+            print "::error::npm " $0 " is older than the 11.5.1 required for trusted publishing"; exit 1 } }'
+          echo "node $(node --version) / npm $(npm --version)"
       - run: npm ci
       - run: npm run build
       - run: npm run test
@@ -34,6 +45,4 @@ jobs:
           TAG="${GITHUB_REF_NAME#ts-v}"
           PKG=$(node -p "require('./package.json').version")
           test "$TAG" = "$PKG" || { echo "tag $TAG != package.json $PKG"; exit 1; }
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public

--- a/llms.txt
+++ b/llms.txt
@@ -1127,12 +1127,12 @@ git push origin main anthropic-oauth-v0.1.1
 ### CI Pipeline
 
 Tag push triggers GitHub Actions:
-- **publish-python.yml**: `uv build` → `pypa/gh-action-pypi-publish` (secret: `PYPI_API_TOKEN`)
-- **publish-rust.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test --all-features` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
-- **publish-typescript.yml**: `npm ci` → `npm run build` → `npm run test` → version-matches-tag guard → `npm publish --provenance --access public` (secret: `NPM_TOKEN`)
-- **publish-motosan-ai-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
-- **publish-codex-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
-- **publish-anthropic-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `cargo publish` (secret: `CARGO_REGISTRY_TOKEN`)
+- **publish-python.yml**: tag-vs-pyproject guard → sync/lint/format/test → `uv build` → `pypa/gh-action-pypi-publish` (Trusted Publishing, no token)
+- **publish-rust.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test --all-features` → `crates-io-auth-action` → `cargo publish` + checksum verify (Trusted Publishing, no token)
+- **publish-typescript.yml**: `npm ci` → `npm run build` → `npm run test` → version-matches-tag guard → `npm publish --access public` (Trusted Publishing, no token; needs npm >= 11.5.1, provenance is automatic)
+- **publish-motosan-ai-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `crates-io-auth-action` → `cargo publish` (Trusted Publishing, no token)
+- **publish-codex-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `crates-io-auth-action` → `cargo publish` (Trusted Publishing, no token)
+- **publish-anthropic-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `crates-io-auth-action` → `cargo publish` (Trusted Publishing, no token)
 
 All Rust workflows support `workflow_dispatch` for manual trigger.
 

--- a/skills/motosan-ai/references/release.md
+++ b/skills/motosan-ai/references/release.md
@@ -73,7 +73,7 @@ Steps:
 1. Checkout
 2. Setup uv
 3. uv build --out-dir dist
-4. pypa/gh-action-pypi-publish (secret: PYPI_API_TOKEN)
+4. pypa/gh-action-pypi-publish (Trusted Publishing via OIDC — no token)
 ```
 
 ### publish-rust.yml
@@ -87,22 +87,25 @@ Steps:
 3. cargo fmt --all -- --check
 4. cargo clippy --all-features --all-targets -- -D warnings
 5. cargo test --all-features
-6. cargo publish (secret: CARGO_REGISTRY_TOKEN)
+6. rust-lang/crates-io-auth-action → cargo publish (Trusted Publishing via OIDC — no token)
 ```
 
 Key: Rust workflow runs full validation (fmt + clippy + test) before publish.
 
 ## Pre-Push Local Validation
 
-```bash
-./scripts/pre-push-gate.sh
-```
+The hook is installed by `./scripts/setup-hooks.sh` and runs
+`scripts/pre-push-gate.sh`, which is **path-scoped**: it reads the pushed range
+and runs only the suites whose SDK was touched, so a docs-only push skips them.
 
-Runs 4 steps:
-1. Python unit tests (`uv run pytest`)
-2. Rust unit tests (`cargo test --all-features`)
-3. Python live integration tests (requires `ANTHROPIC_API_KEY`, skipped if unavailable)
-4. Rust live integration tests (requires `ANTHROPIC_API_KEY`, skipped if unavailable)
+1. Version metadata (`scripts/check-versions.py`) — always
+2. Python unit tests — when `sdks/python/**`, `pyproject.toml`, or `uv.lock` changed
+3. Rust unit tests — when `sdks/rust/**` or the workspace `Cargo.toml` changed
+4. TypeScript build + tests — when `sdks/typescript/**` changed
+
+Live provider tests never run in CI and are opt-in locally: `RUN_LIVE=1 git push`.
+Unit runs have provider credentials stripped from the environment, so the
+env-gated live tests inside those suites cannot fire.
 
 ## Emergency Manual Publish
 
@@ -114,12 +117,20 @@ cd sdks/python && uv build --out-dir dist && uv publish dist/*
 cd sdks/rust && cargo publish
 ```
 
-## GitHub Secrets
+## Registry Authentication
 
-| Secret                | Used by              | Purpose                |
-|-----------------------|----------------------|------------------------|
-| `PYPI_API_TOKEN`      | publish-python.yml   | Authenticate to PyPI   |
-| `CARGO_REGISTRY_TOKEN`| publish-rust.yml     | Authenticate to crates.io |
+All six publish workflows use **Trusted Publishing (OIDC)** — no registry
+secrets are stored. Each job declares `permissions: id-token: write` and the
+registry verifies the workflow's GitHub identity:
+
+| Registry  | Mechanism                                                      |
+|-----------|----------------------------------------------------------------|
+| crates.io | `rust-lang/crates-io-auth-action@v1` mints a short-lived token  |
+| PyPI      | `pypa/gh-action-pypi-publish` with no `password:`               |
+| npm       | `npm publish` with npm >= 11.5.1 (provenance attached by default) |
+
+Each registry must have a trusted publisher registered for the specific
+repository *and* workflow file, otherwise publishing fails with an auth error.
 
 ## CI Workflows (non-release)
 


### PR DESCRIPTION
Closes #260. Item 4 of the release-process work.

⚠️ **Requires registry-side setup before the next release.** These workflows only run on tag pushes, so nothing breaks on merge — but the next `rust-v*` / `python-v*` / `ts-v*` tag will fail to publish until a trusted publisher is registered for this repository **and the specific workflow filename** on each registry:

| Registry | Where | Workflow files to register |
|---|---|---|
| crates.io | crate Settings → Trusted Publishing | publish-rust.yml, publish-motosan-ai-oauth.yml, publish-codex-oauth.yml, publish-anthropic-oauth.yml |
| PyPI | project → Publishing | publish-python.yml |
| npm | package → Settings → Trusted Publisher | publish-typescript.yml |

Keep the three existing secrets until the first OIDC publish succeeds, then delete them.

**Why.** The M1 release failed at `cargo publish` because `CARGO_REGISTRY_TOKEN` had gone stale in repo settings while the local token was fine. A credential that can rot is a credential that will rot at the worst moment; OIDC mints a short-lived token per run and leaves nothing to expire.

**What changed** (six workflows — four crates.io, one PyPI, one npm):

- crates.io ×4 — `permissions: id-token: write` plus `rust-lang/crates-io-auth-action@v1`, whose output feeds `CARGO_REGISTRY_TOKEN`. publish-rust.yml keeps its idempotent checksum-verifying publish logic untouched; only the token source changed, and the "no token" error message now names the auth action rather than a secret.
- PyPI — the `password:` input is dropped so `pypa/gh-action-pypi-publish` uses OIDC, per PyPI's documented requirement that credentials be omitted entirely.
- npm — trusted publishing needs Node >= 22.14 **and npm >= 11.5.1**, and those are not the same requirement: Node 22.14 bundles npm 10.9. The job moves to Node 24, upgrades npm explicitly, and asserts the version (boundary-tested: 10.9.4 and 11.5.0 rejected, 11.5.1 accepted). `NODE_AUTH_TOKEN` is gone and `--provenance` is dropped because trusted publishing attaches provenance by default.

**Docs.** llms.txt's workflow list and skills/motosan-ai/references/release.md no longer describe secrets that will not exist. While in release.md I also corrected its pre-push description, which my #243 made stale — it still claimed four unconditional steps including live tests, rather than the path-scoped, credential-stripped, live-opt-in gate that actually ships. That file has further pre-existing drift (it predates the TypeScript SDK, the oauth crates, and scripts/bump-version.py, and still shows `chore: release` commits that conflict with the current commit-type rule); that belongs to the docs item, which also has to resolve the `chore(release):` question.

Verification: actionlint clean across all workflow files; no `secrets.*_TOKEN` reference remains in any publish workflow; no live doc mentions the retired secrets; treefmt --fail-on-change and check-versions.py green. The mechanics follow the three vendor docs (crates.io 2025-07 development update, PyPI trusted-publishers, npm trusted-publishers) rather than recollection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)