### PR TITLE
feat: TypeScript native model types and Responses codec (#270)

### DIFF
--- a/sdks/typescript/src/serialize/responses.ts
+++ b/sdks/typescript/src/serialize/responses.ts
@@ -21,10 +21,12 @@ import type {
   FunctionCallOutputContentItem,
   FunctionCallOutputPayload,
   Message,
+  ModelChatRequest,
   ModelContextItem,
   ModelToolCall,
   ModelToolOutput,
   ModelToolSpec,
+  ToolChoice,
 } from '../types.js'
 
 /** Encode one tool definition into its Responses wire object. */
@@ -193,4 +195,92 @@ export function encodeContextItem(item: ModelContextItem): Record<string, unknow
 /** Encode the whole ordered context into the Responses `input` array. */
 export function encodeInput(context: ModelContextItem[]): Record<string, unknown>[] {
   return context.flatMap(encodeContextItem)
+}
+
+function encodeToolChoice(choice: ToolChoice): unknown {
+  switch (choice.type) {
+    case 'auto':
+      return 'auto'
+    case 'required':
+      return 'required'
+    case 'none':
+      return 'none'
+    case 'tool':
+      return { type: 'function', name: choice.name }
+  }
+}
+
+/**
+ * Build a Responses request body from a native model request.
+ *
+ * Two non-obvious rules, both load-bearing (Rust build_model_request_body,
+ * providers/responses.rs:59-140):
+ *
+ *   1. System text is HOISTED into `instructions` and REMOVED from `input`.
+ *      Precedence: systemBlocks (joined) > system > any Role::System message
+ *      inside `context`; hoisted context messages are appended after whichever
+ *      of the first two applied. `defaultInstructions` fills in only when
+ *      nothing at all was supplied.
+ *   2. `providerOptions` is shallow-merged into the body root LAST, so a
+ *      caller can override anything this function produced.
+ */
+export function buildModelRequestBody(
+  req: ModelChatRequest,
+  defaultModel: string,
+  stream: boolean,
+  defaultInstructions?: string,
+): Record<string, unknown> {
+  const model = req.model ?? defaultModel
+  const inputContext: ModelContextItem[] = []
+  const instructionsParts: string[] = []
+
+  if (req.systemBlocks !== undefined) {
+    for (const block of req.systemBlocks) {
+      const trimmed = block.text.trim()
+      if (trimmed) instructionsParts.push(trimmed)
+    }
+  } else if (req.system !== undefined) {
+    const trimmed = req.system.trim()
+    if (trimmed) instructionsParts.push(trimmed)
+  }
+
+  for (const item of req.context) {
+    if (item.kind === 'message' && item.message.role === 'system') {
+      const trimmed = item.message.content.trim()
+      if (trimmed) instructionsParts.push(trimmed)
+      continue
+    }
+    inputContext.push(item)
+  }
+
+  const body: Record<string, unknown> = {
+    model,
+    input: encodeInput(inputContext),
+  }
+
+  if (stream) body.stream = true
+
+  const toolSpecs = req.toolSpecs ?? []
+  if (toolSpecs.length > 0) body.tools = encodeTools(toolSpecs)
+
+  const instructions =
+    instructionsParts.length > 0 ? instructionsParts.join('\n\n') : defaultInstructions
+  if (instructions !== undefined) body.instructions = instructions
+
+  if (req.temperature !== undefined) body.temperature = req.temperature
+  // Wire key divergence: maxTokens -> max_output_tokens.
+  if (req.maxTokens !== undefined) body.max_output_tokens = req.maxTokens
+  if (req.toolChoice !== undefined) body.tool_choice = encodeToolChoice(req.toolChoice)
+  if (req.stopSequences !== undefined && req.stopSequences.length > 0) {
+    body.stop = req.stopSequences
+  }
+
+  // LAST — providerOptions wins over everything above.
+  if (req.providerOptions !== undefined) {
+    for (const [key, value] of Object.entries(req.providerOptions)) {
+      body[key] = value
+    }
+  }
+
+  return body
 }

--- a/sdks/typescript/src/serialize/responses.ts
+++ b/sdks/typescript/src/serialize/responses.ts
@@ -17,6 +17,8 @@
  * the SSE adapter too, because the Responses codec is symmetric and shared.
  */
 
+import { IncompleteStreamError, StreamError } from '../error.js'
+import { parseSse } from '../http/sse.js'
 import type {
   FunctionCallOutputContentItem,
   FunctionCallOutputPayload,
@@ -24,6 +26,7 @@ import type {
   ModelChatRequest,
   ModelChatResponse,
   ModelContextItem,
+  ModelStreamDelta,
   ModelToolCall,
   ModelToolOutput,
   ModelToolSpec,
@@ -483,4 +486,147 @@ export function modelChatResponseFromOutput(
   }
   if (thinking !== undefined) response.thinking = thinking
   return response
+}
+
+/**
+ * First non-empty wins: top-level `message` -> `response.error.message` ->
+ * `error.message` -> fallback. Mirrors Rust's error arm in
+ * ResponsesModelStreamAdapter::handle_event.
+ */
+function responsesStreamErrorMessage(data: Record<string, any>): string {
+  if (typeof data.message === 'string' && data.message) return data.message
+  const nested = asRecord(asRecord(data.response)?.error)?.message
+  if (typeof nested === 'string' && nested) return nested
+  const top = asRecord(data.error)?.message
+  if (typeof top === 'string' && top) return top
+  return 'responses stream error'
+}
+
+/**
+ * Adapt a Responses SSE byte stream into ModelStreamDelta values.
+ *
+ * Contract (specs/types.md § Stream termination (native), milestone D8):
+ *   - Exactly ONE terminal `done` per successfully completed stream, emitted
+ *     on `response.completed` or `response.incomplete`. Frames after the
+ *     terminal are consumed but produce no second done.
+ *   - EOF without either terminal throws IncompleteStreamError carrying
+ *     `<provider> ended without a terminal event`. Callers pass `openai` or
+ *     `chatgpt-codex` (HYPHEN — the legacy chat adapter's `chatgpt_codex`
+ *     token is a different, unchanged string).
+ *   - Pending deltas from a frame are yielded before an error frame throws.
+ *   - `tool_call_done` is authoritative; the accumulated input/argument
+ *     deltas are display bookkeeping only.
+ */
+export async function* modelStreamAdapter(
+  body: ReadableStream<Uint8Array>,
+  provider: string,
+): AsyncGenerator<ModelStreamDelta> {
+  const itemToCallId = new Map<string, string>()
+  let sawToolCall = false
+  let sawTerminal = false
+
+  const rememberOutputItem = (item: Record<string, any>): void => {
+    if (item.type !== 'function_call' && item.type !== 'custom_tool_call') return
+    if (typeof item.call_id !== 'string') return
+    sawToolCall = true
+    if (typeof item.id === 'string' && item.id !== '') itemToCallId.set(item.id, item.call_id)
+  }
+
+  const callIdFromEvent = (data: Record<string, any>): string | undefined => {
+    if (typeof data.call_id === 'string') return data.call_id
+    if (typeof data.item_id === 'string') return itemToCallId.get(data.item_id) ?? data.item_id
+    return undefined
+  }
+
+  for await (const evt of parseSse(body)) {
+    const data = evt.data
+    if (!data || data === '[DONE]' || typeof data !== 'object') continue
+    if (sawTerminal) continue
+
+    switch (data.type) {
+      case 'response.output_text.delta': {
+        if (typeof data.delta === 'string' && data.delta !== '') {
+          yield { type: 'text', delta: data.delta }
+        }
+        break
+      }
+      case 'response.reasoning_text.delta':
+      case 'response.reasoning_summary_text.delta': {
+        if (typeof data.delta === 'string' && data.delta !== '') {
+          yield { type: 'thinking_delta', delta: data.delta }
+        }
+        break
+      }
+      case 'response.reasoning_text.done':
+      case 'response.reasoning_summary_text.done': {
+        const thinking =
+          typeof data.text === 'string'
+            ? data.text
+            : typeof data.delta === 'string'
+              ? data.delta
+              : undefined
+        if (thinking !== undefined) yield { type: 'thinking_done', thinking }
+        break
+      }
+      case 'response.output_item.added': {
+        const item = asRecord(data.item)
+        if (item !== undefined) rememberOutputItem(item)
+        break
+      }
+      case 'response.function_call_arguments.delta': {
+        const callId = callIdFromEvent(data)
+        if (callId !== undefined && typeof data.delta === 'string') {
+          yield { type: 'function_arguments', callId, delta: data.delta }
+        }
+        break
+      }
+      case 'response.custom_tool_call_input.delta': {
+        const callId = callIdFromEvent(data)
+        if (callId !== undefined && typeof data.delta === 'string') {
+          yield { type: 'freeform_input', callId, delta: data.delta }
+        }
+        break
+      }
+      case 'response.output_item.done': {
+        const item = asRecord(data.item)
+        if (item !== undefined) {
+          rememberOutputItem(item)
+          const call = decodeToolCall(item)
+          if (call !== undefined) {
+            sawToolCall = true
+            yield { type: 'tool_call_done', call }
+          }
+        }
+        break
+      }
+      case 'response.completed':
+      case 'response.incomplete': {
+        const response = asRecord(data.response)
+        const usage = decodeUsage(response?.usage)
+        if (
+          usage.inputTokens !== 0 ||
+          usage.outputTokens !== 0 ||
+          usage.cacheCreationInputTokens !== undefined ||
+          usage.cacheReadInputTokens !== undefined
+        ) {
+          yield { type: 'usage', usage }
+        }
+        const status = typeof response?.status === 'string' ? response.status : undefined
+        yield { type: 'done', stopReason: stopReasonFromStatus(status, sawToolCall) }
+        sawTerminal = true
+        break
+      }
+      case 'error':
+      case 'response.failed': {
+        sawTerminal = true
+        throw new StreamError(responsesStreamErrorMessage(data))
+      }
+      default:
+        break
+    }
+  }
+
+  if (!sawTerminal) {
+    throw new IncompleteStreamError(`incomplete stream: ${provider} ended without a terminal event`)
+  }
 }

--- a/sdks/typescript/src/serialize/responses.ts
+++ b/sdks/typescript/src/serialize/responses.ts
@@ -22,11 +22,14 @@ import type {
   FunctionCallOutputPayload,
   Message,
   ModelChatRequest,
+  ModelChatResponse,
   ModelContextItem,
   ModelToolCall,
   ModelToolOutput,
   ModelToolSpec,
+  StopReason,
   ToolChoice,
+  Usage,
 } from '../types.js'
 
 /** Encode one tool definition into its Responses wire object. */
@@ -283,4 +286,201 @@ export function buildModelRequestBody(
   }
 
   return body
+}
+
+function asRecord(value: unknown): Record<string, any> | undefined {
+  return value !== null && typeof value === 'object' ? (value as Record<string, any>) : undefined
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+/**
+ * Decode a Responses output item into a model tool call.
+ *
+ * Accepts `call_id` OR `id` for the identity, mirroring Rust's
+ * `ModelToolCall` Deserialize. Returns undefined for anything that is not a
+ * `function_call` / `custom_tool_call`, which is how the output-item loops use
+ * it as a filter.
+ */
+export function decodeToolCall(item: unknown): ModelToolCall | undefined {
+  const obj = asRecord(item)
+  if (obj === undefined) return undefined
+
+  const id =
+    typeof obj.call_id === 'string' ? obj.call_id : typeof obj.id === 'string' ? obj.id : undefined
+  const name = typeof obj.name === 'string' ? obj.name : undefined
+  if (id === undefined || name === undefined) return undefined
+
+  if (obj.type === 'function_call') {
+    return {
+      kind: 'function',
+      id,
+      name,
+      arguments: typeof obj.arguments === 'string' ? obj.arguments : '',
+    }
+  }
+  if (obj.type === 'custom_tool_call') {
+    // Raw model text. Never JSON.parse it, never move it into `arguments`.
+    return { kind: 'freeform', id, name, input: typeof obj.input === 'string' ? obj.input : '' }
+  }
+  return undefined
+}
+
+function decodeOutputContentItem(value: unknown): FunctionCallOutputContentItem | undefined {
+  const obj = asRecord(value)
+  if (obj === undefined) return undefined
+  if (obj.type === 'input_text' && typeof obj.text === 'string') {
+    return { type: 'input_text', text: obj.text }
+  }
+  if (obj.type === 'input_image' && typeof obj.image_url === 'string') {
+    const item: FunctionCallOutputContentItem = { type: 'input_image', imageUrl: obj.image_url }
+    if (
+      obj.detail === 'auto' ||
+      obj.detail === 'low' ||
+      obj.detail === 'high' ||
+      obj.detail === 'original'
+    ) {
+      item.detail = obj.detail
+    }
+    return item
+  }
+  if (obj.type === 'encrypted_content' && typeof obj.encrypted_content === 'string') {
+    return { type: 'encrypted_content', encryptedContent: obj.encrypted_content }
+  }
+  return undefined
+}
+
+function decodeOutputPayload(value: unknown): FunctionCallOutputPayload | undefined {
+  if (typeof value === 'string') return value
+  if (!Array.isArray(value)) return undefined
+  const items: FunctionCallOutputContentItem[] = []
+  for (const entry of value) {
+    const item = decodeOutputContentItem(entry)
+    if (item === undefined) return undefined
+    items.push(item)
+  }
+  return items
+}
+
+/** Decode a Responses output item into a caller tool output. */
+export function decodeToolOutput(item: unknown): ModelToolOutput | undefined {
+  const obj = asRecord(item)
+  if (obj === undefined) return undefined
+
+  const payload = decodeOutputPayload(obj.output)
+  if (payload === undefined) return undefined
+  const callId = typeof obj.call_id === 'string' ? obj.call_id : undefined
+  if (callId === undefined) return undefined
+
+  if (obj.type === 'function_call_output') {
+    return { kind: 'function', callId, output: payload }
+  }
+  if (obj.type === 'custom_tool_call_output') {
+    const output: ModelToolOutput = { kind: 'custom', callId, output: payload }
+    if (typeof obj.name === 'string') output.name = obj.name
+    return output
+  }
+  return undefined
+}
+
+/** Concatenate the `output_text` parts of a Responses `message` output item. */
+export function decodeOutputText(item: unknown): string | undefined {
+  const obj = asRecord(item)
+  if (obj === undefined || obj.type !== 'message') return undefined
+  if (!Array.isArray(obj.content)) return undefined
+
+  let text = ''
+  for (const part of obj.content) {
+    const partObj = asRecord(part)
+    if (partObj !== undefined && partObj.type === 'output_text' && typeof partObj.text === 'string') {
+      text += partObj.text
+    }
+  }
+  return text === '' ? undefined : text
+}
+
+/**
+ * Decode a Responses usage object. Accepts the Responses key names and the
+ * chat-completions ones; `cacheReadInputTokens` is emitted only when
+ * `input_tokens_details.cached_tokens` is greater than zero.
+ */
+export function decodeUsage(value: unknown): Usage {
+  const usage = asRecord(value)
+  const inputTokens = numberOrZero(usage?.input_tokens ?? usage?.prompt_tokens)
+  const outputTokens = numberOrZero(usage?.output_tokens ?? usage?.completion_tokens)
+  const cached = numberOrZero(asRecord(usage?.input_tokens_details)?.cached_tokens)
+
+  const result: Usage = { inputTokens, outputTokens }
+  if (cached > 0) result.cacheReadInputTokens = cached
+  return result
+}
+
+/** Map a Responses `status` to a StopReason. Tool calls always win. */
+export function stopReasonFromStatus(
+  status: string | undefined,
+  hasToolCalls: boolean,
+): StopReason {
+  if (hasToolCalls) return 'tool_use'
+  if (status === 'incomplete') return 'max_tokens'
+  if (status === undefined || status === 'completed') return 'end_turn'
+  return 'other'
+}
+
+/**
+ * Decode a NON-STREAMING Responses payload into a ModelChatResponse. This is
+ * the genuine blocking decode path (OpenAI); ChatGPT Codex has no
+ * non-streaming endpoint and reaches the same shape via collectModelStream.
+ */
+export function modelChatResponseFromOutput(
+  payload: unknown,
+  defaultModel: string,
+): ModelChatResponse {
+  const obj = asRecord(payload) ?? {}
+  let content = ''
+  let thinking: string | undefined
+  const toolCalls: ModelToolCall[] = []
+
+  if (typeof obj.output_text === 'string') content += obj.output_text
+
+  if (Array.isArray(obj.output)) {
+    for (const item of obj.output) {
+      const text = decodeOutputText(item)
+      if (text !== undefined) content += text
+
+      const itemObj = asRecord(item)
+      if (itemObj !== undefined && itemObj.type === 'reasoning' && Array.isArray(itemObj.summary)) {
+        let summary = ''
+        for (const part of itemObj.summary) {
+          const partObj = asRecord(part)
+          if (partObj === undefined) continue
+          const value =
+            typeof partObj.text === 'string'
+              ? partObj.text
+              : typeof partObj.content === 'string'
+                ? partObj.content
+                : undefined
+          if (value !== undefined) summary += value
+        }
+        if (summary !== '') thinking = summary
+      }
+
+      const call = decodeToolCall(item)
+      if (call !== undefined) toolCalls.push(call)
+    }
+  }
+
+  const response: ModelChatResponse = {
+    content,
+    toolCalls,
+    model: typeof obj.model === 'string' ? obj.model : defaultModel,
+    usage: decodeUsage(obj.usage),
+    stopReason: stopReasonFromStatus(
+      typeof obj.status === 'string' ? obj.status : undefined,
+      toolCalls.length > 0,
+    ),
+  }
+  if (thinking !== undefined) response.thinking = thinking
+  return response
 }

--- a/sdks/typescript/src/serialize/responses.ts
+++ b/sdks/typescript/src/serialize/responses.ts
@@ -1,0 +1,196 @@
+/**
+ * OpenAI Responses API codec — the ONE place the native model surface is
+ * translated to and from the wire.
+ *
+ * Mirrors Rust `providers/responses.rs`. Both native providers
+ * (providers/chatgpt_codex.ts and providers/openai.ts) call into here, so the
+ * two cannot drift.
+ *
+ * Wire divergences that matter (all pinned by tests):
+ *   - ModelToolCall.id            -> wire key `call_id` (decoding accepts `call_id` OR `id`)
+ *   - ModelChatRequest.maxTokens  -> body key `max_output_tokens`
+ *   - Tool.inputSchema            -> wire key `parameters`
+ *   - freeform tools              -> wire `type: "custom"` (never "freeform")
+ *   - freeform `input`            -> raw text, preserved byte-for-byte, NEVER JSON-parsed
+ *
+ * Unlike serialize/{anthropic,gemini,openai}.ts this module owns decoding and
+ * the SSE adapter too, because the Responses codec is symmetric and shared.
+ */
+
+import type {
+  FunctionCallOutputContentItem,
+  FunctionCallOutputPayload,
+  Message,
+  ModelContextItem,
+  ModelToolCall,
+  ModelToolOutput,
+  ModelToolSpec,
+} from '../types.js'
+
+/** Encode one tool definition into its Responses wire object. */
+export function encodeToolSpec(spec: ModelToolSpec): Record<string, unknown> {
+  if (spec.kind === 'freeform') {
+    return {
+      type: 'custom',
+      name: spec.tool.name,
+      description: spec.tool.description,
+      format: {
+        type: spec.tool.format.type,
+        syntax: spec.tool.format.syntax,
+        definition: spec.tool.format.definition,
+      },
+    }
+  }
+  // Rust's ToolSchema requires description/input_schema; TypeScript's Tool
+  // makes them optional, so supply the empty forms rather than emitting null.
+  return {
+    type: 'function',
+    name: spec.tool.name,
+    description: spec.tool.description ?? '',
+    parameters: spec.tool.inputSchema ?? {},
+  }
+}
+
+/** Encode the whole tool list, order preserved. */
+export function encodeTools(specs: ModelToolSpec[]): Record<string, unknown>[] {
+  return specs.map(encodeToolSpec)
+}
+
+/** Encode a model tool call. `id` goes out under the wire key `call_id`. */
+export function encodeToolCall(call: ModelToolCall): Record<string, unknown> {
+  if (call.kind === 'freeform') {
+    return {
+      type: 'custom_tool_call',
+      call_id: call.id,
+      name: call.name,
+      input: call.input,
+    }
+  }
+  return {
+    type: 'function_call',
+    call_id: call.id,
+    name: call.name,
+    arguments: call.arguments,
+  }
+}
+
+function encodeOutputContentItem(item: FunctionCallOutputContentItem): Record<string, unknown> {
+  if (item.type === 'input_text') {
+    return { type: 'input_text', text: item.text }
+  }
+  if (item.type === 'input_image') {
+    const encoded: Record<string, unknown> = { type: 'input_image', image_url: item.imageUrl }
+    if (item.detail !== undefined) encoded.detail = item.detail
+    return encoded
+  }
+  return { type: 'encrypted_content', encrypted_content: item.encryptedContent }
+}
+
+function encodeOutputPayload(payload: FunctionCallOutputPayload): unknown {
+  if (typeof payload === 'string') return payload
+  return payload.map(encodeOutputContentItem)
+}
+
+/**
+ * Encode a tool output. NOTE: the custom arm deliberately drops `name` — the
+ * Responses body carries identity in `call_id` only, matching Rust
+ * `encode_tool_output` (providers/responses.rs:34-49).
+ */
+export function encodeToolOutput(output: ModelToolOutput): Record<string, unknown> {
+  if (output.kind === 'custom') {
+    return {
+      type: 'custom_tool_call_output',
+      call_id: output.callId,
+      output: encodeOutputPayload(output.output),
+    }
+  }
+  return {
+    type: 'function_call_output',
+    call_id: output.callId,
+    output: encodeOutputPayload(output.output),
+  }
+}
+
+function encodeUserContent(message: Message): Record<string, unknown>[] {
+  const blocks = message.contentBlocks ?? []
+  if (blocks.length === 0) {
+    return [{ type: 'input_text', text: message.content }]
+  }
+
+  const content: Record<string, unknown>[] = []
+  for (const block of blocks) {
+    if (block.type === 'text') {
+      content.push({ type: 'input_text', text: block.text })
+    } else if (block.type === 'image') {
+      const source = block.source
+      const imageUrl =
+        source.type === 'base64'
+          ? `data:${source.mediaType};base64,${source.data}`
+          : source.url
+      content.push({ type: 'input_image', image_url: imageUrl })
+    }
+    // Document blocks produce nothing (mirrors Rust ContentBlock::Document => {}).
+  }
+
+  if (content.length === 0) {
+    content.push({ type: 'input_text', text: message.content })
+  }
+  return content
+}
+
+function encodeMessage(message: Message): Record<string, unknown>[] {
+  switch (message.role) {
+    case 'system':
+      // System text belongs in `instructions`, never in `input`.
+      return []
+    case 'user':
+      return [{ type: 'message', role: 'user', content: encodeUserContent(message) }]
+    case 'assistant': {
+      const items: Record<string, unknown>[] = []
+      if (message.content) {
+        items.push({
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: message.content }],
+        })
+      }
+      for (const call of message.toolCalls ?? []) {
+        items.push(
+          encodeToolCall({
+            kind: 'function',
+            id: call.id,
+            name: call.name,
+            arguments: JSON.stringify(call.input) ?? '{}',
+          }),
+        )
+      }
+      return items
+    }
+    case 'tool':
+      if (message.toolCallId === undefined) return []
+      return [
+        encodeToolOutput({
+          kind: 'function',
+          callId: message.toolCallId,
+          output: message.content,
+        }),
+      ]
+  }
+}
+
+/** Encode one ordered history entry into zero or more Responses input items. */
+export function encodeContextItem(item: ModelContextItem): Record<string, unknown>[] {
+  switch (item.kind) {
+    case 'message':
+      return encodeMessage(item.message)
+    case 'toolCall':
+      return [encodeToolCall(item.call)]
+    case 'toolOutput':
+      return [encodeToolOutput(item.output)]
+  }
+}
+
+/** Encode the whole ordered context into the Responses `input` array. */
+export function encodeInput(context: ModelContextItem[]): Record<string, unknown>[] {
+  return context.flatMap(encodeContextItem)
+}

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -179,3 +179,129 @@ export interface ChatResponse {
   usage: Usage
   stopReason: StopReason
 }
