### PR TITLE
chore(release): rust-v0.27.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`) + TypeScript (`sdks/typescript/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.27.0 · Python v0.19.0 (PyPI) · TypeScript v0.15.0 (npm)
+Rust v0.27.1 · Python v0.19.0 (PyPI) · TypeScript v0.15.0 (npm)
 
 Python 0.13.0 adds CLI-runtime setters (`.cwd()`, session continuity via `session_id` + `resume()`, per-run `.env()/.envs()`, CLI tool-call stream events, configurable `.timeout()/.no_timeout()`) and a **breaking** fallible stream: HTTP provider `stream()` now raises `motosan_ai.error.StreamError` mid-stream instead of swallowing transport/parse faults (`collect_stream` propagates it; `Client.stream_with` does not retry after a mid-stream raise).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [rust-0.27.1] — 2026-07-28
+
+Documentation-only patch for the Rust crate. No Python or TypeScript package
+version changed.
+
+### Changed
+
+- README install snippets use `cargo add motosan-ai --features <feature>` in
+  place of a version-pinned `[dependencies]` block, so the instructions
+  crates.io renders cannot go stale between releases. No code or API changes.
+
 ## [rust-0.27.0 / python-0.19.0] — 2026-07-28
 
 Correctness quick-wins batch. No TypeScript package version changed.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ response = await client.chat([Message.user("Hello")])
 
 | Language | Package | Version |
 |----------|---------|---------|
-| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.27.0 |
+| Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.27.1 |
 | Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.19.0 |
 | TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) | v0.15.0 |
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.19.0 · TypeScript 0.15.0 · Rust 0.27.0
+- Python 0.19.0 · TypeScript 0.15.0 · Rust 0.27.1
 - Python 0.13.0: CLI-runtime setters (`.cwd()`, `session_id` + `resume()`, `.env()/.envs()`, CLI tool-call stream events, `.timeout()/.no_timeout()`) and a **breaking** fallible stream — HTTP provider `stream()` raises `motosan_ai.error.StreamError` mid-stream instead of swallowing transport/parse faults (`collect_stream` propagates it; `Client.stream_with` does not retry after a mid-stream raise).
 - Python 0.14.0 / TypeScript 0.11.0: **chatgpt-codex** provider — native ChatGPT-backend HTTP client over the OpenAI Responses API (`chatgpt.com/backend-api/codex/responses`; pre-obtained OAuth token + account id, no `api_key`). Python `Client.chatgpt_codex(...)`, TypeScript `Client.builder().chatgptCodex(...)`.
 - Rust 0.24.0 / Python 0.17.0 / TypeScript 0.14.0 (M3): **breaking** stream termination — EOF without the provider terminal event (OpenAI wire: `[DONE]` or a `finish_reason` chunk, either suffices) raises Rust `MotosanError::IncompleteStream` / Python `IncompleteStreamError(StreamError)` / TypeScript `IncompleteStreamError extends StreamError`; one timeout model (connect 10 s / read-idle 120 s / total opt-in) on all builders; Rust build-once shared `reqwest::Client`; TypeScript per-request `AbortSignal` + `CancelledError` (never retried); Python `Client.aclose()` / `async with`.

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `motosan-ai` Rust SDK are documented in this file.
 
 ## [Unreleased]
 
+## [0.27.1] - 2026-07-28
+
+### Changed
+- README install snippets use `cargo add motosan-ai --features <feature>` in
+  place of a version-pinned `[dependencies]` block, so the instructions shown
+  on crates.io cannot go stale between releases. Documentation only — no code
+  or API changes.
+
 ## [0.27.0] - 2026-07-28
 
 ### Changed

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-ai"
-version = "0.27.0"
+version = "0.27.1"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.19.0 / Rust 0.27.0 / TypeScript 0.15.0
+Multi-provider LLM SDK — Python 0.19.0 / Rust 0.27.1 / TypeScript 0.15.0
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI, ChatGPT Codex (Responses API)
 


### PR DESCRIPTION
Closes #268. Documentation-only patch for the Rust crate — no code, no API change.

The crates.io page renders the README of the *published* version, so it still shows `motosan-ai = { version = "0.26.0" }` install snippets. #255 replaced those with `cargo add motosan-ai --features <feature>`, but a README only reaches the registry with a release.

First use of `scripts/bump-version.py` in anger: it wrote the manifest, opened the dated `[0.27.1]` CHANGELOG section from `[Unreleased]`, and refreshed all four version banners. Hand-written: the root CHANGELOG entry. Deliberately skipped: an AGENTS.md release paragraph, since that section records API-level history and a README refresh does not belong there.

TypeScript has the same stale-README situation from #255, but its release is blocked: the local npm token is expired (`npm whoami` → E401), and Trusted Publishing is not configured yet, so neither publishing route is open. It can follow once either is sorted.

Gates: treefmt --fail-on-change, check-versions.py.

Note on publishing: this will be published from a local checkout using the existing cargo token, because Trusted Publishing has no publisher registered yet. Tagging is therefore deferred — pushing `rust-v0.27.1` now would start publish-rust.yml, which would fail at the OIDC auth step. Once the crates.io trusted publisher is configured, `gh workflow run release-tag.yml -f packages=rust` creates the tag and the publish run will verify-and-skip against the already-published checksum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)