### PR TITLE
fix: correct the release process documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,22 @@ These rules exist because motosan-chat and other downstream consumers depend on 
 
 **CLI provider capabilities (Rust 0.20+)** — `ClaudeCodeProvider` / `CodexCliProvider` / `GeminiCliProvider` share, beyond their per-CLI flags: `.cwd(dir)` (`Command::current_dir`; Codex uses `.cd()` → `--cd`); `.env(k,v)` / `.envs(iter)` per-run env injection (redacted from `Debug` via `RedactedEnvs` — never log env values); `.timeout(dur)` / `.no_timeout()`; `.resume(id)` session continuity (Codex `exec resume`, Gemini/Claude `--resume`) with the minted id surfaced on `StreamEvent::session_id` / `ChatResponse::session_id`. `stream()` surfaces CLI tool use as `ToolCallStart → ToolCallArgs → ToolCallEnd`; blocking `chat().tool_calls` stays empty.
 
+## Commits
+
+Subjects use a bare conventional type — `fix:`, `feat:`, or `refactor:`, with no scope parentheses — and end with the issue reference the work is bound to:
+
+```
+fix: ThinkStripper UTF-8 boundary panic and zero-copy fast path (#242)
+```
+
+Breaking changes carry a `BREAKING CHANGE:` body paragraph rather than a `!` marker. The single exception to the type list is `chore(release):`, used for release commits: a release ships no change of its own, so labelling it a feature or a fix would be inaccurate.
+
+Every change lands through a PR — only docs, specs, and planning notes may go directly to `main`.
+
 ## Releasing
 
-Tag `rust-vX.Y.Z` triggers `publish-rust.yml` → crates.io. Tag `python-vX.Y.Z` triggers `publish-python.yml` → PyPI. Tag `ts-vX.Y.Z` triggers `publish-typescript.yml` → npm. OAuth helper crates use per-crate tags (`motosan-ai-oauth-vX.Y.Z`, `codex-oauth-vX.Y.Z`, `anthropic-oauth-vX.Y.Z`). Publish `motosan-ai-oauth` before wrapper crates that depend on its new version.
+Bump with `python3 scripts/bump-version.py --rust X.Y.Z --python A.B.C` (see `llms.txt` § Release). It writes the manifests, both lockfiles, the CHANGELOG headings, and the doc version banners; `ci-metadata` and the pre-push hook reject a tree where any of them disagree, so do not hand-edit them. What stays manual: the root `CHANGELOG.md` entry, the release paragraph in this file, and the OAuth helper crates.
 
-Update before tagging: CHANGELOGs, version in `Cargo.toml`/`pyproject.toml`, `AGENTS.md`, `llms.txt`, `skills/motosan-ai/SKILL.md`.
+After the release PR merges, tag the merge commit. Tag `rust-vX.Y.Z` triggers `publish-rust.yml` → crates.io. Tag `python-vX.Y.Z` triggers `publish-python.yml` → PyPI. Tag `ts-vX.Y.Z` triggers `publish-typescript.yml` → npm. OAuth helper crates use per-crate tags (`motosan-ai-oauth-vX.Y.Z`, `codex-oauth-vX.Y.Z`, `anthropic-oauth-vX.Y.Z`). Publish `motosan-ai-oauth` before wrapper crates that depend on its new version.
+
+Every publish workflow authenticates with Trusted Publishing (OIDC) — no registry secrets — and verifies that the registry serves the exact artifact it built, which also makes a re-run of a half-finished release safe.

--- a/llms.txt
+++ b/llms.txt
@@ -996,165 +996,91 @@ The per-SDK steps below describe what the script automates.
 | codex-oauth      | `codex-oauth-vX.Y.Z`      |
 | anthropic-oauth  | `anthropic-oauth-vX.Y.Z`  |
 