+
+// ---------------------------------------------------------------------------
+// Native model API (specs/types.md § Native Model API).
+//
+// A surface PARALLEL to ChatRequest/Tool/ToolCall/ChatResponse/StreamEvent,
+// for providers that expose OpenAI Responses-style ordered input items and
+// custom (freeform) tool calls. The legacy surface above stays
+// function-tool-only; nothing here widens it.
+//
+// Tag choice (milestone D2): ModelToolSpec / ModelToolCall / ModelToolOutput /
+// ModelContextItem are tagged on `kind` because the model shape and the wire
+// shape disagree (freeform <-> wire "custom", id <-> wire call_id) — the same
+// reason McpToolConfig above uses `kind`. ModelStreamDelta and
+// FunctionCallOutputContentItem are tagged on `type` because their tag VALUES
+// are exactly the wire values.
+//
+// Wire encoding lives in serialize/responses.ts, never here.
+// ---------------------------------------------------------------------------
+
+/** Grammar/format descriptor for a freeform tool. All three fields are mandatory. */
+export interface FreeformToolFormat {
+  type: string
+  syntax: string
+  definition: string
+}
+
+/** A freeform ("custom") tool definition. Serializes with a wire `type: "custom"`. */
+export interface FreeformTool {
+  name: string
+  description: string
+  format: FreeformToolFormat
+}
+
+/**
+ * A tool exposed to the model on the native surface. `function` wraps the
+ * existing `Tool` (wire `{type:"function", name, description, parameters}`);
+ * `freeform` wraps a `FreeformTool` (wire `{type:"custom", name, description,
+ * format}`).
+ */
+export type ModelToolSpec =
+  | { kind: 'function'; tool: Tool }
+  | { kind: 'freeform'; tool: FreeformTool }
+
+/** Image fidelity hint on a Responses `input_image` content item. */
+export type ImageDetail = 'auto' | 'low' | 'high' | 'original'
+
+/** One Responses-style content item inside a tool output payload. */
+export type FunctionCallOutputContentItem =
+  | { type: 'input_text'; text: string }
+  | { type: 'input_image'; imageUrl: string; detail?: ImageDetail }
+  | { type: 'encrypted_content'; encryptedContent: string }
+
+/** A tool output payload: plain text, or Responses-style content items. */
+export type FunctionCallOutputPayload = string | FunctionCallOutputContentItem[]
+
+/**
+ * A tool call the model produced. `id` is the caller-facing identity; it is
+ * written to (and read from) the wire key `call_id`. Freeform `input` is raw
+ * model text — preserved byte-for-byte, never parsed as JSON, never lowered
+ * into a function call's `arguments`.
+ */
+export type ModelToolCall =
+  | { kind: 'function'; id: string; name: string; arguments: string }
+  | { kind: 'freeform'; id: string; name: string; input: string }
+
+/** A tool result the caller returns to the model. */
+export type ModelToolOutput =
+  | { kind: 'function'; callId: string; output: FunctionCallOutputPayload }
+  | { kind: 'custom'; callId: string; name?: string; output: FunctionCallOutputPayload }
+
+/**
+ * One ordered history entry. Preserving message / tool-call / tool-output
+ * ORDER is what makes byte-exact replay of freeform inputs possible in
+ * multi-turn histories.
+ */
+export type ModelContextItem =
+  | { kind: 'message'; message: Message }
+  | { kind: 'toolCall'; call: ModelToolCall }
+  | { kind: 'toolOutput'; output: ModelToolOutput }
+
+/**
+ * A native model request. Deliberately carries NO thinking and NO MCP config
+ * (milestone D3): native requests reach provider-specific reasoning controls
+ * through `providerOptions`.
+ */
+export interface ModelChatRequest {
+  context: ModelContextItem[]
+  toolSpecs?: ModelToolSpec[]
+  model?: string
+  system?: string
+  systemBlocks?: SystemBlock[]
+  systemCache?: boolean
+  temperature?: number
+  /** Serialized to the Responses body key `max_output_tokens`. */
+  maxTokens?: number
+  toolChoice?: ToolChoice
+  stopSequences?: string[]
+  /** Shallow-merged into the request body root LAST — it overrides everything. */
+  providerOptions?: Record<string, unknown>
+}
+
+/** A native, non-streaming model response. */
+export interface ModelChatResponse {
+  content: string
+  thinking?: string
+  toolCalls: ModelToolCall[]
+  model: string
+  usage: Usage
+  stopReason: StopReason
+  sessionId?: string
+}
+
+/**
+ * One native stream delta. `tool_call_done` is AUTHORITATIVE for a completed
+ * call; accumulated `function_arguments` / `freeform_input` deltas are display
+ * bookkeeping only. Exactly one `done` per successfully completed stream.
+ */
+export type ModelStreamDelta =
+  | { type: 'text'; delta: string }
+  | { type: 'thinking_delta'; delta: string }
+  | { type: 'thinking_done'; thinking: string }
+  | { type: 'function_arguments'; callId: string; delta: string }
+  | { type: 'freeform_input'; callId: string; delta: string }
+  | { type: 'tool_call_done'; call: ModelToolCall }
+  | { type: 'usage'; usage: Usage }
+  | { type: 'done'; stopReason: StopReason }

