### PR TITLE
feat: verify PyPI and npm serve the artifacts each release built

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -20,15 +20,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - name: Verify tag matches pyproject.toml version
+        id: release
         run: |
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
-            version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
             expected_tag="python-v${version}"
             if [ "${GITHUB_REF_NAME:-}" != "$expected_tag" ]; then
               echo "::error::Tag ${GITHUB_REF_NAME:-<none>} does not match pyproject.toml version ${expected_tag}"
               exit 1
             fi
           fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Sync deps
         run: uv sync --all-extras
       - name: Lint
@@ -39,6 +41,35 @@ jobs:
         run: uv run pytest tests/ -q --ignore=tests/integration/
       - name: Build
         run: uv build --out-dir dist
+      # Publishing is gated on what PyPI already serves, so a re-run of a
+      # partially-failed release is safe: it either finds its own artifacts
+      # and skips, or finds nothing and uploads.
+      - name: Is this version already on PyPI?
+        id: precheck
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2046  # each digest is a separate argument
+          python3 "$GITHUB_WORKSPACE/scripts/verify-published.py" \
+            --registry pypi --package motosan-ai --version "$VERSION" \
+            $(for file in dist/*; do
+                printf -- '--digest %s=%s ' "$(basename "$file")" "$(sha256sum "$file" | cut -d' ' -f1)"
+              done) \
+            --mode precheck
       - uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.precheck.outputs.published != 'true'
         with:
           packages-dir: sdks/python/dist/
+      - name: Verify PyPI serves the artifacts this run built
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2046  # each digest is a separate argument
+          python3 "$GITHUB_WORKSPACE/scripts/verify-published.py" \
+            --registry pypi --package motosan-ai --version "$VERSION" \
+            $(for file in dist/*; do
+                printf -- '--digest %s=%s ' "$(basename "$file")" "$(sha256sum "$file" | cut -d' ' -f1)"
+              done) \
+            --mode verify

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -37,12 +37,49 @@ jobs:
       - run: npm run build
       - run: npm run test
       - name: Verify tag matches package.json version
+        id: release
         run: |
+          PKG=$(node -p "require('./package.json').version")
           if [ "${GITHUB_REF_TYPE:-}" != "tag" ]; then
             echo "::notice::Not a tag ref (workflow_dispatch) — skipping tag check; publishing package.json version as-is"
-            exit 0
+          else
+            TAG="${GITHUB_REF_NAME#ts-v}"
+            test "$TAG" = "$PKG" || { echo "tag $TAG != package.json $PKG"; exit 1; }
           fi
-          TAG="${GITHUB_REF_NAME#ts-v}"
-          PKG=$(node -p "require('./package.json').version")
-          test "$TAG" = "$PKG" || { echo "tag $TAG != package.json $PKG"; exit 1; }
-      - run: npm publish --access public
+          echo "version=$PKG" >> "$GITHUB_OUTPUT"
+      # Pack once, then publish *that* tarball, so the bytes npm serves are the
+      # bytes whose integrity we recorded. Letting `npm publish` re-pack would
+      # make the comparison a guess: packing is not byte-reproducible across
+      # npm versions (verified — a fresh pack of the ts-v0.15.0 tree does not
+      # reproduce the integrity npm 10 published for 0.15.0). Packing to a
+      # directory outside the package also keeps the tarball out of itself.
+      - name: Pack the tarball to publish
+        id: pack
+        run: |
+          set -euo pipefail
+          output=$(npm pack --json --pack-destination "$RUNNER_TEMP")
+          integrity=$(node -p "JSON.parse(process.argv[1])[0].integrity" "$output")
+          filename=$(node -p "JSON.parse(process.argv[1])[0].filename" "$output")
+          echo "integrity=$integrity" >> "$GITHUB_OUTPUT"
+          echo "tarball=$RUNNER_TEMP/$filename" >> "$GITHUB_OUTPUT"
+          echo "Packed $filename with integrity $integrity"
+      # Publishing is gated on what npm already serves, so a re-run of a
+      # partially-failed release is safe: it either finds its own tarball and
+      # skips, or finds nothing and uploads.
+      - name: Is this version already on npm?
+        id: precheck
+        run: |
+          python3 "$GITHUB_WORKSPACE/scripts/verify-published.py" \
+            --registry npm --package @motosan-ai/sdk \
+            --version "${{ steps.release.outputs.version }}" \
+            --digest "integrity=${{ steps.pack.outputs.integrity }}" \
+            --mode precheck
+      - run: npm publish "${{ steps.pack.outputs.tarball }}" --access public
+        if: steps.precheck.outputs.published != 'true'
+      - name: Verify npm serves the tarball this run built
+        run: |
+          python3 "$GITHUB_WORKSPACE/scripts/verify-published.py" \
+            --registry npm --package @motosan-ai/sdk \
+            --version "${{ steps.release.outputs.version }}" \
+            --digest "integrity=${{ steps.pack.outputs.integrity }}" \
+            --mode verify

--- a/scripts/verify-published.py
+++ b/scripts/verify-published.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Compare what a registry serves against the artifact this run built.
+
+`publish-rust.yml` already refuses to call a release done until crates.io
+serves the exact SHA-256 it packaged. This gives PyPI and npm the same
+guarantee, because "the version appeared" is a much weaker claim than "the
+bytes people will download are the bytes we built".
+
+Two modes, mirroring the Rust workflow's shape:
+
+  --mode precheck   Is this version already published?
+                    Matching digests  -> published=true  (publish is skipped)
+                    Absent            -> published=false (publish proceeds)
+                    Different digests -> failure; something else owns that
+                                         version and republishing would lie
+  --mode verify     Poll until the version is served, then compare digests.
+
+Both modes fail on a digest mismatch, which makes the publish step safe to
+re-run: a retried job either finds its own artifact and skips, or finds
+nothing and uploads.
+
+    python3 scripts/verify-published.py --registry pypi \\
+        --package motosan-ai --version 0.19.0 \\
+        --digest motosan_ai-0.19.0-py3-none-any.whl=<sha256> --mode precheck
+
+    python3 scripts/verify-published.py --registry npm \\
+        --package @motosan-ai/sdk --version 0.15.0 \\
+        --digest integrity=sha512-... --mode verify
+
+Digests are supplied by the caller rather than computed here, so the script
+needs no build tooling and can be exercised against the live registries.
+PyPI digests are per-file SHA-256 (`sha256sum dist/*`); npm's is the
+subresource integrity string that `npm pack --json` reports for the tarball
+it would upload.
+
+Needs Python >= 3.11; stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+USER_AGENT = "motosan-ai publish workflow"
+POLL_ATTEMPTS = 30
+POLL_INTERVAL_SECONDS = 10
+
+
+class NotPublished(Exception):
+    """The registry does not serve this version (yet)."""
+
+
+class DigestMismatch(Exception):
+    """The registry serves this version with different bytes."""
+
+
+def fetch_json(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            raise NotPublished(url) from None
+        raise
+
+
+def pypi_digests(package: str, version: str) -> dict[str, str]:
+    """Per-file SHA-256, keyed by filename."""
+    payload = fetch_json(f"https://pypi.org/pypi/{package}/{version}/json")
+    return {entry["filename"]: entry["digests"]["sha256"] for entry in payload["urls"]}
+
+
+def npm_digests(package: str, version: str) -> dict[str, str]:
+    """The tarball's subresource integrity, under the key `integrity`."""
+    payload = fetch_json(
+        f"https://registry.npmjs.org/{urllib.parse.quote(package, safe='')}"
+    )
+    release = payload.get("versions", {}).get(version)
+    if release is None:
+        raise NotPublished(f"{package}@{version}")
+    return {"integrity": release["dist"]["integrity"]}
+
+
+REGISTRIES = {"pypi": pypi_digests, "npm": npm_digests}
+
+
+def compare(expected: dict[str, str], served: dict[str, str]) -> None:
+    problems = []
+    for name, digest in expected.items():
+        actual = served.get(name)
+        if actual is None:
+            problems.append(f"    {name}: absent from the registry")
+        elif actual != digest:
+            problems.append(
+                f"    {name}:\n      built    {digest}\n      registry {actual}"
+            )
+    if problems:
+        raise DigestMismatch("\n".join(problems))
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="verify-published.py")
+    parser.add_argument("--registry", required=True, choices=sorted(REGISTRIES))
+    parser.add_argument("--package", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument(
+        "--digest",
+        required=True,
+        action="append",
+        metavar="NAME=DIGEST",
+        help="repeatable; NAME is a filename (pypi) or the literal `integrity` (npm)",
+    )
+    parser.add_argument("--mode", required=True, choices=("precheck", "verify"))
+    args = parser.parse_args(argv)
+
+    expected = {}
+    for item in args.digest:
+        name, separator, digest = item.partition("=")
+        if not separator or not name or not digest:
+            parser.error(f"--digest {item!r} is not NAME=DIGEST")
+        expected[name] = digest
+    args.expected = expected
+    return args
+
+
+def emit_output(published: bool) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"published={'true' if published else 'false'}\n")
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    lookup = REGISTRIES[args.registry]
+    label = f"{args.package} {args.version}"
+
+    if args.mode == "precheck":
+        try:
+            served = lookup(args.package, args.version)
+        except NotPublished:
+            print(f"{label} is not on {args.registry} yet — publishing.")
+            emit_output(False)
+            return 0
+        try:
+            compare(args.expected, served)
+        except DigestMismatch as mismatch:
+            print(
+                f"::error::{label} is already on {args.registry} with different "
+                f"artifacts:\n{mismatch}",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"{label} is already on {args.registry} with matching digests — skipping publish."
+        )
+        emit_output(True)
+        return 0
+
+    for attempt in range(1, POLL_ATTEMPTS + 1):
+        try:
+            served = lookup(args.package, args.version)
+        except NotPublished:
+            print(f"Waiting for {label} on {args.registry} ({attempt}/{POLL_ATTEMPTS})")
+            time.sleep(POLL_INTERVAL_SECONDS)
+            continue
+        try:
+            compare(args.expected, served)
+        except DigestMismatch as mismatch:
+            print(
+                f"::error::{label} on {args.registry} does not match what this run "
+                f"built:\n{mismatch}",
+                file=sys.stderr,
+            )
+            return 1
+        for name, digest in sorted(args.expected.items()):
+            print(f"  ✓ {name} {digest}")
+        print(f"Verified {label} on {args.registry}.")
+        return 0
+
+    print(
+        f"::error::{label} did not become visible on {args.registry} after "
+        f"{POLL_ATTEMPTS * POLL_INTERVAL_SECONDS}s",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/motosan-ai/references/release.md
+++ b/skills/motosan-ai/references/release.md
@@ -129,6 +129,21 @@ registry verifies the workflow's GitHub identity:
 | PyPI      | `pypa/gh-action-pypi-publish` with no `password:`               |
 | npm       | `npm publish` with npm >= 11.5.1 (provenance attached by default) |
 
+## Publish Verification
+
+crates.io, PyPI, and npm publishes are all gated on what the registry actually
+serves, via `scripts/verify-published.py`: before publishing, a matching
+version already on the registry short-circuits the upload, and a *differing*
+one fails the run; after publishing, the workflow polls until the registry
+serves the artifact and compares digests. Re-running a half-finished release
+is therefore safe.
+
+The comparison is by construction rather than by reproducible build: PyPI
+receives the exact `dist/*` files that were hashed, and npm receives the exact
+tarball `npm pack` produced and reported an integrity for. (`npm pack` is *not*
+byte-reproducible across npm versions, so re-packing at verification time would
+compare two different tarballs.)
+
 Each registry must have a trusted publisher registered for the specific
 repository *and* workflow file, otherwise publishing fails with an auth error.
 


### PR DESCRIPTION
Closes #262. Item 5 of the release-process work.

publish-rust.yml already refuses to call a release done until crates.io serves the exact SHA-256 it packaged. PyPI and npm had no post-publish verification at all — a green workflow only meant "the upload step exited 0".

`scripts/verify-published.py` gives both the Rust shape, in two phases:

- **precheck** — the version is already served with matching digests → skip the publish step; served with *different* digests → fail, because something else owns that version and republishing would be a lie; absent → publish.
- **verify** — poll until the registry serves it, then compare digests.

Together these make a half-finished release safe to re-run: the retry either finds its own artifact and skips, or finds nothing and uploads.

**The comparison is by construction, not by reproducible build** — this is the part that needed care. PyPI receives the exact `dist/*` files that were hashed, so its stored SHA-256 must equal ours. npm is different: `npm publish` re-packs the directory, so hashing a local pack and hoping it matches the upload would be a guess. I tested that guess and it fails — a fresh `npm pack` of the **ts-v0.15.0 tree** does not reproduce the integrity npm 10 published for 0.15.0, so a naive integrity check would have failed every TypeScript release. The workflow therefore packs once to `$RUNNER_TEMP` and publishes *that tarball* (`npm publish <tarball>`), which is the same by-construction guarantee PyPI gets; packing outside the package directory also keeps the tarball from being packed into itself. Confirmed that npm's reported integrity is exactly the sha512 of the file it wrote.

The script takes digests as arguments rather than computing them, so it needs no build tooling and can be run against the live registries. All six paths were exercised that way: PyPI matching digests → skip; PyPI wrong digest → failure naming both values; PyPI absent version → proceed; npm matching integrity → verified; npm wrong integrity → failure; and `GITHUB_OUTPUT` receives `published=true`.

Also documents the verification and the packing caveat in skills/motosan-ai/references/release.md. Gates: actionlint (which shellchecks the `run:` blocks) clean across all workflows, treefmt --fail-on-change, check-versions.py.

Note: like #261, the npm and PyPI paths cannot be fully exercised until the next real release — worth watching the first one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)