-### Release Steps (Python)
+### Releasing an SDK
+
+The three SDK versions move independently, but the mechanical edits are shared,
+so one script covers all of them:
 
 ```bash
-# 1. Bump version
-#    sdks/python/pyproject.toml → version = "X.Y.Z"
+# 1. Bump — manifests, lockfiles, CHANGELOG headings, doc version banners.
+#    Several SDKs in one run; --dry-run previews; re-running is a no-op.
+python3 scripts/bump-version.py --rust 0.28.0 --python 0.20.0
 
-# 2. Update CHANGELOG
-#    sdks/python/CHANGELOG.md → ## [X.Y.Z] - YYYY-MM-DD
+# 2. Write the prose the script cannot: the root CHANGELOG.md entry and the
+#    AGENTS.md release paragraph.
 
-# 3. Update version references in:
-#    - README.md (root) — Languages table, provider table
-#    - AGENTS.md — "Current versions" section, Releasing table
-#    - llms.txt — header version line, Install section
-#    - skills/motosan-ai/SKILL.md — header version, Install section
+# 3. Commit and open a PR — releases go through review like any other change.
+git add -A
+git commit -m "chore(release): rust-v0.28.0 and python-v0.20.0 (#<issue>)"
+gh pr create --title "chore(release): rust-v0.28.0 and python-v0.20.0"
 
-# 4. Commit
-git add sdks/python/pyproject.toml sdks/python/CHANGELOG.md README.md AGENTS.md llms.txt skills/motosan-ai/SKILL.md
-git commit -m "chore: release python-vX.Y.Z"
-
-# 5. Tag + push (triggers publish-python.yml → PyPI)
-git tag -a python-vX.Y.Z -m "python-vX.Y.Z — summary"
-git push origin main python-vX.Y.Z
+# 4. After the PR merges, tag the MERGE COMMIT on main and push the tags.
+#    Create them from a checkout of origin/main, not a stale branch.
+git tag -a rust-v0.28.0 -m "rust-v0.28.0 — summary"
+git tag -a python-v0.20.0 -m "python-v0.20.0 — summary"
+git push origin rust-v0.28.0 python-v0.20.0
 ```
 
-### Release Steps (Rust)
+`chore(release):` is the one place the `fix:` / `feat:` / `refactor:` commit-type
+rule does not apply — a release ships no new change of its own, so dressing it
+as a feature or fix would be inaccurate.
+
+Each tag push runs that SDK's publish workflow, which re-verifies the tag
+against the manifest, runs the SDK's gates, publishes via Trusted Publishing,
+and then confirms the registry serves the exact artifact it built. Nothing here
+requires a registry secret, and a re-run of a half-finished release is safe.
+
+### Releasing an OAuth Helper Crate
+
+The helper crates are not covered by `bump-version.py` — bump them by hand:
 
 ```bash
-# 1. Bump version
-#    sdks/rust/Cargo.toml → version = "0.4.1"
-
-# 2. Update CHANGELOG
-#    sdks/rust/CHANGELOG.md → ## [0.4.1] - YYYY-MM-DD
-
-# 3. Update version references in:
-#    - README.md (root) — Languages table, provider table
-#    - AGENTS.md — "Current versions" section, Releasing table
-#    - llms.txt — header version line, Install section
-#    - skills/motosan-ai/SKILL.md — header version, Install section
-
-# 4. Commit
-git add sdks/rust/Cargo.toml sdks/rust/CHANGELOG.md README.md AGENTS.md llms.txt skills/motosan-ai/SKILL.md
-git commit -m "chore: release rust-v0.4.1"
-
-# 5. Tag + push (triggers publish-rust.yml → crates.io)
-git tag -a rust-v0.4.1 -m "rust-v0.4.1 — summary"
-git push origin main rust-v0.4.1
+# 1. sdks/rust/crates/<crate>/Cargo.toml → version = "X.Y.Z"
+# 2. sdks/rust/crates/<crate>/CHANGELOG.md → ## [X.Y.Z] - YYYY-MM-DD
+# 3. Commit, PR, merge as above with a chore(release): subject.
+# 4. Tag the merge commit:
+git tag -a codex-oauth-vX.Y.Z -m "codex-oauth-vX.Y.Z — summary"
+git push origin codex-oauth-vX.Y.Z
 ```
 
