### PR TITLE
feat: tag releases and start publishes from a workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,100 @@
+name: release-tag
+
+# Tags a release and starts the matching publish workflows, so nobody has to
+# create tags by hand from whatever checkout happens to be nearby — a stale
+# checkout carries a stale pre-push hook.
+#
+# Two ways in, both explicit: dispatch it manually, or merge a PR labelled
+# `release:<package>` (e.g. `release:rust`). Merging an unlabelled PR does
+# nothing.
+on:
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "Space-separated: rust python ts motosan-ai-oauth codex-oauth anthropic-oauth"
+        required: true
+  pull_request:
+    types: [closed]
+
+jobs:
+  tag:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(join(github.event.pull_request.labels.*.name, ','), 'release:'))
+    runs-on: ubuntu-latest
+    # Give this environment required reviewers in repo settings to gate
+    # releases on an approval; without them the job simply runs.
+    environment: release
+    permissions:
+      contents: write # push tags
+      actions: write # start the publish workflows
+    steps:
+      # Tag the merge commit the release actually landed as, not whatever main
+      # points at by the time this runs.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      # Tags are derived from the manifests, so re-checking metadata here means
+      # a tag can never point at a tree whose versions disagree.
+      - name: Re-verify version metadata
+        run: python3 scripts/check-versions.py
+      - name: Resolve tags from the manifests
+        id: plan
+        env:
+          PACKAGES: ${{ github.event.inputs.packages }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            args=()
+            for package in $PACKAGES; do args+=(--package "$package"); done
+            python3 scripts/release-tags.py "${args[@]}"
+          else
+            python3 scripts/release-tags.py --from-labels "$LABELS"
+          fi
+      - name: Create and push tags
+        env:
+          PLAN: ${{ steps.plan.outputs.plan }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          mapfile -t tags < <(printf '%s' "$PLAN" |
+            python3 -c "import json,sys; [print(item['tag']) for item in json.load(sys.stdin)]")
+
+          for tag in "${tags[@]}"; do
+            if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+              echo "::error::$tag already exists on origin — bump the version or delete the tag"
+              exit 1
+            fi
+            git tag -a "$tag" -m "$tag — tagged by release-tag.yml at $(git rev-parse HEAD)"
+          done
+
+          git push origin "${tags[@]}"
+          printf 'Pushed: %s\n' "${tags[*]}"
+      # A tag pushed with GITHUB_TOKEN does not start any workflow — GitHub
+      # suppresses those events. workflow_dispatch is one of the two documented
+      # exceptions, so the publish runs are started explicitly. Dispatching
+      # against the tag ref keeps `github.ref_type == 'tag'`, so each publish
+      # workflow's tag-vs-manifest guard still applies.
+      - name: Start the publish workflows
+        env:
+          PLAN: ${{ steps.plan.outputs.plan }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mapfile -t entries < <(printf '%s' "$PLAN" |
+            python3 -c "import json,sys; [print(item['workflow'], item['tag']) for item in json.load(sys.stdin)]")
+
+          for entry in "${entries[@]}"; do
+            workflow="${entry% *}"
+            tag="${entry#* }"
+            echo "Dispatching $workflow against $tag"
+            gh workflow run "$workflow" --ref "$tag"
+          done

--- a/llms.txt
+++ b/llms.txt
@@ -1014,12 +1014,15 @@ git add -A
 git commit -m "chore(release): rust-v0.28.0 and python-v0.20.0 (#<issue>)"
 gh pr create --title "chore(release): rust-v0.28.0 and python-v0.20.0"
 
-# 4. After the PR merges, tag the MERGE COMMIT on main and push the tags.
-#    Create them from a checkout of origin/main, not a stale branch.
-git tag -a rust-v0.28.0 -m "rust-v0.28.0 — summary"
-git tag -a python-v0.20.0 -m "python-v0.20.0 — summary"
-git push origin rust-v0.28.0 python-v0.20.0
+# 4. Tag. Label the release PR `release:rust` / `release:python` before
+#    merging and release-tag.yml does it, or dispatch that workflow by hand:
+gh workflow run release-tag.yml -f packages="rust python"
 ```
+
+`release-tag.yml` tags the merge commit, derives tag names from the manifests,
+refuses a tag that already exists, and starts each publish workflow. Tagging by
+hand still works, but create the tags from a checkout of `origin/main` — a
+stale branch carries a stale pre-push hook.
 
 `chore(release):` is the one place the `fix:` / `feat:` / `refactor:` commit-type
 rule does not apply — a release ships no new change of its own, so dressing it

--- a/scripts/_release_sites.py
+++ b/scripts/_release_sites.py
@@ -32,6 +32,60 @@ CHANGELOGS = {
 UV_LOCK = "uv.lock"
 NPM_LOCK = "sdks/typescript/package-lock.json"
 
+# Every independently-tagged package, including the OAuth helper crates, which
+# the SDK-shaped tables above deliberately exclude (they carry no doc banners,
+# no lockfile entry, and are bumped by hand). `release-tags.py` derives tags
+# from these manifests so a tag can never disagree with what it points at.
+PACKAGES: dict[str, dict[str, str]] = {
+    "rust": {
+        "manifest": MANIFESTS["rust"],
+        "kind": "cargo",
+        "tag_prefix": "rust-v",
+        "workflow": "publish-rust.yml",
+    },
+    "python": {
+        "manifest": MANIFESTS["python"],
+        "kind": "pyproject",
+        "tag_prefix": "python-v",
+        "workflow": "publish-python.yml",
+    },
+    "ts": {
+        "manifest": MANIFESTS["ts"],
+        "kind": "npm",
+        "tag_prefix": "ts-v",
+        "workflow": "publish-typescript.yml",
+    },
+    "motosan-ai-oauth": {
+        "manifest": "sdks/rust/crates/motosan-ai-oauth/Cargo.toml",
+        "kind": "cargo",
+        "tag_prefix": "motosan-ai-oauth-v",
+        "workflow": "publish-motosan-ai-oauth.yml",
+    },
+    "codex-oauth": {
+        "manifest": "sdks/rust/crates/codex-oauth/Cargo.toml",
+        "kind": "cargo",
+        "tag_prefix": "codex-oauth-v",
+        "workflow": "publish-codex-oauth.yml",
+    },
+    "anthropic-oauth": {
+        "manifest": "sdks/rust/crates/anthropic-oauth/Cargo.toml",
+        "kind": "cargo",
+        "tag_prefix": "anthropic-oauth-v",
+        "workflow": "publish-anthropic-oauth.yml",
+    },
+}
+
+
+def package_version(package: str) -> str:
+    """Read a package's version straight from its own manifest."""
+    spec = PACKAGES[package]
+    if spec["kind"] == "cargo":
+        return load_toml(spec["manifest"])["package"]["version"]
+    if spec["kind"] == "pyproject":
+        return load_toml(spec["manifest"])["project"]["version"]
+    return load_json(spec["manifest"])["version"]
+
+
 # (path, template, anchor). The anchor locates the line even when its version
 # is stale, so it must contain no version and must match exactly one line —
 # `check_anchor_uniqueness` enforces that.

--- a/scripts/release-tags.py
+++ b/scripts/release-tags.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Resolve which release tags to create, straight from the manifests.
+
+Used by `.github/workflows/release-tag.yml`. Tag names are derived from each
+package's own manifest rather than typed by a human, so a tag cannot disagree
+with the version it points at.
+
+    python3 scripts/release-tags.py --package rust --package python
+    python3 scripts/release-tags.py --from-labels "release:rust,needs-review"
+
+Prints a JSON array of {package, version, tag, workflow} to stdout, and (when
+run inside Actions) writes it to `$GITHUB_OUTPUT` as `plan`.
+
+Needs Python >= 3.11; stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import _release_sites as sites
+
+LABEL_PREFIX = "release:"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="release-tags.py")
+    parser.add_argument(
+        "--package",
+        action="append",
+        default=[],
+        choices=sorted(sites.PACKAGES),
+        help="repeatable; package to tag",
+    )
+    parser.add_argument(
+        "--from-labels",
+        default="",
+        help=f"comma-separated labels; `{LABEL_PREFIX}<package>` selects a package",
+    )
+    return parser.parse_args(argv)
+
+
+def packages_from_labels(labels: str) -> list[str]:
+    selected = []
+    for label in labels.split(","):
+        label = label.strip()
+        if not label.startswith(LABEL_PREFIX):
+            continue
+        package = label[len(LABEL_PREFIX) :]
+        if package not in sites.PACKAGES:
+            raise SystemExit(
+                f"release-tags: label {label!r} names no known package; "
+                f"expected one of {', '.join(sorted(sites.PACKAGES))}"
+            )
+        selected.append(package)
+    return selected
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    packages = list(
+        dict.fromkeys(args.package + packages_from_labels(args.from_labels))
+    )
+    if not packages:
+        print(
+            "release-tags: nothing selected — pass --package or a "
+            f"`{LABEL_PREFIX}<package>` label",
+            file=sys.stderr,
+        )
+        return 1
+
+    plan = []
+    for package in packages:
+        version = sites.package_version(package)
+        spec = sites.PACKAGES[package]
+        plan.append(
+            {
+                "package": package,
+                "version": version,
+                "tag": f"{spec['tag_prefix']}{version}",
+                "workflow": spec["workflow"],
+            }
+        )
+
+    serialized = json.dumps(plan)
+    print(serialized)
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"plan={serialized}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/motosan-ai/references/release.md
+++ b/skills/motosan-ai/references/release.md
@@ -46,13 +46,23 @@ else.
 
 ### 4. Tag the merge commit
 
+Label the release PR `release:rust` / `release:python` / `release:ts` (or
+`release:<crate>`) before merging, and `release-tag.yml` tags the merge commit
+on its way out. It can also be started by hand:
+
 ```bash
-git tag -a rust-v0.28.0 -m "rust-v0.28.0 — summary of changes"
-git push origin rust-v0.28.0
+gh workflow run release-tag.yml -f packages="rust python"
 ```
 
-Create tags from a checkout of `origin/main` after the PR merges — not from a
-stale branch, whose pre-push hook may be an older version.
+It derives tag names from the manifests, re-runs `check-versions.py`, refuses a
+tag that already exists, and then starts each publish workflow — explicitly,
+because a tag pushed with `GITHUB_TOKEN` does not start one on its own.
+
+Give the `release` environment required reviewers in repo settings if releases
+should wait for an approval.
+
+Tagging by hand still works, but create the tags from a checkout of
+`origin/main` — a stale branch carries a stale pre-push hook.
 
 ## CI Publish Pipelines
 


### PR DESCRIPTION
Closes #266. Item 7 — the optional one — completing the release-process work.

`release-tag.yml` takes the last manual step. Two explicit ways in, as agreed: merge a PR labelled `release:rust` / `release:python` / `release:ts` / `release:<crate>`, or dispatch it by hand with `gh workflow run release-tag.yml -f packages="rust python"`. Merging an unlabelled PR does nothing.

It tags `pull_request.merge_commit_sha` (not whatever main points at by the time it runs), re-runs `check-versions.py` before tagging, derives every tag name from the package's own manifest via `scripts/release-tags.py` so a tag cannot disagree with what it points at, refuses a tag that already exists on origin, and runs under `environment: release` — give that environment required reviewers in repo settings and releases wait for an approval.

**The constraint that shaped the design:** a tag pushed with `GITHUB_TOKEN` starts no workflow at all — GitHub suppresses events created by that token — so naive auto-tagging would have *stopped* publishing from happening, which is worse than tagging by hand. `workflow_dispatch` and `repository_dispatch` are the two documented exceptions, so the job starts each publish workflow explicitly. Dispatching against the **tag ref** keeps `github.ref_type == 'tag'`, so every publish workflow's tag-vs-manifest guard still fires exactly as it does today.

`_release_sites.py` gains a `PACKAGES` registry covering all six independently-tagged packages — the SDK-shaped tables deliberately exclude the OAuth crates, which carry no banners, no lockfile entry, and are bumped by hand.

Verified locally: the resolver handles multiple packages, label extraction mixed with unrelated labels, OAuth crates reading their own manifests, deduplication when a package arrives by both routes, empty selection, an unknown `release:` label, and `GITHUB_OUTPUT`. Both workflow shell blocks were run under real bash 5 against a real plan (`mapfile` is bash-only — my local zsh cannot run them, which is why they were checked explicitly), and the already-exists guard was exercised against origin, correctly blocking `rust-v0.27.0` and allowing `rust-v9.9.9`. actionlint (which shellchecks `run:` blocks) is clean; treefmt and check-versions.py green. Docs in llms.txt and release.md now lead with the workflow and keep hand-tagging as the fallback.

Untested until first use, necessarily: the dispatch chain itself. Worth watching the first release that goes through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)