--- a/sdks/typescript/tests/serialize.responses.test.ts
+++ b/sdks/typescript/tests/serialize.responses.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildModelRequestBody,
+  decodeOutputText,
+  decodeToolCall,
+  decodeToolOutput,
+  decodeUsage,
   encodeContextItem,
   encodeInput,
   encodeToolCall,
   encodeToolOutput,
   encodeTools,
   encodeToolSpec,
+  modelChatResponseFromOutput,
+  stopReasonFromStatus,
 } from '../src/serialize/responses.js'
 import type { FreeformTool, ModelChatRequest, ModelToolSpec } from '../src/types.js'
 
@@ -392,5 +398,206 @@ describe('buildModelRequestBody', () => {
     expect(input[1].input).toBe(raw)
     expect(input[1].call_id).toBe('call_js')
     expect((body.tools as Record<string, unknown>[])[0].type).toBe('custom')
+  })
+})
+
+describe('decodeToolCall', () => {
+  it('decodes a custom_tool_call and keeps input byte-exact', () => {
+    const raw = 'const x = {a: 1};\nconsole.log(`raw ${x.a}`);\n'
+    expect(
+      decodeToolCall({ type: 'custom_tool_call', call_id: 'call_js', name: 'exec', input: raw }),
+    ).toEqual({ kind: 'freeform', id: 'call_js', name: 'exec', input: raw })
+  })
+
+  it('decodes a function_call', () => {
+    expect(
+      decodeToolCall({
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'get_weather',
+        arguments: '{"city":"Paris"}',
+      }),
+    ).toEqual({
+      kind: 'function',
+      id: 'call_1',
+      name: 'get_weather',
+      arguments: '{"city":"Paris"}',
+    })
+  })
+
+  it('accepts `id` when `call_id` is absent', () => {
+    expect(decodeToolCall({ type: 'function_call', id: 'call_2', name: 'f' })).toEqual({
+      kind: 'function',
+      id: 'call_2',
+      name: 'f',
+      arguments: '',
+    })
+  })
+
+  it('returns undefined for non-call items', () => {
+    expect(decodeToolCall({ type: 'message', role: 'assistant' })).toBeUndefined()
+    expect(decodeToolCall({ type: 'function_call' })).toBeUndefined()
+    expect(decodeToolCall('nope')).toBeUndefined()
+  })
+
+  it('round-trips a freeform call through encode then decode', () => {
+    const raw = 'const x = {a: 1};\nconsole.log(`raw ${x.a}`);\n'
+    const call = { kind: 'freeform', id: 'call_js', name: 'exec', input: raw } as const
+    expect(decodeToolCall(JSON.parse(JSON.stringify(encodeToolCall(call))))).toEqual(call)
+  })
+})
+
+describe('decodeToolOutput', () => {
+  it('decodes a custom output including its optional name', () => {
+    expect(
+      decodeToolOutput({
+        type: 'custom_tool_call_output',
+        call_id: 'call_js',
+        name: 'exec',
+        output: 'stdout: 42',
+      }),
+    ).toEqual({ kind: 'custom', callId: 'call_js', name: 'exec', output: 'stdout: 42' })
+  })
+
+  it('omits name when the wire has none', () => {
+    expect(
+      decodeToolOutput({ type: 'custom_tool_call_output', call_id: 'call_js', output: 'x' }),
+    ).toEqual({ kind: 'custom', callId: 'call_js', output: 'x' })
+  })
+
+  it('decodes a function output with content items', () => {
+    expect(
+      decodeToolOutput({
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: [{ type: 'input_text', text: 'hi' }],
+      }),
+    ).toEqual({ kind: 'function', callId: 'call_1', output: [{ type: 'input_text', text: 'hi' }] })
+  })
+
+  it('returns undefined without a payload or a known type', () => {
+    expect(decodeToolOutput({ type: 'function_call_output', call_id: 'c' })).toBeUndefined()
+    expect(decodeToolOutput({ type: 'other', call_id: 'c', output: 'x' })).toBeUndefined()
+  })
+})
+
+describe('decodeOutputText', () => {
+  it('concatenates output_text parts of a message item', () => {
+    expect(
+      decodeOutputText({
+        type: 'message',
+        content: [
+          { type: 'output_text', text: 'Hi ' },
+          { type: 'refusal', text: 'IGNORED' },
+          { type: 'output_text', text: 'there' },
+        ],
+      }),
+    ).toBe('Hi there')
+  })
+
+  it('returns undefined for non-message items and empty text', () => {
+    expect(decodeOutputText({ type: 'reasoning' })).toBeUndefined()
+    expect(decodeOutputText({ type: 'message', content: [] })).toBeUndefined()
+  })
+})
+
+describe('decodeUsage', () => {
+  it('reads Responses keys', () => {
+    expect(decodeUsage({ input_tokens: 9, output_tokens: 7 })).toEqual({
+      inputTokens: 9,
+      outputTokens: 7,
+    })
+  })
+
+  it('falls back to chat-completions key names', () => {
+    expect(decodeUsage({ prompt_tokens: 4, completion_tokens: 5 })).toEqual({
+      inputTokens: 4,
+      outputTokens: 5,
+    })
+  })
+
+  it('maps cached_tokens only when positive', () => {
+    expect(
+      decodeUsage({ input_tokens: 1, output_tokens: 1, input_tokens_details: { cached_tokens: 3 } }),
+    ).toEqual({ inputTokens: 1, outputTokens: 1, cacheReadInputTokens: 3 })
+    expect(
+      decodeUsage({ input_tokens: 1, output_tokens: 1, input_tokens_details: { cached_tokens: 0 } }),
+    ).toEqual({ inputTokens: 1, outputTokens: 1 })
+  })
+
+  it('returns zeros for missing usage', () => {
+    expect(decodeUsage(undefined)).toEqual({ inputTokens: 0, outputTokens: 0 })
+  })
+})
+
+describe('stopReasonFromStatus', () => {
+  it('prefers tool_use whenever there are tool calls', () => {
+    expect(stopReasonFromStatus('incomplete', true)).toBe('tool_use')
+  })
+
+  it('maps statuses', () => {
+    expect(stopReasonFromStatus('completed', false)).toBe('end_turn')
+    expect(stopReasonFromStatus(undefined, false)).toBe('end_turn')
+    expect(stopReasonFromStatus('incomplete', false)).toBe('max_tokens')
+    expect(stopReasonFromStatus('failed', false)).toBe('other')
+    expect(stopReasonFromStatus('weird', false)).toBe('other')
+  })
+})
+
+describe('modelChatResponseFromOutput', () => {
+  it('decodes a freeform tool call with tool_use and usage', () => {
+    const raw = 'const x = {a: 1};\nconsole.log(x.a);\n'
+    const response = modelChatResponseFromOutput(
+      {
+        model: 'gpt-5.5-codex',
+        status: 'completed',
+        output: [{ type: 'custom_tool_call', call_id: 'call_js', name: 'exec', input: raw }],
+        usage: { input_tokens: 9, output_tokens: 7 },
+      },
+      'fallback-model',
+    )
+    expect(response.toolCalls).toEqual([
+      { kind: 'freeform', id: 'call_js', name: 'exec', input: raw },
+    ])
+    expect(response.stopReason).toBe('tool_use')
+    expect(response.usage.inputTokens).toBe(9)
+    expect(response.model).toBe('gpt-5.5-codex')
+    expect(response.content).toBe('')
+  })
+
+  it('concatenates output_text items into content', () => {
+    const response = modelChatResponseFromOutput(
+      {
+        status: 'completed',
+        output: [
+          { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'ok' }] },
+        ],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+      'gpt-5.5-codex',
+    )
+    expect(response.content).toBe('ok')
+    expect(response.model).toBe('gpt-5.5-codex')
+    expect(response.stopReason).toBe('end_turn')
+  })
+
+  it('keeps reasoning summary text in thinking, separate from content', () => {
+    const response = modelChatResponseFromOutput(
+      {
+        status: 'completed',
+        output: [
+          { type: 'reasoning', summary: [{ text: 'private reasoning' }] },
+          { type: 'message', content: [{ type: 'output_text', text: 'answer' }] },
+        ],
+      },
+      'm',
+    )
+    expect(response.content).toBe('answer')
+    expect(response.thinking).toBe('private reasoning')
+  })
+
+  it('omits thinking entirely when there is no reasoning summary', () => {
+    const response = modelChatResponseFromOutput({ status: 'completed' }, 'm')
+    expect('thinking' in response).toBe(false)
   })
 })