-### Release Steps (TypeScript)
-
-```bash
-# 1. Bump version
-#    sdks/typescript/package.json → "version": "X.Y.Z"
-
-# 2. Update CHANGELOG
-#    sdks/typescript/CHANGELOG.md → ## [X.Y.Z] - YYYY-MM-DD
-
-# 3. Update version references in:
-#    - README.md (root) — Languages table
-#    - AGENTS.md — Releasing paragraph
-#    - llms.txt — Tag Convention + this section
-
-# 4. Commit
-git add sdks/typescript/package.json sdks/typescript/CHANGELOG.md README.md AGENTS.md llms.txt skills/motosan-ai/SKILL.md
-git commit -m "chore: release ts-vX.Y.Z"
-
-# 5. Tag + push (triggers publish-typescript.yml → npm)
-git tag ts-vX.Y.Z
-git push origin main ts-vX.Y.Z
-```
-
-### Release Steps (motosan-ai-oauth)
-
-```bash
-# 1. Bump version
-#    sdks/rust/crates/motosan-ai-oauth/Cargo.toml → version = "0.2.0"
-
-# 2. Update CHANGELOG
-#    sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md → ## [0.2.0] - YYYY-MM-DD
-
-# 3. Commit
-git add sdks/rust/crates/motosan-ai-oauth/Cargo.toml sdks/rust/crates/motosan-ai-oauth/CHANGELOG.md
-git commit -m "chore: release motosan-ai-oauth-v0.2.0"
-
-# 4. Tag + push (triggers publish-motosan-ai-oauth.yml → crates.io)
-git tag -a motosan-ai-oauth-v0.2.0 -m "motosan-ai-oauth-v0.2.0 — summary"
-git push origin main motosan-ai-oauth-v0.2.0
-```
-
-Publish `motosan-ai-oauth` before publishing wrapper crates (`codex-oauth`,
+Publish `motosan-ai-oauth` before the wrapper crates (`codex-oauth`,
 `anthropic-oauth`) that depend on its new version.
-
-### Release Steps (codex-oauth)
-
-```bash
-# 1. Bump version
-#    sdks/rust/crates/codex-oauth/Cargo.toml → version = "0.1.1"
-
-# 2. Update CHANGELOG
-#    sdks/rust/crates/codex-oauth/CHANGELOG.md → ## [0.1.1] - YYYY-MM-DD
-
-# 3. Commit
-git add sdks/rust/crates/codex-oauth/Cargo.toml sdks/rust/crates/codex-oauth/CHANGELOG.md
-git commit -m "chore: release codex-oauth-v0.1.1"
-
-# 4. Tag + push (triggers publish-codex-oauth.yml → crates.io)
-git tag -a codex-oauth-v0.1.1 -m "codex-oauth-v0.1.1 — summary"
-git push origin main codex-oauth-v0.1.1
-```
-
-### Release Steps (anthropic-oauth)
-
-```bash
-# 1. Bump version
-#    sdks/rust/crates/anthropic-oauth/Cargo.toml → version = "0.1.1"
-
-# 2. Update CHANGELOG
-#    sdks/rust/crates/anthropic-oauth/CHANGELOG.md → ## [0.1.1] - YYYY-MM-DD
-
-# 3. Commit
-git add sdks/rust/crates/anthropic-oauth/Cargo.toml sdks/rust/crates/anthropic-oauth/CHANGELOG.md
-git commit -m "chore: release anthropic-oauth-v0.1.1"
-
-# 4. Tag + push (triggers publish-anthropic-oauth.yml → crates.io)
-git tag -a anthropic-oauth-v0.1.1 -m "anthropic-oauth-v0.1.1 — summary"
-git push origin main anthropic-oauth-v0.1.1
-```
 
 ### CI Pipeline
 
-Tag push triggers GitHub Actions:
-- **publish-python.yml**: tag-vs-pyproject guard → sync/lint/format/test → `uv build` → `pypa/gh-action-pypi-publish` (Trusted Publishing, no token)
-- **publish-rust.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test --all-features` → `crates-io-auth-action` → `cargo publish` + checksum verify (Trusted Publishing, no token)
-- **publish-typescript.yml**: `npm ci` → `npm run build` → `npm run test` → version-matches-tag guard → `npm publish --access public` (Trusted Publishing, no token; needs npm >= 11.5.1, provenance is automatic)
-- **publish-motosan-ai-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `crates-io-auth-action` → `cargo publish` (Trusted Publishing, no token)
-- **publish-codex-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `crates-io-auth-action` → `cargo publish` (Trusted Publishing, no token)
-- **publish-anthropic-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `crates-io-auth-action` → `cargo publish` (Trusted Publishing, no token)
+Tag push triggers GitHub Actions. Every workflow authenticates with Trusted
+Publishing (OIDC) — no registry token is stored anywhere:
+- **publish-python.yml**: tag-vs-pyproject guard → sync/lint/format/test → `uv build` → digest precheck → `pypa/gh-action-pypi-publish` → digest verify
+- **publish-rust.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test --all-features` → `crates-io-auth-action` → `cargo publish` with SHA-256 precheck and verify
+- **publish-typescript.yml**: `npm ci` → build → test → tag-vs-package.json guard → `npm pack` → integrity precheck → `npm publish <tarball>` → integrity verify
+- **publish-motosan-ai-oauth.yml** / **publish-codex-oauth.yml** / **publish-anthropic-oauth.yml**: `cargo fmt --check` → `cargo clippy` → `cargo test` → `crates-io-auth-action` → `cargo publish`
 
-All Rust workflows support `workflow_dispatch` for manual trigger.
+All workflows also support `workflow_dispatch`.
+
+Each registry must have a trusted publisher registered for this repository **and
+the specific workflow filename**, or publishing fails with an auth error.
 
 ### Pre-Push Validation (Local)
 
-```bash
-./scripts/pre-push-gate.sh
-# [1/4] Python unit tests
-# [2/4] Rust unit tests
-# [3/4] Python live tests (skipped if no ANTHROPIC_API_KEY)
-# [4/4] Rust live tests (skipped if no ANTHROPIC_API_KEY)
+`scripts/pre-push-gate.sh` (installed by `scripts/setup-hooks.sh`) is
+path-scoped: it reads the pushed range and runs only what that range touches.
+
 ```
+[metadata]   scripts/check-versions.py            — always
+[python]     unit tests                           — sdks/python/**, pyproject.toml, uv.lock
+[rust]       unit tests (--all-features)          — sdks/rust/**, workspace Cargo.toml
+[typescript] build + tests                        — sdks/typescript/**
+```
+
+Provider credentials are stripped from the environment for those runs, so the
+env-gated live tests inside the suites cannot fire. Live tests are opt-in
+(`RUN_LIVE=1 git push`) and never run in CI.
 
 ### Emergency Manual Publish
 
-```bash
-# Python
-cd sdks/python && uv build --out-dir dist && uv publish dist/*
-
-# Rust
-cd sdks/rust && cargo publish
-
-# TypeScript
-cd sdks/typescript && npm ci && npm run build && npm publish --access public
-```
+Prefer re-running the failed publish workflow: its steps are gated on digests,
+so a re-run either finds its own artifact already published and succeeds, or
+uploads what is missing. Publishing from a laptop requires temporarily minting a
+registry token (Trusted Publishing leaves no ambient credential) and skips every
+guard — version checks, gates, and the digest verification that proves the
+registry serves what was built.

--- a/skills/motosan-ai/references/release.md
+++ b/skills/motosan-ai/references/release.md
@@ -1,66 +1,58 @@
 # Release Process
 
-Python and Rust SDKs are versioned and released **independently**.
+The Rust, Python, and TypeScript SDKs are versioned and released
+**independently**, as are the three OAuth helper crates.
 
 ## Tag Convention
 
-| SDK    | Tag format       | Registry   | Workflow              |
-|--------|------------------|------------|-----------------------|
-| Python | `python-vX.Y.Z`  | PyPI       | `publish-python.yml`  |
-| Rust   | `rust-vX.Y.Z`    | crates.io  | `publish-rust.yml`    |
+| Package          | Tag format                | Registry  | Workflow                        |
+|------------------|---------------------------|-----------|---------------------------------|
+| Python           | `python-vX.Y.Z`           | PyPI      | `publish-python.yml`            |
+| Rust             | `rust-vX.Y.Z`             | crates.io | `publish-rust.yml`              |
+| TypeScript       | `ts-vX.Y.Z`               | npm       | `publish-typescript.yml`        |
+| motosan-ai-oauth | `motosan-ai-oauth-vX.Y.Z` | crates.io | `publish-motosan-ai-oauth.yml`  |
+| codex-oauth      | `codex-oauth-vX.Y.Z`      | crates.io | `publish-codex-oauth.yml`       |
+| anthropic-oauth  | `anthropic-oauth-vX.Y.Z`  | crates.io | `publish-anthropic-oauth.yml`   |
 
 ## Release Checklist
 
-### 1. Version Bump
-
-| SDK    | File                          | Field              |
-|--------|-------------------------------|--------------------|
-| Python | `sdks/python/pyproject.toml`  | `version = "X.Y.Z"` |
-| Rust   | `sdks/rust/Cargo.toml`        | `version = "X.Y.Z"` |
-
-### 2. Update CHANGELOG
-
-Both use Keep a Changelog format:
-
-```markdown
-## [X.Y.Z] - YYYY-MM-DD
-
-### Added
-- ...
-
-### Changed
-- ...
-
-### Fixed
-- ...
-```
-
-- Python: `sdks/python/CHANGELOG.md`
-- Rust: `sdks/rust/CHANGELOG.md`
-
-### 3. Commit
+### 1. Bump (scripted)
 
 ```bash
-# Python
-git add sdks/python/pyproject.toml sdks/python/CHANGELOG.md
-git commit -m "chore: release python-vX.Y.Z"
-
-# Rust
-git add sdks/rust/Cargo.toml sdks/rust/CHANGELOG.md
-git commit -m "chore: release rust-vX.Y.Z"
+python3 scripts/bump-version.py --rust 0.28.0 --python 0.20.0   # --dry-run previews
 ```
 
-### 4. Tag + Push
+Writes the manifests, both lockfiles, the CHANGELOG headings (renaming whatever
+sits under `[Unreleased]`), and the doc version banners, then runs
+`scripts/check-versions.py`. Several SDKs can go in one run; re-running is a
+no-op. Do not hand-edit those locations — `ci-metadata` and the pre-push hook
+verify them. The OAuth helper crates are not covered; bump those by hand.
+
+### 2. Write the prose
+
+- root `CHANGELOG.md` — a combined entry naming only the SDKs that moved
+- `AGENTS.md` — a release paragraph
+
+### 3. Commit and open a PR
 
 ```bash
-# Python → triggers publish-python.yml → PyPI
-git tag -a python-vX.Y.Z -m "python-vX.Y.Z — summary of changes"
-git push origin main python-vX.Y.Z
-
-# Rust → triggers publish-rust.yml → crates.io
-git tag -a rust-vX.Y.Z -m "rust-vX.Y.Z — summary of changes"
-git push origin main rust-vX.Y.Z
+git commit -m "chore(release): rust-v0.28.0 and python-v0.20.0 (#<issue>)"
 ```
+
+`chore(release):` is the one exception to the `fix:` / `feat:` / `refactor:`
+commit-type rule: a release ships no change of its own, so labelling it a
+feature or a fix would be inaccurate. Releases go through review like anything
+else.
+
+### 4. Tag the merge commit
+
+```bash
+git tag -a rust-v0.28.0 -m "rust-v0.28.0 — summary of changes"
+git push origin rust-v0.28.0
+```
+
+Create tags from a checkout of `origin/main` after the PR merges — not from a
+stale branch, whose pre-push hook may be an older version.
 
 ## CI Publish Pipelines
 
@@ -109,13 +101,14 @@ env-gated live tests inside those suites cannot fire.
 
 ## Emergency Manual Publish
 
-```bash
-# Python
-cd sdks/python && uv build --out-dir dist && uv publish dist/*
+Re-run the failed publish workflow first. Its steps are gated on digests, so a
+re-run either finds its own artifact already published and succeeds, or uploads
+what is missing.
 
-# Rust
-cd sdks/rust && cargo publish
-```
+Publishing from a laptop is a last resort: Trusted Publishing leaves no ambient
+credential, so it requires temporarily minting a registry token, and it skips
+every guard — the tag-vs-manifest check, the SDK gates, and the digest
+verification that proves the registry serves what was built.
 
 ## Registry Authentication
 
@@ -151,19 +144,23 @@ repository *and* workflow file, otherwise publishing fails with an auth error.
 
 | Workflow         | Trigger                     | Steps                              |
 |------------------|-----------------------------|------------------------------------|
-| `ci-python.yml`  | Push/PR to `sdks/python/**` | `uv sync` → `ruff check` → `pytest` |
-| `ci-rust.yml`    | Push/PR to `sdks/rust/**`   | `fmt` → `clippy` → `test` (stable + MSRV 1.82) |
+| `ci-metadata.yml`   | Every push/PR (no path filter) | `scripts/check-versions.py` |
+| `ci-python.yml`     | Push/PR to `sdks/python/**` | `uv sync` → `ruff check` → `mypy` → `pytest` |
+| `ci-rust.yml`       | Push/PR to `sdks/rust/**`   | `fmt` → `clippy` → `test` → `cargo hack --each-feature` (stable + MSRV 1.82) |
+| `ci-typescript.yml` | Push/PR to `sdks/typescript/**` | `npm ci` → build → typecheck → test → pack smoke |
 
-## Dual Release (both SDKs)
+## Releasing Several SDKs Together
 
-When releasing both at once, use separate tags:
+This is the normal case, not a special one: `bump-version.py` takes every SDK in
+a single run because they share the doc banners, the root `CHANGELOG.md` entry
+names only the SDKs that moved, and one PR carries all of it. After it merges,
+push one tag per SDK:
 
 ```bash
-git add sdks/python/pyproject.toml sdks/python/CHANGELOG.md sdks/rust/Cargo.toml sdks/rust/CHANGELOG.md
-git commit -m "chore: release python-vX.Y.Z + rust-vA.B.C"
 git tag -a python-vX.Y.Z -m "python-vX.Y.Z — summary"
 git tag -a rust-vA.B.C -m "rust-vA.B.C — summary"
-git push origin main python-vX.Y.Z rust-vA.B.C
+git push origin python-vX.Y.Z rust-vA.B.C
 ```
 
-Both publish workflows will run in parallel.
+The publish workflows run in parallel, each verifying its own tag against its
+own manifest.


### PR DESCRIPTION
Closes #264. Item 6 of the release-process work — the last of the non-optional items.

Both release documents described a process that no longer exists, and in places one that was never safe:

- **Hand-editing version references**, with a file list that was already incomplete. That omission is exactly what shipped stale install snippets in M1. Replaced by `bump-version.py`, with a note that `ci-metadata` and the pre-push hook now reject a tree where those locations disagree.
- **`git push origin main <tag>`** — pushing straight to main, contrary to the PR-based workflow. The flow now says: bump → write prose → PR → merge → tag the merge commit, and warns to create tags from a checkout of `origin/main` rather than a stale branch (the trap I hit tagging 0.27.0, where the stale checkout's hook would have run live tests).
- **`chore: release`**, which conflicted with the commit-type rule. Resolved as you decided: `chore(release):` is documented as the one exception to `fix:` / `feat:` / `refactor:`, because a release ships no change of its own and calling it a feature would be inaccurate.
- **release.md predated the TypeScript SDK and the OAuth helper crates entirely** — its tag table listed two packages out of six — and its pre-push and CI descriptions were several changes behind. Both are now current, including `ci-metadata` and `ci-typescript`.
- **"Emergency manual publish"** assumed an ambient registry credential that Trusted Publishing removed. It now says to re-run the workflow first (its steps are digest-gated, so a re-run is safe) and is explicit that a laptop publish requires temporarily minting a token and skips every guard.

AGENTS.md gains a **Commits** section. The convention has never been written down anywhere in the repo, which is why it kept being guessed at — including twice by me in this workstream, and once more while committing this very change, which is now `fix:` rather than the `docs:` I reached for first.

Gates: treefmt --fail-on-change, check-versions.py, and a grep confirming no `push origin main`-style tag instruction or `chore: release` subject survives in any of the three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)