--- a/sdks/typescript/tests/serialize.responses.test.ts
+++ b/sdks/typescript/tests/serialize.responses.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+import {
+  encodeContextItem,
+  encodeInput,
+  encodeToolCall,
+  encodeToolOutput,
+  encodeTools,
+  encodeToolSpec,
+} from '../src/serialize/responses.js'
+import type { FreeformTool, ModelToolSpec } from '../src/types.js'
+
+const GRAMMAR_TOOL: FreeformTool = {
+  name: 'exec',
+  description: 'Run JavaScript',
+  format: { type: 'grammar', syntax: 'lark', definition: 'start: source' },
+}
+
+describe('encodeToolSpec', () => {
+  it('encodes a freeform tool with the mandatory exact format object', () => {
+    expect(encodeToolSpec({ kind: 'freeform', tool: GRAMMAR_TOOL })).toEqual({
+      type: 'custom',
+      name: 'exec',
+      description: 'Run JavaScript',
+      format: { type: 'grammar', syntax: 'lark', definition: 'start: source' },
+    })
+  })
+
+  it('encodes a function tool with inputSchema under the wire key `parameters`', () => {
+    const spec: ModelToolSpec = {
+      kind: 'function',
+      tool: {
+        name: 'get_weather',
+        description: 'Fetch the weather',
+        inputSchema: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+    }
+    expect(encodeToolSpec(spec)).toEqual({
+      type: 'function',
+      name: 'get_weather',
+      description: 'Fetch the weather',
+      parameters: { type: 'object', properties: { city: { type: 'string' } } },
+    })
+  })
+
+  it("defaults TypeScript's optional description/inputSchema to '' and {}", () => {
+    expect(encodeToolSpec({ kind: 'function', tool: { name: 'noop' } })).toEqual({
+      type: 'function',
+      name: 'noop',
+      description: '',
+      parameters: {},
+    })
+  })
+
+  it('encodeTools maps every spec in order', () => {
+    expect(
+      encodeTools([
+        { kind: 'function', tool: { name: 'a', description: 'A', inputSchema: {} } },
+        { kind: 'freeform', tool: GRAMMAR_TOOL },
+      ]).map((t) => t.type),
+    ).toEqual(['function', 'custom'])
+  })
+})
+
+describe('encodeToolCall', () => {
+  it('encodes a freeform call as custom_tool_call with id under call_id', () => {
+    expect(
+      encodeToolCall({ kind: 'freeform', id: 'call_js', name: 'exec', input: 'console.log(1);' }),
+    ).toEqual({
+      type: 'custom_tool_call',
+      call_id: 'call_js',
+      name: 'exec',
+      input: 'console.log(1);',
+    })
+  })
+
+  it('encodes a function call as function_call with a string arguments field', () => {
+    expect(
+      encodeToolCall({
+        kind: 'function',
+        id: 'call_1',
+        name: 'get_weather',
+        arguments: '{"city":"Paris"}',
+      }),
+    ).toEqual({
+      type: 'function_call',
+      call_id: 'call_1',
+      name: 'get_weather',
+      arguments: '{"city":"Paris"}',
+    })
+  })
+
+  it('preserves freeform input byte-for-byte and never parses it as JSON', () => {
+    const raw = '{"this":"looks like json"}\nconsole.log(\'but is JS\');'
+    const encoded = encodeToolCall({ kind: 'freeform', id: 'call_js', name: 'exec', input: raw })
+    expect(encoded.input).toBe(raw)
+    expect(typeof encoded.input).toBe('string')
+  })
+})
+
+describe('encodeToolOutput', () => {
+  it('encodes a function output', () => {
+    expect(encodeToolOutput({ kind: 'function', callId: 'call_1', output: 'sunny, 21C' })).toEqual({
+      type: 'function_call_output',
+      call_id: 'call_1',
+      output: 'sunny, 21C',
+    })
+  })
+
+  it('encodes a custom output and drops `name` (mirrors Rust encode_tool_output)', () => {
+    expect(
+      encodeToolOutput({ kind: 'custom', callId: 'call_js', name: 'exec', output: 'stdout: 42' }),
+    ).toEqual({
+      type: 'custom_tool_call_output',
+      call_id: 'call_js',
+      output: 'stdout: 42',
+    })
+  })
+
+  it('encodes a content-item payload with snake_case wire keys', () => {
+    expect(
+      encodeToolOutput({
+        kind: 'function',
+        callId: 'call_1',
+        output: [
+          { type: 'input_text', text: 'hi' },
+          { type: 'input_image', imageUrl: 'https://e.example/a.png', detail: 'high' },
+          { type: 'encrypted_content', encryptedContent: 'zzz' },
+        ],
+      }),
+    ).toEqual({
+      type: 'function_call_output',
+      call_id: 'call_1',
+      output: [
+        { type: 'input_text', text: 'hi' },
+        { type: 'input_image', image_url: 'https://e.example/a.png', detail: 'high' },
+        { type: 'encrypted_content', encrypted_content: 'zzz' },
+      ],
+    })
+  })
+})
+
+describe('encodeContextItem / encodeInput', () => {
+  it('drops system messages from input', () => {
+    expect(
+      encodeContextItem({ kind: 'message', message: { role: 'system', content: 'be terse' } }),
+    ).toEqual([])
+  })
+
+  it('encodes a user message as a message item with input_text', () => {
+    expect(
+      encodeContextItem({ kind: 'message', message: { role: 'user', content: 'run js' } }),
+    ).toEqual([
+      { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'run js' }] },
+    ])
+  })
+
+  it('encodes user image blocks as input_image data URLs', () => {
+    expect(
+      encodeContextItem({
+        kind: 'message',
+        message: {
+          role: 'user',
+          content: 'inspect',
+          contentBlocks: [
+            { type: 'text', text: 'inspect' },
+            { type: 'image', source: { type: 'base64', mediaType: 'image/png', data: 'abc123' } },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'inspect' },
+          { type: 'input_image', image_url: 'data:image/png;base64,abc123' },
+        ],
+      },
+    ])
+  })
+
+  it('splits an assistant message with tool calls into text + function_call items', () => {
+    expect(
+      encodeContextItem({
+        kind: 'message',
+        message: {
+          role: 'assistant',
+          content: 'let me look',
+          toolCalls: [{ id: 'call_1', name: 'get_weather', input: { city: 'Paris' } }],
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'let me look' }],
+      },
+      {
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'get_weather',
+        arguments: '{"city":"Paris"}',
+      },
+    ])
+  })
+
+  it('encodes a tool-role message as a function_call_output', () => {
+    expect(
+      encodeContextItem({
+        kind: 'message',
+        message: { role: 'tool', content: 'sunny', toolCallId: 'call_1' },
+      }),
+    ).toEqual([{ type: 'function_call_output', call_id: 'call_1', output: 'sunny' }])
+  })
+
+  it('preserves mixed message / toolCall / toolOutput order', () => {
+    const items = encodeInput([
+      { kind: 'message', message: { role: 'user', content: 'run it' } },
+      {
+        kind: 'toolCall',
+        call: { kind: 'freeform', id: 'call_js', name: 'exec', input: 'console.log(1);' },
+      },
+      {
+        kind: 'toolOutput',
+        output: { kind: 'custom', callId: 'call_js', name: 'exec', output: '1\n' },
+      },
+    ])
+    expect(items.map((item) => item.type)).toEqual([
+      'message',
+      'custom_tool_call',
+      'custom_tool_call_output',
+    ])
+  })
+})

--- a/sdks/typescript/tests/serialize.responses.test.ts
+++ b/sdks/typescript/tests/serialize.responses.test.ts
@@ -12,14 +12,36 @@ import {
   encodeTools,
   encodeToolSpec,
   modelChatResponseFromOutput,
+  modelStreamAdapter,
   stopReasonFromStatus,
 } from '../src/serialize/responses.js'
-import type { FreeformTool, ModelChatRequest, ModelToolSpec } from '../src/types.js'
+import { IncompleteStreamError, StreamError } from '../src/error.js'
+import type {
+  FreeformTool,
+  ModelChatRequest,
+  ModelStreamDelta,
+  ModelToolSpec,
+} from '../src/types.js'
 
 const GRAMMAR_TOOL: FreeformTool = {
   name: 'exec',
   description: 'Run JavaScript',
   format: { type: 'grammar', syntax: 'lark', definition: 'start: source' },
+}
+
+function sseBody(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text))
+      controller.close()
+    },
+  })
+}
+
+async function drainDeltas(sse: string, provider = 'openai'): Promise<ModelStreamDelta[]> {
+  const deltas: ModelStreamDelta[] = []
+  for await (const delta of modelStreamAdapter(sseBody(sse), provider)) deltas.push(delta)
+  return deltas
 }
 
 describe('encodeToolSpec', () => {
@@ -599,5 +621,170 @@ describe('modelChatResponseFromOutput', () => {
   it('omits thinking entirely when there is no reasoning summary', () => {
     const response = modelChatResponseFromOutput({ status: 'completed' }, 'm')
     expect('thinking' in response).toBe(false)
+  })
+})
+
+describe('modelStreamAdapter', () => {
+  it('decodes custom tool input deltas plus an authoritative tool_call_done', async () => {
+    const sse =
+      'data: {"type":"response.custom_tool_call_input.delta","call_id":"call_js","delta":"console."}\n\n' +
+      'data: {"type":"response.custom_tool_call_input.delta","call_id":"call_js","delta":"log(1);\\n"}\n\n' +
+      'data: {"type":"response.output_item.done","item":{"type":"custom_tool_call","call_id":"call_js","name":"exec","input":"console.log(1);\\n"}}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":3}}}\n\n'
+
+    expect(await drainDeltas(sse)).toEqual([
+      { type: 'freeform_input', callId: 'call_js', delta: 'console.' },
+      { type: 'freeform_input', callId: 'call_js', delta: 'log(1);\n' },
+      {
+        type: 'tool_call_done',
+        call: { kind: 'freeform', id: 'call_js', name: 'exec', input: 'console.log(1);\n' },
+      },
+      { type: 'usage', usage: { inputTokens: 2, outputTokens: 3 } },
+      { type: 'done', stopReason: 'tool_use' },
+    ])
+  })
+
+  it('emits text deltas and skips empty ones', async () => {
+    const sse =
+      'data: {"type":"response.output_text.delta","delta":"hel"}\n\n' +
+      'data: {"type":"response.output_text.delta","delta":""}\n\n' +
+      'data: {"type":"response.output_text.delta","delta":"lo"}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+
+    expect(await drainDeltas(sse)).toEqual([
+      { type: 'text', delta: 'hel' },
+      { type: 'text', delta: 'lo' },
+      { type: 'done', stopReason: 'end_turn' },
+    ])
+  })
+
+  it('emits thinking deltas and a thinking_done from both reasoning families', async () => {
+    const sse =
+      'data: {"type":"response.reasoning_text.delta","delta":"think "}\n\n' +
+      'data: {"type":"response.reasoning_summary_text.delta","delta":"hard"}\n\n' +
+      'data: {"type":"response.reasoning_summary_text.done","text":"think hard"}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+
+    expect(await drainDeltas(sse)).toEqual([
+      { type: 'thinking_delta', delta: 'think ' },
+      { type: 'thinking_delta', delta: 'hard' },
+      { type: 'thinking_done', thinking: 'think hard' },
+      { type: 'done', stopReason: 'end_turn' },
+    ])
+  })
+
+  it('resolves call_id through the item map when frames are keyed by item_id', async () => {
+    const sse =
+      'data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"f"}}\n\n' +
+      'data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\\"a\\":1}"}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+
+    expect(await drainDeltas(sse)).toEqual([
+      { type: 'function_arguments', callId: 'call_1', delta: '{"a":1}' },
+      { type: 'done', stopReason: 'tool_use' },
+    ])
+  })
+
+  it('falls back to the raw item_id when the map has no entry', async () => {
+    const sse =
+      'data: {"type":"response.function_call_arguments.delta","item_id":"fc_orphan","delta":"x"}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+
+    expect(await drainDeltas(sse)).toEqual([
+      { type: 'function_arguments', callId: 'fc_orphan', delta: 'x' },
+      { type: 'done', stopReason: 'end_turn' },
+    ])
+  })
+
+  it('maps response.incomplete to a max_tokens done', async () => {
+    const sse =
+      'data: {"type":"response.output_text.delta","delta":"partial"}\n\n' +
+      'data: {"type":"response.incomplete","response":{"status":"incomplete","usage":{"input_tokens":6,"output_tokens":7}}}\n\n'
+
+    expect(await drainDeltas(sse)).toEqual([
+      { type: 'text', delta: 'partial' },
+      { type: 'usage', usage: { inputTokens: 6, outputTokens: 7 } },
+      { type: 'done', stopReason: 'max_tokens' },
+    ])
+  })
+
+  it('omits the usage delta when the terminal frame carries no usage', async () => {
+    const sse = 'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+    expect(await drainDeltas(sse)).toEqual([{ type: 'done', stopReason: 'end_turn' }])
+  })
+
+  it('ignores empty, [DONE], malformed and unknown frames', async () => {
+    const sse =
+      'data: \n\n' +
+      'data: [DONE]\n\n' +
+      'data: {not json}\n\n' +
+      'data: {"type":"response.unknown"}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+    expect(await drainDeltas(sse)).toEqual([{ type: 'done', stopReason: 'end_turn' }])
+  })
+
+  it('drains pending deltas before surfacing a stream error frame', async () => {
+    const sse =
+      'data: {"type":"response.output_text.delta","delta":"before"}\n\n' +
+      'data: {"type":"error","message":"upstream exploded"}\n\n'
+
+    const deltas: ModelStreamDelta[] = []
+    let caught: unknown
+    try {
+      for await (const delta of modelStreamAdapter(sseBody(sse), 'openai')) deltas.push(delta)
+    } catch (error) {
+      caught = error
+    }
+    expect(deltas).toEqual([{ type: 'text', delta: 'before' }])
+    expect(caught).toBeInstanceOf(StreamError)
+    expect((caught as Error).message).toBe('upstream exploded')
+  })
+
+  it('uses the nested response.error.message, then error.message, then a fallback', async () => {
+    const nested =
+      'data: {"type":"response.failed","response":{"error":{"message":"nested boom"}}}\n\n'
+    await expect(drainDeltas(nested)).rejects.toThrow('nested boom')
+
+    const top = 'data: {"type":"error","error":{"message":"top boom"}}\n\n'
+    await expect(drainDeltas(top)).rejects.toThrow('top boom')
+
+    const bare = 'data: {"type":"error"}\n\n'
+    await expect(drainDeltas(bare)).rejects.toThrow('responses stream error')
+  })
+
+  it('throws IncompleteStreamError with the openai payload on EOF without a terminal', async () => {
+    const sse =
+      'data: {"type":"response.output_text.delta","delta":"hel"}\n\n' +
+      'data: {"type":"response.output_text.delta","delta":"lo"}\n\n'
+
+    const deltas: ModelStreamDelta[] = []
+    let caught: unknown
+    try {
+      for await (const delta of modelStreamAdapter(sseBody(sse), 'openai')) deltas.push(delta)
+    } catch (error) {
+      caught = error
+    }
+    expect(deltas.some((d) => d.type === 'done')).toBe(false)
+    expect(caught).toBeInstanceOf(IncompleteStreamError)
+    expect(caught).toBeInstanceOf(StreamError)
+    expect((caught as Error).message).toBe(
+      'incomplete stream: openai ended without a terminal event',
+    )
+  })
+
+  it('uses the hyphenated chatgpt-codex provider token on the native path', async () => {
+    const sse =
+      'data: {"type":"response.custom_tool_call_input.delta","call_id":"call_js","delta":"console."}\n\n'
+    await expect(drainDeltas(sse, 'chatgpt-codex')).rejects.toThrow(
+      'incomplete stream: chatgpt-codex ended without a terminal event',
+    )
+  })
+
+  it('emits exactly one done even when frames follow the terminal', async () => {
+    const sse =
+      'data: {"type":"response.completed","response":{"status":"completed"}}\n\n' +
+      'data: {"type":"response.output_text.delta","delta":"trailing"}\n\n'
+    const deltas = await drainDeltas(sse)
+    expect(deltas.filter((d) => d.type === 'done')).toHaveLength(1)
   })
 })

--- a/sdks/typescript/tests/serialize.responses.test.ts
+++ b/sdks/typescript/tests/serialize.responses.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildModelRequestBody,
   encodeContextItem,
   encodeInput,
   encodeToolCall,
@@ -7,7 +8,7 @@ import {
   encodeTools,
   encodeToolSpec,
 } from '../src/serialize/responses.js'
-import type { FreeformTool, ModelToolSpec } from '../src/types.js'
+import type { FreeformTool, ModelChatRequest, ModelToolSpec } from '../src/types.js'
 
 const GRAMMAR_TOOL: FreeformTool = {
   name: 'exec',
@@ -230,5 +231,166 @@ describe('encodeContextItem / encodeInput', () => {
       'custom_tool_call',
       'custom_tool_call_output',
     ])
+  })
+})
+
+describe('buildModelRequestBody', () => {
+  it('uses the request model, falling back to the provider default', () => {
+    expect(
+      buildModelRequestBody({ context: [], model: 'gpt-5.5-codex' }, 'gpt-5.5', false).model,
+    ).toBe('gpt-5.5-codex')
+    expect(buildModelRequestBody({ context: [] }, 'gpt-5.5', false).model).toBe('gpt-5.5')
+  })
+
+  it('sets stream only when asked', () => {
+    expect(buildModelRequestBody({ context: [] }, 'm', false).stream).toBeUndefined()
+    expect(buildModelRequestBody({ context: [] }, 'm', true).stream).toBe(true)
+  })
+
+  it('hoists a system message into instructions AND removes it from input', () => {
+    const body = buildModelRequestBody(
+      {
+        context: [
+          { kind: 'message', message: { role: 'system', content: 'be terse' } },
+          { kind: 'message', message: { role: 'user', content: 'hi' } },
+        ],
+      },
+      'm',
+      false,
+    )
+    expect(body.instructions).toBe('be terse')
+    expect(body.input).toHaveLength(1)
+    expect((body.input as Record<string, unknown>[])[0].role).toBe('user')
+  })
+
+  it('prefers systemBlocks over system and joins with a blank line', () => {
+    const body = buildModelRequestBody(
+      {
+        context: [],
+        system: 'ignored',
+        systemBlocks: [{ text: 'a' }, { text: '  ' }, { text: 'b' }],
+      },
+      'm',
+      false,
+    )
+    expect(body.instructions).toBe('a\n\nb')
+  })
+
+  it('appends hoisted system messages after system/systemBlocks', () => {
+    const body = buildModelRequestBody(
+      {
+        context: [{ kind: 'message', message: { role: 'system', content: 'second' } }],
+        system: 'first',
+      },
+      'm',
+      false,
+    )
+    expect(body.instructions).toBe('first\n\nsecond')
+  })
+
+  it('falls back to defaultInstructions only when nothing was supplied', () => {
+    expect(
+      buildModelRequestBody({ context: [] }, 'm', false, 'You are a helpful assistant.')
+        .instructions,
+    ).toBe('You are a helpful assistant.')
+    expect(
+      buildModelRequestBody({ context: [], system: 'given' }, 'm', false, 'default').instructions,
+    ).toBe('given')
+    expect(buildModelRequestBody({ context: [] }, 'm', false).instructions).toBeUndefined()
+  })
+
+  it('maps maxTokens to max_output_tokens and never emits max_tokens', () => {
+    const body = buildModelRequestBody({ context: [], maxTokens: 512 }, 'm', false)
+    expect(body.max_output_tokens).toBe(512)
+    expect(body.max_tokens).toBeUndefined()
+  })
+
+  it('emits temperature, tool_choice and stop when set', () => {
+    const body = buildModelRequestBody(
+      {
+        context: [],
+        temperature: 0.3,
+        toolChoice: { type: 'tool', name: 'exec' },
+        stopSequences: ['STOP'],
+      },
+      'm',
+      false,
+    )
+    expect(body.temperature).toBe(0.3)
+    expect(body.tool_choice).toEqual({ type: 'function', name: 'exec' })
+    expect(body.stop).toEqual(['STOP'])
+  })
+
+  it('maps the string tool choices', () => {
+    expect(
+      buildModelRequestBody({ context: [], toolChoice: { type: 'auto' } }, 'm', false)
+        .tool_choice,
+    ).toBe('auto')
+    expect(
+      buildModelRequestBody({ context: [], toolChoice: { type: 'required' } }, 'm', false)
+        .tool_choice,
+    ).toBe('required')
+    expect(
+      buildModelRequestBody({ context: [], toolChoice: { type: 'none' } }, 'm', false)
+        .tool_choice,
+    ).toBe('none')
+  })
+
+  it('omits stop for an empty stopSequences array', () => {
+    expect(buildModelRequestBody({ context: [], stopSequences: [] }, 'm', false).stop).toBeUndefined()
+  })
+
+  it('omits tools when there are no tool specs', () => {
+    expect(buildModelRequestBody({ context: [] }, 'm', false).tools).toBeUndefined()
+    expect(buildModelRequestBody({ context: [], toolSpecs: [] }, 'm', false).tools).toBeUndefined()
+  })
+
+  it('shallow-merges providerOptions LAST so it overrides encoder output', () => {
+    const body = buildModelRequestBody(
+      {
+        context: [],
+        temperature: 0.1,
+        providerOptions: { temperature: 0.9, reasoning_effort: 'high', custom: 1 },
+      },
+      'm',
+      false,
+    )
+    expect(body.temperature).toBe(0.9)
+    expect(body.reasoning_effort).toBe('high')
+    expect(body.custom).toBe(1)
+  })
+
+  it('replays a symmetric freeform history byte-exact and in order', () => {
+    const raw = '{"this":"looks like json"}\nconsole.log(\'but is JS\');'
+    const req: ModelChatRequest = {
+      context: [
+        { kind: 'message', message: { role: 'user', content: 'run js' } },
+        { kind: 'toolCall', call: { kind: 'freeform', id: 'call_js', name: 'exec', input: raw } },
+        {
+          kind: 'toolOutput',
+          output: { kind: 'custom', callId: 'call_js', name: 'exec', output: 'done' },
+        },
+      ],
+      toolSpecs: [
+        {
+          kind: 'freeform',
+          tool: {
+            name: 'exec',
+            description: 'Run JavaScript',
+            format: { type: 'grammar', syntax: 'lark', definition: 'start: source' },
+          },
+        },
+      ],
+    }
+    const body = buildModelRequestBody(req, 'gpt-5.5-codex', false)
+    const input = body.input as Record<string, unknown>[]
+    expect(input.map((item) => item.type)).toEqual([
+      'message',
+      'custom_tool_call',
+      'custom_tool_call_output',
+    ])
+    expect(input[1].input).toBe(raw)
+    expect(input[1].call_id).toBe('call_js')
+    expect((body.tools as Record<string, unknown>[])[0].type).toBe('custom')
   })
 })


### PR DESCRIPTION
Task group T1 of the Freeform parity milestone (#270). Adds the native model type family to `types.ts` and the shared `serialize/responses.ts` codec (encoders, decoders, SSE adapter). No provider wiring — that is T2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)