### PR TITLE
feat: wire the native model API into the Python providers and Client (#270)

### DIFF
--- a/sdks/python/motosan_ai/__init__.py
+++ b/sdks/python/motosan_ai/__init__.py
@@ -1,5 +1,5 @@
 from motosan_ai import oauth
-from motosan_ai._stream_collect import collect_stream
+from motosan_ai._stream_collect import collect_model_stream, collect_stream
 from motosan_ai.client import Client, Provider
 from motosan_ai.error import (
     AuthError,
@@ -182,6 +182,7 @@ __all__ = [
     "ToolChoice",
     "UnsupportedFeatureError",
     "Usage",
+    "collect_model_stream",
     "collect_stream",
     "oauth",
 ]

--- a/sdks/python/motosan_ai/_stream_collect.py
+++ b/sdks/python/motosan_ai/_stream_collect.py
@@ -6,7 +6,25 @@ import json
 from collections.abc import AsyncIterator
 from typing import Any
 
-from motosan_ai.types import ChatResponse, StopReason, StreamEvent, ToolCall, Usage
+from motosan_ai.types import (
+    ChatResponse,
+    ModelChatResponse,
+    ModelStreamDelta,
+    ModelStreamDone,
+    ModelStreamFreeformInput,
+    ModelStreamFunctionArguments,
+    ModelStreamText,
+    ModelStreamThinkingDelta,
+    ModelStreamThinkingDone,
+    ModelStreamToolCallDone,
+    ModelStreamUsage,
+    ModelToolCall,
+    ModelToolCallFreeform,
+    StopReason,
+    StreamEvent,
+    ToolCall,
+    Usage,
+)
 
 
 async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
@@ -105,4 +123,77 @@ async def collect_stream(events: AsyncIterator[StreamEvent]) -> ChatResponse:
         stop_reason=stop_reason,
         thinking=thinking,
         session_id=session_id,
+    )
+
+
+async def collect_model_stream(deltas: AsyncIterator[ModelStreamDelta]) -> ModelChatResponse:
+    """Collect a native model stream into one ModelChatResponse.
+
+    Unlike ``collect_stream``, this carries native function and freeform tool
+    calls without lowering freeform input into JSON arguments.
+
+    Three rules differ from the legacy collector and are contract, not taste:
+    ``ModelStreamToolCallDone`` is authoritative (accumulated deltas are
+    discarded, never merged); ``ModelStreamUsage`` REPLACES rather than
+    merging field-by-field; and ``model`` is left empty for the caller to
+    backfill. A mid-stream provider error raised by ``deltas`` propagates out
+    uncollected.
+    """
+    content = ""
+    thinking_delta_buf = ""
+    thinking_done_buf: str | None = None
+    function_arguments: dict[str, str] = {}
+    freeform_inputs: dict[str, str] = {}
+    tool_calls: list[ModelToolCall] = []
+    usage = Usage(0, 0)
+    explicit_stop_reason: StopReason | None = None
+
+    async for delta in deltas:
+        if isinstance(delta, ModelStreamText):
+            content += delta.delta
+        elif isinstance(delta, ModelStreamThinkingDelta):
+            thinking_delta_buf += delta.delta
+        elif isinstance(delta, ModelStreamThinkingDone):
+            # Carries the full text; wins over the accumulator. Clearing the
+            # delta buffer lets a second block start fresh.
+            thinking_done_buf = delta.thinking
+            thinking_delta_buf = ""
+        elif isinstance(delta, ModelStreamFunctionArguments):
+            function_arguments[delta.call_id] = (
+                function_arguments.get(delta.call_id, "") + delta.delta
+            )
+        elif isinstance(delta, ModelStreamFreeformInput):
+            freeform_inputs[delta.call_id] = freeform_inputs.get(delta.call_id, "") + delta.delta
+        elif isinstance(delta, ModelStreamToolCallDone):
+            # Authoritative: drop the bookkeeping, keep what the provider sent.
+            if isinstance(delta.call, ModelToolCallFreeform):
+                freeform_inputs.pop(delta.call.id, None)
+            else:
+                function_arguments.pop(delta.call.id, None)
+            tool_calls.append(delta.call)
+        elif isinstance(delta, ModelStreamUsage):
+            # Replaces, never merges.
+            usage = delta.usage
+        elif isinstance(delta, ModelStreamDone):
+            explicit_stop_reason = delta.stop_reason
+            break
+
+    if thinking_done_buf is not None:
+        thinking = thinking_done_buf or None
+    else:
+        thinking = thinking_delta_buf or None
+
+    if explicit_stop_reason is not None:
+        stop_reason = explicit_stop_reason
+    else:
+        stop_reason = StopReason.tool_use if tool_calls else StopReason.end_turn
+
+    return ModelChatResponse(
+        content=content,
+        thinking=thinking,
+        tool_calls=tool_calls,
+        model="",
+        usage=usage,
+        stop_reason=stop_reason,
+        session_id=None,
     )

--- a/sdks/python/motosan_ai/client.py
+++ b/sdks/python/motosan_ai/client.py
@@ -9,7 +9,15 @@ from enum import StrEnum
 from types import TracebackType
 from typing import Any
 
-from motosan_ai.error import ConfigError, MotosanError, NetworkError, ProviderError, RateLimitError
+from motosan_ai.error import (
+    ConfigError,
+    MotosanError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    UnsupportedFeatureError,
+)
+from motosan_ai.provider_base import validate_model_request as _validate_model_request
 from motosan_ai.provider_base import validate_request as _validate_request
 from motosan_ai.providers import (
     AnthropicProvider,
@@ -25,7 +33,16 @@ from motosan_ai.providers import (
 )
 from motosan_ai.retry import RetryPolicy
 from motosan_ai.think_stripper import ThinkStripper
-from motosan_ai.types import ChatRequest, ChatResponse, Message, StreamEvent, Tool
+from motosan_ai.types import (
+    ChatRequest,
+    ChatResponse,
+    Message,
+    ModelChatRequest,
+    ModelChatResponse,
+    ModelStreamDelta,
+    StreamEvent,
+    Tool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +99,7 @@ class Client:
         ollama_think: bool = False,
         ollama_keep_alive: str | None = None,
         ollama_num_ctx: int | None = None,
+        openai_responses_api: bool = False,
         max_retries: int = 3,
         retry_policy: RetryPolicy | None = None,
         connect_timeout: float = 10.0,
@@ -192,6 +210,10 @@ class Client:
                     api_key=self.api_key,
                     model=model,
                     base_url=base_url,
+                    # Native opt-in. Deliberately not threaded into the
+                    # Provider.ollama branch above: Ollama's OpenAI-compatible
+                    # endpoint has no Responses API.
+                    responses_api=openai_responses_api,
                     connect_timeout=connect_timeout,
                     read_idle_timeout=read_idle_timeout,
                 )
@@ -235,6 +257,8 @@ class Client:
         model: str | None = None,
         max_retries: int = 3,
         retry_policy: RetryPolicy | None = None,
+        *,
+        openai_responses_api: bool = False,
     ) -> Client:
         return cls(
             provider=Provider.openai,
@@ -242,6 +266,7 @@ class Client:
             model=model,
             max_retries=max_retries,
             retry_policy=retry_policy,
+            openai_responses_api=openai_responses_api,
         )
 
     @classmethod
@@ -637,4 +662,105 @@ class Client:
         response = await collect_stream(self.stream_with(request))
         if not response.model:
             response = replace(response, model=model_hint)
+        return response
+
+    def _prepare_model_request(self, request: ModelChatRequest) -> ModelChatRequest:
+        """Backfill the model and run capability enforcement before dispatch."""
+        if request.model is None and self.model is not None:
+            request = replace(request, model=self.model)
+
+        caps = getattr(self._provider, "capabilities", None)
+        if caps is not None:
+            _validate_model_request(request, caps)
+        return request
+
+    async def model_chat_with(self, request: ModelChatRequest) -> ModelChatResponse:
+        """Send a fully-built native ModelChatRequest.
+
+        The native counterpart of ``chat_with``. ``total_timeout`` bounds this
+        call (retries included), never stream consumption.
+        """
+        request = self._prepare_model_request(request)
+        if self._total_timeout is None:
+            return await self._dispatch_model_chat(request)
+        try:
+            async with asyncio.timeout(self._total_timeout):
+                return await self._dispatch_model_chat(request)
+        except TimeoutError as exc:
+            raise NetworkError(f"total timeout of {self._total_timeout}s exceeded") from exc
+
+    async def _dispatch_model_chat(self, request: ModelChatRequest) -> ModelChatResponse:
+        # Duck-typed on purpose: BaseProvider is subclassed by only 4 of the 11
+        # providers, so a default on the ABC would never reach OpenAIProvider
+        # or the CLI clients. Mirrors the 0.19.0 capability enforcement.
+        model_chat = getattr(self._provider, "model_chat", None)
+        if model_chat is None:
+            raise UnsupportedFeatureError("provider does not support native model requests")
+
+        if self._retry_policy.max_retries > 0:
+            from motosan_ai.retry import with_retry
+
+            return await with_retry(lambda: model_chat(request), policy=self._retry_policy)
+        return await model_chat(request)
+
+    async def model_stream_with(self, request: ModelChatRequest) -> AsyncIterator[ModelStreamDelta]:
+        """Stream a fully-built native ModelChatRequest.
+
+        No ThinkStripper here: native streams carry thinking as explicit
+        ModelStreamThinkingDelta / ModelStreamThinkingDone deltas, and the
+        read-idle timeout already lives in the provider's httpx client.
+        """
+        request = self._prepare_model_request(request)
+        model_stream = getattr(self._provider, "model_stream", None)
+        if model_stream is None:
+            raise UnsupportedFeatureError("provider does not support native model streams")
+
+        policy = self._retry_policy
+        last_error: MotosanError | None = None
+        max_attempts = policy.max_retries + 1 if policy.max_retries > 0 else 1
+        for attempt in range(max_attempts):
+            yielded = False
+            try:
+                async for delta in model_stream(request):
+                    yielded = True
+                    yield delta
+                return
+            except (RateLimitError, NetworkError, ProviderError) as e:
+                from motosan_ai.retry import (
+                    RetryEvent,
+                    _is_retryable,
+                    compute_delay,
+                    retry_cause,
+                )
+
+                # Once any delta has been emitted a mid-stream error must
+                # propagate verbatim; retrying would replay delivered deltas.
+                if yielded or not _is_retryable(e):
+                    raise
+                last_error = e
+                if attempt >= policy.max_retries:
+                    break
+                wait = compute_delay(policy, attempt + 1, e.retry_after)
+                if policy.on_retry is not None:
+                    policy.on_retry(
+                        RetryEvent(attempt=attempt + 1, delay=wait, cause=retry_cause(e))
+                    )
+                logger.warning(
+                    "Retryable native stream error (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1,
+                    policy.max_retries,
+                    wait,
+                    type(e).__name__,
+                )
+                await asyncio.sleep(wait)
+        raise last_error  # type: ignore[misc]
+
+    async def model_stream_collect_with(self, request: ModelChatRequest) -> ModelChatResponse:
+        """Stream a native request and assemble the full ModelChatResponse."""
+        from motosan_ai._stream_collect import collect_model_stream
+
+        model_hint = request.model or self.model or ""
+        response = await collect_model_stream(self.model_stream_with(request))
+        if not response.model:
+            response.model = model_hint
         return response

--- a/sdks/python/motosan_ai/provider_base.py
+++ b/sdks/python/motosan_ai/provider_base.py
@@ -4,26 +4,52 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 
-from motosan_ai.error import InvalidRequestError
-from motosan_ai.types import ChatRequest, ChatResponse, DocumentBlock, ImageBlock, StreamEvent
+from motosan_ai.error import InvalidRequestError, UnsupportedFeatureError
+from motosan_ai.types import (
+    ChatRequest,
+    ChatResponse,
+    DocumentBlock,
+    ImageBlock,
+    ModelChatRequest,
+    ModelContextMessage,
+    ModelContextToolCall,
+    ModelContextToolOutput,
+    ModelToolCallFreeform,
+    ModelToolOutputCustom,
+    ModelToolSpecFreeform,
+    StreamEvent,
+)
 
 
 @dataclass(frozen=True)
 class ProviderCapabilities:
     supports_image: bool
     supports_document: bool
+    # Defaulted so existing two-argument construction keeps working.
+    supports_freeform_tools: bool = False
 
     @classmethod
     def text_only(cls) -> ProviderCapabilities:
-        return cls(supports_image=False, supports_document=False)
+        return cls(supports_image=False, supports_document=False, supports_freeform_tools=False)
 
     @classmethod
     def with_image(cls) -> ProviderCapabilities:
-        return cls(supports_image=True, supports_document=False)
+        return cls(supports_image=True, supports_document=False, supports_freeform_tools=False)
+
+    @classmethod
+    def with_freeform_tools(cls) -> ProviderCapabilities:
+        return cls(supports_image=False, supports_document=False, supports_freeform_tools=True)
+
+    @classmethod
+    def with_image_and_freeform_tools(cls) -> ProviderCapabilities:
+        return cls(supports_image=True, supports_document=False, supports_freeform_tools=True)
 
     @classmethod
     def full(cls) -> ProviderCapabilities:
-        return cls(supports_image=True, supports_document=True)
+        # Rust parity: full() is image + document and deliberately leaves
+        # freeform False. A provider that claimed freeform support it lacks
+        # is exactly what this flag exists to prevent.
+        return cls(supports_image=True, supports_document=True, supports_freeform_tools=False)
 
 
 def validate_request(request: ChatRequest, capabilities: ProviderCapabilities) -> None:
@@ -40,11 +66,43 @@ def validate_request(request: ChatRequest, capabilities: ProviderCapabilities) -
                 raise InvalidRequestError("provider does not support document input")
 
 
+def validate_model_request(request: ModelChatRequest, capabilities: ProviderCapabilities) -> None:
+    """Reject native model requests the capabilities do not support, pre-network.
+
+    Mirrors Rust ``ProviderImpl::validate_model_request`` minus the three
+    reject-only fields (thinking / mcp_servers / mcp_tool_configs), which the
+    Python ``ModelChatRequest`` deliberately does not carry (milestone D3).
+    """
+    has_freeform_spec = any(isinstance(spec, ModelToolSpecFreeform) for spec in request.tool_specs)
+    has_freeform_history = any(
+        (isinstance(item, ModelContextToolCall) and isinstance(item.call, ModelToolCallFreeform))
+        or (
+            isinstance(item, ModelContextToolOutput)
+            and isinstance(item.output, ModelToolOutputCustom)
+        )
+        for item in request.context
+    )
+    if (has_freeform_spec or has_freeform_history) and not capabilities.supports_freeform_tools:
+        raise UnsupportedFeatureError("provider does not support native freeform tools")
+
+    for item in request.context:
+        if not isinstance(item, ModelContextMessage):
+            continue
+        for block in item.message.content_blocks:
+            if isinstance(block, ImageBlock) and not capabilities.supports_image:
+                raise UnsupportedFeatureError("provider does not support image input")
+            if isinstance(block, DocumentBlock) and not capabilities.supports_document:
+                raise UnsupportedFeatureError("provider does not support document input")
+
+
 class BaseProvider(ABC):
     capabilities: ProviderCapabilities = ProviderCapabilities.text_only()
 
     def validate_request(self, request: ChatRequest) -> None:
         validate_request(request, self.capabilities)
+
+    def validate_model_request(self, request: ModelChatRequest) -> None:
+        validate_model_request(request, self.capabilities)
 
     @abstractmethod
     async def chat(self, request: ChatRequest) -> ChatResponse: ...

--- a/sdks/python/motosan_ai/providers/chatgpt_codex.py
+++ b/sdks/python/motosan_ai/providers/chatgpt_codex.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import httpx
 
-from motosan_ai._stream_collect import collect_stream
+from motosan_ai._stream_collect import collect_model_stream, collect_stream
 from motosan_ai.error import (
     AuthError,
     ConfigError,
@@ -19,10 +19,19 @@ from motosan_ai.error import (
     StreamReadTimeoutError,
 )
 from motosan_ai.provider_base import BaseProvider, ProviderCapabilities
+from motosan_ai.providers.responses import (
+    ModelStreamState,
+    build_model_request_body,
+    parse_model_sse_event,
+)
 from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
     ChatRequest,
     ChatResponse,
+    ModelChatRequest,
+    ModelChatResponse,
+    ModelStreamDelta,
+    ModelStreamDone,
     Role,
     StopReason,
     StreamEvent,
@@ -197,7 +206,7 @@ def _parse_sse_event(data: str, state: _ChatGptCodexAdapterState) -> list[Stream
 
 
 class ChatGptCodexProvider(BaseProvider):
-    capabilities: ProviderCapabilities = ProviderCapabilities.text_only()
+    capabilities: ProviderCapabilities = ProviderCapabilities.with_freeform_tools()
 
     def __init__(
         self,
@@ -378,6 +387,42 @@ class ChatGptCodexProvider(BaseProvider):
 
         return body
 
+    def build_model_responses_body(self, request: ModelChatRequest) -> dict[str, Any]:
+        """Encode a native ModelChatRequest into the ChatGPT-backend body.
+
+        The four hard overrides below are applied AFTER the shared codec, and
+        the codec already shallow-merged ``provider_options`` — so these beat
+        both the caller's ``provider_options`` AND an explicit
+        ``request.tool_choice``. That is deliberate Rust parity.
+        """
+        body = build_model_request_body(
+            request,
+            self.model,
+            stream=True,
+            default_instructions="You are a helpful assistant.",
+        )
+        body["store"] = False
+        body["include"] = ["reasoning.encrypted_content"]
+        body["tool_choice"] = "auto"
+        body["parallel_tool_calls"] = True
+
+        # Effort: per-request provider_options wins, then the provider default,
+        # else the `reasoning` object is omitted entirely.
+        effort: str | None = None
+        if request.provider_options is not None:
+            candidate = request.provider_options.get("reasoning_effort")
+            if isinstance(candidate, str):
+                effort = candidate
+        if effort is None:
+            effort = self._reasoning_effort
+        if effort is not None:
+            body["reasoning"] = {"effort": effort, "summary": "auto"}
+            # The codec's shallow merge will have injected the raw key onto the
+            # body. It must never reach the wire.
+            body.pop("reasoning_effort", None)
+
+        return body
+
     @staticmethod
     def _map_http_error(
         status: int, message: str, headers: httpx.Headers | None = None
@@ -457,3 +502,65 @@ class ChatGptCodexProvider(BaseProvider):
             stop_reason=response.stop_reason,
             thinking=response.thinking,
         )
+
+    async def model_stream(self, request: ModelChatRequest) -> AsyncIterator[ModelStreamDelta]:
+        self.validate_model_request(request)
+        body = self.build_model_responses_body(request)
+        bearer = await self._bearer()
+        try:
+            resp = await self._http.send(
+                self._http.build_request(
+                    "POST", self._stream_url(), headers=self._headers(bearer), json=body
+                ),
+                stream=True,
+            )
+        except httpx.HTTPError as exc:
+            raise NetworkError(str(exc)) from exc
+
+        try:
+            if not resp.is_success:
+                error_body = await resp.aread()
+                message = f"HTTP {resp.status_code}: {error_body.decode()}"
+                retry_after = resp.headers.get("retry-after")
+                if retry_after:
+                    message = f"Retry-After: {retry_after}\n{message}"
+                raise self._map_http_error(resp.status_code, message, resp.headers)
+
+            state = ModelStreamState()
+            try:
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    for delta in parse_model_sse_event(line[len("data: ") :], state):
+                        yield delta
+                        if isinstance(delta, ModelStreamDone):
+                            return
+                    if state.error is not None:
+                        raise StreamError(state.error)
+
+                # Provider string is `chatgpt-codex` (hyphen) on the native
+                # path; the legacy adapter above uses `chatgpt_codex`.
+                raise IncompleteStreamError(
+                    "incomplete stream: chatgpt-codex ended without a terminal event"
+                )
+            except (StreamError, AuthError, RateLimitError, ProviderError, NetworkError):
+                raise
+            except httpx.ReadTimeout as exc:
+                raise StreamReadTimeoutError(
+                    f"stream read timed out after {self._read_idle_timeout}s"
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise StreamError(f"stream transport error: {exc}") from exc
+        except httpx.ReadTimeout as exc:
+            raise StreamReadTimeoutError(
+                f"stream read timed out after {self._read_idle_timeout}s"
+            ) from exc
+        finally:
+            await resp.aclose()
+
+    async def model_chat(self, request: ModelChatRequest) -> ModelChatResponse:
+        """Native chat = native stream + collect: there is no blocking endpoint."""
+        response = await collect_model_stream(self.model_stream(request))
+        if not response.model:
+            response.model = request.model or self.model
+        return response

--- a/sdks/python/motosan_ai/providers/openai.py
+++ b/sdks/python/motosan_ai/providers/openai.py
@@ -14,8 +14,16 @@ from motosan_ai.error import (
     RateLimitError,
     StreamError,
     StreamReadTimeoutError,
+    UnsupportedFeatureError,
 )
 from motosan_ai.provider_base import ProviderCapabilities
+from motosan_ai.provider_base import validate_model_request as _validate_model_request
+from motosan_ai.providers.responses import (
+    ModelStreamState,
+    build_model_request_body,
+    model_chat_response_from_output,
+    parse_model_sse_event,
+)
 from motosan_ai.retry import parse_retry_after_header
 from motosan_ai.types import (
     ChatRequest,
@@ -24,6 +32,10 @@ from motosan_ai.types import (
     ImageSourceBase64,
     ImageSourceUrl,
     Message,
+    ModelChatRequest,
+    ModelChatResponse,
+    ModelStreamDelta,
+    ModelStreamDone,
     Role,
     StopReason,
     StreamEvent,
@@ -51,6 +63,8 @@ def _http_error_kwargs(status: int, headers: httpx.Headers | None) -> dict[str, 
 
 
 class OpenAIProvider:
+    # Class-level default; __init__ replaces it per instance because the
+    # native capability depends on the Responses opt-in.
     capabilities: ProviderCapabilities = ProviderCapabilities.with_image()
 
     def __init__(
@@ -59,12 +73,21 @@ class OpenAIProvider:
         model: str | None = None,
         base_url: str | None = None,
         *,
+        responses_api: bool = False,
+        responses_url: str | None = None,
         connect_timeout: float = 10.0,
         read_idle_timeout: float = 120.0,
     ) -> None:
         self.api_key = api_key
         self.model = model or "gpt-4o"
         self.base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
+        self.responses_api = responses_api
+        self.responses_url = responses_url.rstrip("/") if responses_url else None
+        self.capabilities = (
+            ProviderCapabilities.with_image_and_freeform_tools()
+            if responses_api
+            else ProviderCapabilities.with_image()
+        )
         self._read_idle_timeout = read_idle_timeout
         self._http = httpx.AsyncClient(
             timeout=httpx.Timeout(
@@ -81,6 +104,9 @@ class OpenAIProvider:
 
     def _endpoint(self) -> str:
         return f"{self.base_url}/v1/chat/completions"
+
+    def _responses_endpoint(self) -> str:
+        return self.responses_url or f"{self.base_url}/v1/responses"
 
     def _headers(self) -> dict[str, str]:
         return {
@@ -361,6 +387,87 @@ class OpenAIProvider:
                 # even if the [DONE] transport epilogue never arrived.
                 yield StreamEvent(content="", done=True, stop_reason=current_stop_reason)
                 return
+
+            raise IncompleteStreamError("incomplete stream: openai ended without a terminal event")
+        except StreamError:
+            raise
+        except (AuthError, RateLimitError, ProviderError, NetworkError):
+            raise
+        except httpx.ReadTimeout as exc:
+            raise StreamReadTimeoutError(
+                f"stream read timed out after {self._read_idle_timeout}s"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise StreamError(f"stream transport error: {exc}") from exc
+        finally:
+            await resp.aclose()
+
+    def validate_model_request(self, request: ModelChatRequest) -> None:
+        # OpenAIProvider does not subclass BaseProvider, so it carries its own
+        # method delegating to the shared validator.
+        _validate_model_request(request, self.capabilities)
+
+    async def model_chat(self, request: ModelChatRequest) -> ModelChatResponse:
+        # Order matters: validation first, so a freeform request without the
+        # opt-in reports "native freeform tools", not the opt-in message.
+        self.validate_model_request(request)
+        if not self.responses_api:
+            raise UnsupportedFeatureError(
+                "OpenAI Chat Completions does not support native model requests; "
+                "enable OpenAI Responses API"
+            )
+
+        body = build_model_request_body(request, self.model, stream=False)
+        try:
+            resp = await self._http.post(
+                self._responses_endpoint(), headers=self._headers(), json=body
+            )
+        except httpx.HTTPError as exc:
+            raise NetworkError(str(exc)) from exc
+
+        if not resp.is_success:
+            message = self._response_error_message(resp.status_code, resp.headers, resp.text)
+            raise self._map_http_error(resp.status_code, message, resp.headers)
+
+        return model_chat_response_from_output(resp.json(), self.model)
+
+    async def model_stream(self, request: ModelChatRequest) -> AsyncIterator[ModelStreamDelta]:
+        self.validate_model_request(request)
+        if not self.responses_api:
+            raise UnsupportedFeatureError(
+                "OpenAI Chat Completions does not support native model streams; "
+                "enable OpenAI Responses API"
+            )
+
+        body = build_model_request_body(request, self.model, stream=True)
+        try:
+            resp = await self._http.send(
+                self._http.build_request(
+                    "POST", self._responses_endpoint(), headers=self._headers(), json=body
+                ),
+                stream=True,
+            )
+        except httpx.HTTPError as exc:
+            raise NetworkError(str(exc)) from exc
+
+        try:
+            if not resp.is_success:
+                error_body = await resp.aread()
+                message = self._response_error_message(
+                    resp.status_code, resp.headers, error_body.decode()
+                )
+                raise self._map_http_error(resp.status_code, message, resp.headers)
+
+            state = ModelStreamState()
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                for delta in parse_model_sse_event(line[len("data: ") :], state):
+                    yield delta
+                    if isinstance(delta, ModelStreamDone):
+                        return
+                if state.error is not None:
+                    raise StreamError(state.error)
 
             raise IncompleteStreamError("incomplete stream: openai ended without a terminal event")
         except StreamError:

--- a/sdks/python/tests/test_chatgpt_codex_native.py
+++ b/sdks/python/tests/test_chatgpt_codex_native.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from motosan_ai.error import IncompleteStreamError, ProviderError, StreamError
+from motosan_ai.provider_base import ProviderCapabilities
+from motosan_ai.providers.chatgpt_codex import ChatGptCodexProvider
+from motosan_ai.types import (
+    FreeformTool,
+    FreeformToolFormat,
+    FunctionCallOutputText,
+    Message,
+    ModelChatRequest,
+    ModelToolCallFreeform,
+    ModelToolOutputCustom,
+    ModelToolSpecFreeform,
+    StopReason,
+    ToolChoice,
+)
+
+_URL = "https://chatgpt.com/backend-api/codex/responses"
+
+FREEFORM_SPEC = ModelToolSpecFreeform(
+    tool=FreeformTool(
+        name="exec",
+        description="Run JavaScript",
+        format=FreeformToolFormat(type="grammar", syntax="lark", definition="start: source"),
+    )
+)
+
+
+def _provider() -> ChatGptCodexProvider:
+    return ChatGptCodexProvider("oauth-token", "acct-123", "gpt-5.5", None)
+
+
+def _native_request() -> ModelChatRequest:
+    return (
+        ModelChatRequest.builder().message(Message.user("run js")).tool_spec(FREEFORM_SPEC).build()
+    )
+
+
+def _sse(*payloads: dict) -> str:
+    return "\n".join(f"data: {json.dumps(p)}" for p in payloads) + "\n"
+
+
+def test_capabilities_declare_freeform_but_not_image_or_document():
+    assert _provider().capabilities == ProviderCapabilities.with_freeform_tools()
+
+
+def test_native_body_has_the_codex_hard_overrides():
+    body = _provider().build_model_responses_body(_native_request())
+
+    assert body["model"] == "gpt-5.5"
+    assert body["stream"] is True
+    assert body["store"] is False
+    assert body["include"] == ["reasoning.encrypted_content"]
+    assert body["parallel_tool_calls"] is True
+    assert body["tool_choice"] == "auto"
+    assert body["instructions"] == "You are a helpful assistant."
+    assert body["tools"][0]["type"] == "custom"
+    assert body["tools"][0]["format"]["syntax"] == "lark"
+
+
+def test_native_body_tool_choice_override_beats_the_caller():
+    request = (
+        ModelChatRequest.builder()
+        .message(Message.user("hi"))
+        .tool_choice(ToolChoice.required())
+        .build()
+    )
+    assert _provider().build_model_responses_body(request)["tool_choice"] == "auto"
+
+
+def test_native_body_per_request_effort_beats_the_provider_default():
+    provider = _provider().reasoning_effort("low")
+    request = (
+        ModelChatRequest.builder()
+        .message(Message.user("hi"))
+        .provider_options({"reasoning_effort": "high"})
+        .build()
+    )
+    body = provider.build_model_responses_body(request)
+
+    assert body["reasoning"] == {"effort": "high", "summary": "auto"}
+    # The shallow merge injected the raw key; it must never reach the wire.
+    assert "reasoning_effort" not in body
+
+
+def test_native_body_falls_back_to_the_provider_default_effort():
+    body = (
+        _provider()
+        .reasoning_effort("medium")
+        .build_model_responses_body(ModelChatRequest.builder().message(Message.user("hi")).build())
+    )
+    assert body["reasoning"] == {"effort": "medium", "summary": "auto"}
+
+
+def test_native_body_omits_reasoning_when_no_effort_resolves():
+    body = _provider().build_model_responses_body(
+        ModelChatRequest.builder().message(Message.user("hi")).build()
+    )
+    assert "reasoning" not in body
+    assert "reasoning_effort" not in body
+
+
+def test_native_body_hoists_system_messages_into_instructions():
+    request = (
+        ModelChatRequest.builder()
+        .message(Message.system("be terse"))
+        .message(Message.user("hi"))
+        .build()
+    )
+    body = _provider().build_model_responses_body(request)
+    assert body["instructions"] == "be terse"
+    assert len(body["input"]) == 1
+    assert body["input"][0]["role"] == "user"
+
+
+@respx.mock
+async def test_native_stream_decodes_custom_delta_and_done():
+    respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "type": "response.custom_tool_call_input.delta",
+                    "call_id": "call_js",
+                    "delta": "console.",
+                },
+                {
+                    "type": "response.custom_tool_call_input.delta",
+                    "call_id": "call_js",
+                    "delta": "log(1);\n",
+                },
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "custom_tool_call",
+                        "call_id": "call_js",
+                        "name": "exec",
+                        "input": "console.log(1);\n",
+                    },
+                },
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "status": "completed",
+                        "usage": {"input_tokens": 2, "output_tokens": 3},
+                    },
+                },
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    response = await _provider().model_chat(_native_request())
+
+    assert response.tool_calls == [
+        ModelToolCallFreeform(id="call_js", name="exec", input="console.log(1);\n")
+    ]
+    assert response.stop_reason == StopReason.tool_use
+    assert response.usage.output_tokens == 3
+    assert response.model == "gpt-5.5"
+
+
+@respx.mock
+async def test_native_stream_maps_response_incomplete_to_max_tokens():
+    respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200,
+            text=_sse(
+                {"type": "response.output_text.delta", "delta": "partial"},
+                {
+                    "type": "response.incomplete",
+                    "response": {
+                        "status": "incomplete",
+                        "usage": {"input_tokens": 6, "output_tokens": 7},
+                        "incomplete_details": {"reason": "max_output_tokens"},
+                    },
+                },
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    response = await _provider().model_chat(
+        ModelChatRequest.builder().message(Message.user("short")).build()
+    )
+    assert response.content == "partial"
+    assert response.stop_reason == StopReason.max_tokens
+    assert response.usage.output_tokens == 7
+
+
+@respx.mock
+async def test_native_stream_eof_without_terminal_is_incomplete():
+    respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "type": "response.custom_tool_call_input.delta",
+                    "call_id": "call_js",
+                    "delta": "console.",
+                }
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    # Note the hyphen: the native provider string is `chatgpt-codex`, not the
+    # legacy adapter's `chatgpt_codex`.
+    with pytest.raises(
+        IncompleteStreamError,
+        match="incomplete stream: chatgpt-codex ended without a terminal event",
+    ):
+        async for _ in _provider().model_stream(_native_request()):
+            pass
+    assert issubclass(IncompleteStreamError, StreamError)
+
+
+@respx.mock
+async def test_native_stream_sends_history_byte_exact():
+    captured: dict = {}
+    raw = '{"this":"looks like json"}\nconsole.log(\'but is JS\');'
+
+    def _capture(request):
+        captured["body"] = json.loads(request.content)
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "status": "completed",
+                        "usage": {"input_tokens": 1, "output_tokens": 1},
+                    },
+                }
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    respx.post(_URL).mock(side_effect=_capture)
+
+    request = (
+        ModelChatRequest.builder()
+        .message(Message.user("run js"))
+        .tool_call(ModelToolCallFreeform(id="call_js", name="exec", input=raw))
+        .tool_output(
+            ModelToolOutputCustom(
+                call_id="call_js", output=FunctionCallOutputText(text="done"), name="exec"
+            )
+        )
+        .tool_spec(FREEFORM_SPEC)
+        .build()
+    )
+    response = await _provider().model_chat(request)
+
+    assert response.stop_reason == StopReason.end_turn
+    body = captured["body"]
+    assert [item["type"] for item in body["input"]] == [
+        "message",
+        "custom_tool_call",
+        "custom_tool_call_output",
+    ]
+    assert body["input"][1]["input"] == raw
+    assert body["tools"][0]["type"] == "custom"
+    assert captured["headers"]["authorization"] == "Bearer oauth-token"
+    assert captured["headers"]["chatgpt-account-id"] == "acct-123"
+    assert captured["headers"]["openai-beta"] == "responses=experimental"
+
+
+@respx.mock
+async def test_native_stream_maps_http_errors():
+    respx.post(_URL).mock(return_value=httpx.Response(500, text="boom"))
+    with pytest.raises(ProviderError, match="HTTP 500"):
+        async for _ in _provider().model_stream(_native_request()):
+            pass
+
+
+@respx.mock
+async def test_native_stream_raises_on_a_stream_error_frame():
+    respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200,
+            text=_sse(
+                {"type": "response.output_text.delta", "delta": "partial"},
+                {"type": "response.failed", "response": {"error": {"message": "upstream died"}}},
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    seen = []
+    with pytest.raises(StreamError, match="upstream died"):
+        async for delta in _provider().model_stream(_native_request()):
+            seen.append(delta)
+    # Pending deltas drain before the stored error surfaces.
+    assert len(seen) == 1

--- a/sdks/python/tests/test_client_native.py
+++ b/sdks/python/tests/test_client_native.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import respx
+
+from motosan_ai import Client
+from motosan_ai.error import UnsupportedFeatureError
+from motosan_ai.retry import RetryPolicy
+from motosan_ai.types import (
+    FreeformTool,
+    FreeformToolFormat,
+    Message,
+    ModelChatRequest,
+    ModelChatResponse,
+    ModelStreamDelta,
+    ModelStreamDone,
+    ModelStreamText,
+    ModelStreamToolCallDone,
+    ModelStreamUsage,
+    ModelToolCallFreeform,
+    ModelToolSpecFreeform,
+    StopReason,
+    Usage,
+)
+
+FREEFORM_SPEC = ModelToolSpecFreeform(
+    tool=FreeformTool(
+        name="exec",
+        description="Run JavaScript",
+        format=FreeformToolFormat(type="grammar", syntax="lark", definition="start: source"),
+    )
+)
+
+
+def _sse(*payloads: dict) -> str:
+    return "\n".join(f"data: {json.dumps(p)}" for p in payloads) + "\n"
+
+
+class _RecordingProvider:
+    """Structurally-typed provider — deliberately NOT a BaseProvider subclass."""
+
+    def __init__(self, capabilities=None) -> None:
+        from motosan_ai.provider_base import ProviderCapabilities
+
+        self.capabilities = capabilities or ProviderCapabilities.with_freeform_tools()
+        self.seen: list[ModelChatRequest] = []
+
+    async def model_chat(self, request: ModelChatRequest) -> ModelChatResponse:
+        self.seen.append(request)
+        return ModelChatResponse(content="native", model="", stop_reason=StopReason.end_turn)
+
+    async def model_stream(self, request: ModelChatRequest) -> AsyncIterator[ModelStreamDelta]:
+        self.seen.append(request)
+        yield ModelStreamText(delta="nat")
+        yield ModelStreamText(delta="ive")
+        yield ModelStreamUsage(usage=Usage(input_tokens=1, output_tokens=2))
+        yield ModelStreamDone(stop_reason=StopReason.end_turn)
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _NoNativeProvider:
+    async def aclose(self) -> None:
+        return None
+
+
+def _client(provider_obj) -> Client:
+    client = Client(provider="anthropic", api_key="k", model="client-model")
+    client._provider = provider_obj
+    return client
+
+
+def test_openai_responses_api_flag_is_threaded_through_the_constructor():
+    off = Client(provider="openai", api_key="k")
+    on = Client(provider="openai", api_key="k", openai_responses_api=True)
+    assert off._provider.responses_api is False
+    assert on._provider.responses_api is True
+    assert on._provider.capabilities.supports_freeform_tools is True
+
+
+def test_openai_responses_api_flag_is_threaded_through_the_shortcut():
+    assert Client.openai(api_key="k")._provider.responses_api is False
+    assert Client.openai(api_key="k", openai_responses_api=True)._provider.responses_api is True
+
+
+def test_ollama_over_openai_never_receives_the_responses_opt_in():
+    client = Client(provider="ollama", model="llama3.2")
+    assert client._provider.responses_api is False
+
+
+async def test_model_chat_with_dispatches_and_backfills_the_model():
+    provider = _RecordingProvider()
+    client = _client(provider)
+
+    response = await client.model_chat_with(
+        ModelChatRequest.builder().message(Message.user("hi")).build()
+    )
+
+    assert response.content == "native"
+    assert provider.seen[0].model == "client-model"
+
+
+async def test_model_chat_with_keeps_an_explicit_request_model():
+    provider = _RecordingProvider()
+    response = await _client(provider).model_chat_with(
+        ModelChatRequest.builder().model("explicit").message(Message.user("hi")).build()
+    )
+    assert provider.seen[0].model == "explicit"
+    assert response.content == "native"
+
+
+async def test_model_stream_with_yields_every_delta():
+    deltas = [
+        delta
+        async for delta in _client(_RecordingProvider()).model_stream_with(
+            ModelChatRequest.builder().message(Message.user("hi")).build()
+        )
+    ]
+    assert deltas == [
+        ModelStreamText(delta="nat"),
+        ModelStreamText(delta="ive"),
+        ModelStreamUsage(usage=Usage(input_tokens=1, output_tokens=2)),
+        ModelStreamDone(stop_reason=StopReason.end_turn),
+    ]
+
+
+async def test_model_stream_collect_with_assembles_and_backfills_the_model():
+    response = await _client(_RecordingProvider()).model_stream_collect_with(
+        ModelChatRequest.builder().message(Message.user("hi")).build()
+    )
+    assert response.content == "native"
+    assert response.usage == Usage(input_tokens=1, output_tokens=2)
+    assert response.stop_reason == StopReason.end_turn
+    assert response.model == "client-model"
+
+
+async def test_native_dispatch_is_duck_typed_not_isinstance_based():
+    client = _client(_NoNativeProvider())
+    request = ModelChatRequest.builder().message(Message.user("hi")).build()
+
+    with pytest.raises(UnsupportedFeatureError, match="native model requests"):
+        await client.model_chat_with(request)
+    with pytest.raises(UnsupportedFeatureError, match="native model streams"):
+        async for _ in client.model_stream_with(request):
+            pass
+
+
+async def test_capabilities_are_enforced_before_native_dispatch():
+    from motosan_ai.provider_base import ProviderCapabilities
+
+    provider = _RecordingProvider(capabilities=ProviderCapabilities.with_image())
+    client = _client(provider)
+    request = (
+        ModelChatRequest.builder().message(Message.user("hi")).tool_spec(FREEFORM_SPEC).build()
+    )
+
+    with pytest.raises(UnsupportedFeatureError, match="native freeform tools"):
+        await client.model_chat_with(request)
+    with pytest.raises(UnsupportedFeatureError, match="native freeform tools"):
+        async for _ in client.model_stream_with(request):
+            pass
+    assert provider.seen == []
+
+
+async def test_provider_without_capabilities_is_not_validated():
+    # The LlmClient Protocol does not require `capabilities`; native
+    # validation must be skipped, not crash, for such providers.
+    provider = _RecordingProvider()
+    del provider.capabilities
+    client = _client(provider)
+    response = await client.model_chat_with(
+        ModelChatRequest.builder().tool_spec(FREEFORM_SPEC).build()
+    )
+    assert response.content == "native"
+
+
+@respx.mock
+async def test_end_to_end_over_the_chatgpt_codex_provider():
+    respx.post("https://chatgpt.com/backend-api/codex/responses").mock(
+        return_value=httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "custom_tool_call",
+                        "call_id": "call_js",
+                        "name": "exec",
+                        "input": "text('captured');",
+                    },
+                },
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "status": "completed",
+                        "usage": {"input_tokens": 4, "output_tokens": 5},
+                    },
+                },
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    client = Client.chatgpt_codex(
+        access_token="tok",
+        account_id="acct-123",
+        model="gpt-5.5",
+        retry_policy=RetryPolicy(max_retries=0),
+    )
+    response = await client.model_stream_collect_with(
+        ModelChatRequest.builder().message(Message.user("run js")).tool_spec(FREEFORM_SPEC).build()
+    )
+
+    assert response.tool_calls == [
+        ModelToolCallFreeform(id="call_js", name="exec", input="text('captured');")
+    ]
+    assert response.model == "gpt-5.5"
+    assert response.stop_reason == StopReason.tool_use
+
+
+async def test_native_stream_does_not_strip_think_tags():
+    class _ThinkProvider(_RecordingProvider):
+        async def model_stream(self, request: ModelChatRequest) -> AsyncIterator[ModelStreamDelta]:
+            yield ModelStreamText(delta="<think>secret</think>visible")
+            yield ModelStreamDone(stop_reason=StopReason.end_turn)
+
+    response = await _client(_ThinkProvider()).model_stream_collect_with(
+        ModelChatRequest.builder().message(Message.user("hi")).build()
+    )
+    # The native path carries thinking as explicit deltas, so text passes
+    # through untouched — unlike Client.stream_with.
+    assert response.content == "<think>secret</think>visible"
+
+
+async def test_tool_call_done_survives_client_level_collection():
+    class _ToolProvider(_RecordingProvider):
+        async def model_stream(self, request: ModelChatRequest) -> AsyncIterator[ModelStreamDelta]:
+            yield ModelStreamToolCallDone(
+                call=ModelToolCallFreeform(id="c", name="exec", input="raw();")
+            )
+            yield ModelStreamDone(stop_reason=StopReason.tool_use)
+
+    response = await _client(_ToolProvider()).model_stream_collect_with(
+        ModelChatRequest.builder().build()
+    )
+    assert response.tool_calls == [ModelToolCallFreeform(id="c", name="exec", input="raw();")]

--- a/sdks/python/tests/test_native_capabilities.py
+++ b/sdks/python/tests/test_native_capabilities.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from motosan_ai.error import InvalidRequestError, UnsupportedFeatureError
+from motosan_ai.provider_base import BaseProvider, ProviderCapabilities, validate_model_request
+from motosan_ai.types import (
+    ChatRequest,
+    ChatResponse,
+    FreeformTool,
+    FreeformToolFormat,
+    FunctionCallOutputText,
+    Message,
+    ModelChatRequest,
+    ModelContextToolCall,
+    ModelToolCallFreeform,
+    ModelToolCallFunction,
+    ModelToolOutputCustom,
+    ModelToolOutputFunction,
+    ModelToolSpecFreeform,
+    ModelToolSpecFunction,
+    StreamEvent,
+    Tool,
+)
+
+FREEFORM_SPEC = ModelToolSpecFreeform(
+    tool=FreeformTool(
+        name="exec",
+        description="Run JavaScript",
+        format=FreeformToolFormat(type="grammar", syntax="lark", definition="start: source"),
+    )
+)
+
+
+def test_with_freeform_tools_constructor():
+    caps = ProviderCapabilities.with_freeform_tools()
+    assert caps.supports_image is False
+    assert caps.supports_document is False
+    assert caps.supports_freeform_tools is True
+
+
+def test_with_image_and_freeform_tools_constructor():
+    caps = ProviderCapabilities.with_image_and_freeform_tools()
+    assert caps.supports_image is True
+    assert caps.supports_document is False
+    assert caps.supports_freeform_tools is True
+
+
+def test_full_deliberately_leaves_freeform_false():
+    # Rust parity: full() is image + document, never freeform.
+    assert ProviderCapabilities.full().supports_freeform_tools is False
+    assert ProviderCapabilities.text_only().supports_freeform_tools is False
+    assert ProviderCapabilities.with_image().supports_freeform_tools is False
+
+
+def test_freeform_field_defaults_to_false_for_positional_construction():
+    assert ProviderCapabilities(supports_image=True, supports_document=True) == (
+        ProviderCapabilities.full()
+    )
+
+
+def test_rejects_freeform_spec_when_unsupported():
+    request = ModelChatRequest.builder().tool_spec(FREEFORM_SPEC).build()
+    with pytest.raises(UnsupportedFeatureError, match="native freeform tools"):
+        validate_model_request(request, ProviderCapabilities.with_image())
+
+
+def test_rejects_freeform_history_call_when_unsupported():
+    request = (
+        ModelChatRequest.builder()
+        .tool_call(ModelToolCallFreeform(id="call_js", name="exec", input="x"))
+        .build()
+    )
+    with pytest.raises(UnsupportedFeatureError, match="native freeform tools"):
+        validate_model_request(request, ProviderCapabilities.full())
+
+
+def test_rejects_custom_history_output_when_unsupported():
+    request = (
+        ModelChatRequest.builder()
+        .tool_output(
+            ModelToolOutputCustom(call_id="call_js", output=FunctionCallOutputText(text="1"))
+        )
+        .build()
+    )
+    with pytest.raises(UnsupportedFeatureError, match="native freeform tools"):
+        validate_model_request(request, ProviderCapabilities.text_only())
+
+
+def test_accepts_freeform_when_supported():
+    request = (
+        ModelChatRequest.builder()
+        .tool_spec(FREEFORM_SPEC)
+        .tool_call(ModelToolCallFreeform(id="call_js", name="exec", input="x"))
+        .tool_output(
+            ModelToolOutputCustom(call_id="call_js", output=FunctionCallOutputText(text="1"))
+        )
+        .build()
+    )
+    validate_model_request(request, ProviderCapabilities.with_freeform_tools())
+
+
+def test_function_only_history_is_accepted_everywhere():
+    request = (
+        ModelChatRequest.builder()
+        .tool_spec(ModelToolSpecFunction(tool=Tool(name="sum")))
+        .tool_call(ModelToolCallFunction(id="call_fn", name="sum", arguments="{}"))
+        .tool_output(
+            ModelToolOutputFunction(call_id="call_fn", output=FunctionCallOutputText(text="1"))
+        )
+        .message(Message.user("hi"))
+        .build()
+    )
+    validate_model_request(request, ProviderCapabilities.text_only())
+
+
+def test_rejects_image_and_document_context_blocks():
+    image = (
+        ModelChatRequest.builder()
+        .message(Message.user_with_image("look", "abc", "image/png"))
+        .build()
+    )
+    with pytest.raises(UnsupportedFeatureError, match="image"):
+        validate_model_request(image, ProviderCapabilities.with_freeform_tools())
+    validate_model_request(image, ProviderCapabilities.with_image_and_freeform_tools())
+
+    document = (
+        ModelChatRequest.builder().message(Message.user_with_pdf_base64("read", "abc")).build()
+    )
+    with pytest.raises(UnsupportedFeatureError, match="document"):
+        validate_model_request(document, ProviderCapabilities.with_image())
+    validate_model_request(document, ProviderCapabilities.full())
+
+
+def test_rejection_is_catchable_as_invalid_request_error():
+    request = ModelChatRequest.builder().tool_spec(FREEFORM_SPEC).build()
+    with pytest.raises(InvalidRequestError):
+        validate_model_request(request, ProviderCapabilities.text_only())
+
+
+def test_base_provider_method_delegates_to_its_capabilities():
+    class _Freeform(BaseProvider):
+        capabilities = ProviderCapabilities.with_freeform_tools()
+
+        async def chat(self, request: ChatRequest) -> ChatResponse:  # pragma: no cover
+            raise NotImplementedError
+
+        async def stream(self, request: ChatRequest) -> AsyncIterator[StreamEvent]:
+            if False:  # pragma: no cover
+                yield StreamEvent(content="", done=True)
+            raise NotImplementedError
+
+    class _TextOnly(_Freeform):
+        capabilities = ProviderCapabilities.text_only()
+
+    request = ModelChatRequest.builder().tool_spec(FREEFORM_SPEC).build()
+    _Freeform().validate_model_request(request)
+    with pytest.raises(UnsupportedFeatureError, match="native freeform tools"):
+        _TextOnly().validate_model_request(request)

--- a/sdks/python/tests/test_native_collect_stream.py
+++ b/sdks/python/tests/test_native_collect_stream.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from motosan_ai._stream_collect import collect_model_stream
+from motosan_ai.error import StreamError
+from motosan_ai.types import (
+    ModelStreamDelta,
+    ModelStreamDone,
+    ModelStreamFreeformInput,
+    ModelStreamFunctionArguments,
+    ModelStreamText,
+    ModelStreamThinkingDelta,
+    ModelStreamThinkingDone,
+    ModelStreamToolCallDone,
+    ModelStreamUsage,
+    ModelToolCallFreeform,
+    ModelToolCallFunction,
+    StopReason,
+    Usage,
+)
+
+
+async def _stream(*deltas: ModelStreamDelta) -> AsyncIterator[ModelStreamDelta]:
+    for delta in deltas:
+        yield delta
+
+
+async def test_preserves_freeform_tool_call_and_usage():
+    response = await collect_model_stream(
+        _stream(
+            ModelStreamFreeformInput(call_id="call_js", delta="console."),
+            ModelStreamFreeformInput(call_id="call_js", delta="log(1);"),
+            ModelStreamToolCallDone(
+                call=ModelToolCallFreeform(id="call_js", name="exec", input="console.log(1);")
+            ),
+            ModelStreamUsage(usage=Usage(input_tokens=2, output_tokens=3)),
+            ModelStreamDone(stop_reason=StopReason.tool_use),
+        )
+    )
+
+    assert response.tool_calls == [
+        ModelToolCallFreeform(id="call_js", name="exec", input="console.log(1);")
+    ]
+    assert response.stop_reason == StopReason.tool_use
+    assert response.usage.output_tokens == 3
+    assert response.model == ""
+    assert response.content == ""
+    assert response.thinking is None
+
+
+async def test_tool_call_done_is_authoritative_over_accumulated_deltas():
+    response = await collect_model_stream(
+        _stream(
+            ModelStreamFreeformInput(call_id="call_js", delta="WRONG"),
+            ModelStreamFunctionArguments(call_id="call_fn", delta="ALSO WRONG"),
+            ModelStreamToolCallDone(
+                call=ModelToolCallFreeform(id="call_js", name="exec", input="RIGHT")
+            ),
+            ModelStreamToolCallDone(
+                call=ModelToolCallFunction(id="call_fn", name="sum", arguments='{"a":1}')
+            ),
+            ModelStreamDone(stop_reason=StopReason.tool_use),
+        )
+    )
+
+    assert response.tool_calls == [
+        ModelToolCallFreeform(id="call_js", name="exec", input="RIGHT"),
+        ModelToolCallFunction(id="call_fn", name="sum", arguments='{"a":1}'),
+    ]
+
+
+async def test_usage_replaces_rather_than_merges():
+    response = await collect_model_stream(
+        _stream(
+            ModelStreamUsage(
+                usage=Usage(input_tokens=100, output_tokens=100, cache_read_input_tokens=7)
+            ),
+            ModelStreamUsage(usage=Usage(input_tokens=0, output_tokens=5)),
+            ModelStreamDone(stop_reason=StopReason.end_turn),
+        )
+    )
+    assert response.usage == Usage(input_tokens=0, output_tokens=5)
+    assert response.usage.cache_read_input_tokens is None
+
+
+async def test_text_and_thinking_assembly():
+    response = await collect_model_stream(
+        _stream(
+            ModelStreamThinkingDelta(delta="think "),
+            ModelStreamThinkingDelta(delta="hard"),
+            ModelStreamThinkingDone(thinking="think hard"),
+            ModelStreamText(delta="ans"),
+            ModelStreamText(delta="wer"),
+            ModelStreamDone(stop_reason=StopReason.end_turn),
+        )
+    )
+    assert response.content == "answer"
+    assert response.thinking == "think hard"
+
+
+async def test_thinking_done_does_not_duplicate_accumulated_deltas():
+    response = await collect_model_stream(
+        _stream(
+            ModelStreamThinkingDelta(delta="same"),
+            ModelStreamThinkingDone(thinking="same"),
+            ModelStreamDone(stop_reason=StopReason.end_turn),
+        )
+    )
+    assert response.thinking == "same"
+
+
+async def test_thinking_falls_back_to_deltas_and_empty_done_means_none():
+    from_deltas = await collect_model_stream(
+        _stream(
+            ModelStreamThinkingDelta(delta="A "),
+            ModelStreamThinkingDelta(delta="B"),
+            ModelStreamDone(stop_reason=StopReason.end_turn),
+        )
+    )
+    assert from_deltas.thinking == "A B"
+
+    empty_done = await collect_model_stream(
+        _stream(
+            ModelStreamThinkingDelta(delta="discarded"),
+            ModelStreamThinkingDone(thinking=""),
+            ModelStreamDone(stop_reason=StopReason.end_turn),
+        )
+    )
+    assert empty_done.thinking is None
+
+
+async def test_stop_reason_heuristic_only_applies_without_a_terminal():
+    no_terminal = await collect_model_stream(_stream(ModelStreamText(delta="hi")))
+    assert no_terminal.stop_reason == StopReason.end_turn
+
+    tool_no_terminal = await collect_model_stream(
+        _stream(
+            ModelStreamToolCallDone(call=ModelToolCallFunction(id="c", name="n", arguments="{}"))
+        )
+    )
+    assert tool_no_terminal.stop_reason == StopReason.tool_use
+
+    explicit = await collect_model_stream(
+        _stream(
+            ModelStreamToolCallDone(call=ModelToolCallFunction(id="c", name="n", arguments="{}")),
+            ModelStreamDone(stop_reason=StopReason.max_tokens),
+        )
+    )
+    assert explicit.stop_reason == StopReason.max_tokens
+
+
+async def test_stream_errors_propagate_uncollected():
+    async def _boom() -> AsyncIterator[ModelStreamDelta]:
+        yield ModelStreamText(delta="partial")
+        raise StreamError("boom")
+
+    with pytest.raises(StreamError, match="boom"):
+        await collect_model_stream(_boom())

--- a/sdks/python/tests/test_openai_native.py
+++ b/sdks/python/tests/test_openai_native.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from motosan_ai.error import (
+    IncompleteStreamError,
+    ProviderError,
+    StreamError,
+    UnsupportedFeatureError,
+)
+from motosan_ai.provider_base import ProviderCapabilities
+from motosan_ai.providers.openai import OpenAIProvider
+from motosan_ai.types import (
+    FreeformTool,
+    FreeformToolFormat,
+    FunctionCallOutputText,
+    Message,
+    ModelChatRequest,
+    ModelToolCallFreeform,
+    ModelToolOutputCustom,
+    ModelToolSpecFreeform,
+    StopReason,
+)
+
+_RESPONSES = "https://api.openai.com/v1/responses"
+
+FREEFORM_SPEC = ModelToolSpecFreeform(
+    tool=FreeformTool(
+        name="exec",
+        description="Run JavaScript",
+        format=FreeformToolFormat(type="grammar", syntax="lark", definition="start: source"),
+    )
+)
+
+
+def _native_provider() -> OpenAIProvider:
+    return OpenAIProvider(api_key="test-key", model="gpt-5.5-codex", responses_api=True)
+
+
+def _native_request() -> ModelChatRequest:
+    return (
+        ModelChatRequest.builder()
+        .model("gpt-5.5-codex")
+        .message(Message.user("run js"))
+        .tool_spec(FREEFORM_SPEC)
+        .build()
+    )
+
+
+def _sse(*payloads: dict) -> str:
+    return "\n".join(f"data: {json.dumps(p)}" for p in payloads) + "\n"
+
+
+def test_capabilities_switch_on_the_opt_in():
+    assert OpenAIProvider(api_key="k").capabilities == ProviderCapabilities.with_image()
+    assert (
+        OpenAIProvider(api_key="k", responses_api=True).capabilities
+        == ProviderCapabilities.with_image_and_freeform_tools()
+    )
+
+
+def test_responses_endpoint_defaults_and_override():
+    assert OpenAIProvider(api_key="k")._responses_endpoint() == _RESPONSES
+    assert (
+        OpenAIProvider(api_key="k", base_url="https://proxy.test/")._responses_endpoint()
+        == "https://proxy.test/v1/responses"
+    )
+    assert (
+        OpenAIProvider(
+            api_key="k", responses_url="https://mock.test/v1/responses/"
+        )._responses_endpoint()
+        == "https://mock.test/v1/responses"
+    )
+    # The chat endpoint is untouched by the opt-in.
+    assert OpenAIProvider(api_key="k")._endpoint() == "https://api.openai.com/v1/chat/completions"
+
+
+@respx.mock
+async def test_chat_completions_rejects_freeform_before_any_http():
+    route = respx.post(host="api.openai.com").mock(return_value=httpx.Response(500))
+    with pytest.raises(UnsupportedFeatureError, match="freeform"):
+        await OpenAIProvider(api_key="k").model_chat(_native_request())
+    assert route.call_count == 0
+
+
+@respx.mock
+async def test_chat_completions_rejects_freeform_streams_before_any_http():
+    route = respx.post(host="api.openai.com").mock(return_value=httpx.Response(500))
+    with pytest.raises(UnsupportedFeatureError, match="freeform"):
+        async for _ in OpenAIProvider(api_key="k").model_stream(_native_request()):
+            pass
+    assert route.call_count == 0
+
+
+@respx.mock
+async def test_chat_completions_rejects_plain_native_requests_with_the_opt_in_message():
+    route = respx.post(host="api.openai.com").mock(return_value=httpx.Response(500))
+    plain = ModelChatRequest.builder().message(Message.user("hi")).build()
+    with pytest.raises(UnsupportedFeatureError, match="enable OpenAI Responses API"):
+        await OpenAIProvider(api_key="k").model_chat(plain)
+    with pytest.raises(UnsupportedFeatureError, match="enable OpenAI Responses API"):
+        async for _ in OpenAIProvider(api_key="k").model_stream(plain):
+            pass
+    assert route.call_count == 0
+
+
+@respx.mock
+async def test_native_chat_posts_a_non_streaming_body_and_decodes_custom_calls():
+    captured: dict = {}
+    raw = "const x = {a: 1};\nconsole.log(x.a);\n"
+
+    def _capture(request):
+        captured["body"] = json.loads(request.content)
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            json={
+                "model": "gpt-5.5-codex",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "custom_tool_call",
+                        "call_id": "call_js",
+                        "name": "exec",
+                        "input": raw,
+                    }
+                ],
+                "usage": {"input_tokens": 9, "output_tokens": 7},
+            },
+        )
+
+    respx.post(_RESPONSES).mock(side_effect=_capture)
+
+    response = await _native_provider().model_chat(_native_request())
+
+    assert response.tool_calls == [ModelToolCallFreeform(id="call_js", name="exec", input=raw)]
+    assert response.stop_reason == StopReason.tool_use
+    assert response.usage.input_tokens == 9
+    assert captured["headers"]["authorization"] == "Bearer test-key"
+    assert "stream" not in captured["body"]
+    assert captured["body"]["tools"][0]["type"] == "custom"
+    assert captured["body"]["tools"][0]["format"]["definition"] == "start: source"
+
+
+@respx.mock
+async def test_native_chat_encodes_image_blocks():
+    captured: dict = {}
+
+    def _capture(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": "gpt-5.5-codex",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "ok"}],
+                    }
+                ],
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    respx.post(_RESPONSES).mock(side_effect=_capture)
+    request = (
+        ModelChatRequest.builder()
+        .message(Message.user_with_image("inspect", "abc123", "image/png"))
+        .build()
+    )
+
+    response = await _native_provider().model_chat(request)
+
+    assert response.content == "ok"
+    content = captured["body"]["input"][0]["content"]
+    assert content[0] == {"type": "input_text", "text": "inspect"}
+    assert content[1] == {"type": "input_image", "image_url": "data:image/png;base64,abc123"}
+
+
+@respx.mock
+async def test_native_chat_replays_symmetric_history_byte_exact():
+    captured: dict = {}
+    raw = '{"this":"looks like json"}\nconsole.log(\'but is JS\');'
+
+    def _capture(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": "gpt-5.5-codex",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "ok"}],
+                    }
+                ],
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    respx.post(_RESPONSES).mock(side_effect=_capture)
+
+    request = (
+        ModelChatRequest.builder()
+        .message(Message.user("run js"))
+        .tool_call(ModelToolCallFreeform(id="call_js", name="exec", input=raw))
+        .tool_output(
+            ModelToolOutputCustom(
+                call_id="call_js", output=FunctionCallOutputText(text="done"), name="exec"
+            )
+        )
+        .tool_spec(FREEFORM_SPEC)
+        .build()
+    )
+    response = await _native_provider().model_chat(request)
+
+    assert response.content == "ok"
+    body = captured["body"]
+    assert [item["type"] for item in body["input"]] == [
+        "message",
+        "custom_tool_call",
+        "custom_tool_call_output",
+    ]
+    assert body["input"][1]["input"] == raw
+    assert body["input"][1]["call_id"] == "call_js"
+    assert body["input"][1]["name"] == "exec"
+
+
+@respx.mock
+async def test_native_chat_maps_http_errors():
+    respx.post(_RESPONSES).mock(return_value=httpx.Response(500, text="boom"))
+    with pytest.raises(ProviderError, match="HTTP 500"):
+        await _native_provider().model_chat(_native_request())
+
+
+@respx.mock
+async def test_native_stream_decodes_custom_delta_and_done():
+    from motosan_ai._stream_collect import collect_model_stream
+
+    respx.post(_RESPONSES).mock(
+        return_value=httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "type": "response.custom_tool_call_input.delta",
+                    "call_id": "call_js",
+                    "delta": "console.",
+                },
+                {
+                    "type": "response.custom_tool_call_input.delta",
+                    "call_id": "call_js",
+                    "delta": "log(1);\n",
+                },
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "custom_tool_call",
+                        "call_id": "call_js",
+                        "name": "exec",
+                        "input": "console.log(1);\n",
+                    },
+                },
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "status": "completed",
+                        "usage": {"input_tokens": 2, "output_tokens": 3},
+                    },
+                },
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    response = await collect_model_stream(_native_provider().model_stream(_native_request()))
+
+    assert response.tool_calls == [
+        ModelToolCallFreeform(id="call_js", name="exec", input="console.log(1);\n")
+    ]
+    assert response.stop_reason == StopReason.tool_use
+    assert response.usage.output_tokens == 3
+
+
+@respx.mock
+async def test_native_stream_sets_the_stream_flag():
+    captured: dict = {}
+
+    def _capture(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            text=_sse({"type": "response.completed", "response": {"status": "completed"}}),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    respx.post(_RESPONSES).mock(side_effect=_capture)
+    async for _ in _native_provider().model_stream(_native_request()):
+        pass
+    assert captured["body"]["stream"] is True
+
+
+@respx.mock
+async def test_native_stream_eof_without_terminal_is_incomplete():
+    respx.post(_RESPONSES).mock(
+        return_value=httpx.Response(
+            200,
+            text=_sse(
+                {"type": "response.output_text.delta", "delta": "hel"},
+                {"type": "response.output_text.delta", "delta": "lo"},
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    seen = []
+    with pytest.raises(
+        IncompleteStreamError, match="incomplete stream: openai ended without a terminal event"
+    ):
+        async for delta in _native_provider().model_stream(_native_request()):
+            seen.append(delta)
+    assert len(seen) == 2
+    assert issubclass(IncompleteStreamError, StreamError)

--- a/sdks/python/tests/test_provider_capabilities.py
+++ b/sdks/python/tests/test_provider_capabilities.py
@@ -45,18 +45,21 @@ def test_text_only_capabilities():
     caps = ProviderCapabilities.text_only()
     assert caps.supports_image is False
     assert caps.supports_document is False
+    assert caps.supports_freeform_tools is False
 
 
 def test_with_image_capabilities():
     caps = ProviderCapabilities.with_image()
     assert caps.supports_image is True
     assert caps.supports_document is False
+    assert caps.supports_freeform_tools is False
 
 
 def test_full_capabilities():
     caps = ProviderCapabilities.full()
     assert caps.supports_image is True
     assert caps.supports_document is True
+    assert caps.supports_freeform_tools is False
 
 
 def test_text_only_rejects_image():

--- a/sdks/python/tests/test_public_exports.py
+++ b/sdks/python/tests/test_public_exports.py
@@ -67,3 +67,37 @@ def test_dunder_all_is_sorted_and_free_of_duplicates():
 def test_every_all_entry_actually_resolves():
     unresolved = [name for name in motosan_ai.__all__ if not hasattr(motosan_ai, name)]
     assert unresolved == []
+
+
+P2_EXPORTS = ["collect_model_stream"]
+
+
+def test_p2_symbols_are_importable_and_listed():
+    for name in P2_EXPORTS:
+        assert hasattr(motosan_ai, name), f"{name} is not importable from motosan_ai"
+        assert name in motosan_ai.__all__, f"{name} is missing from __all__"
+
+
+def test_collect_model_stream_is_the_native_collector():
+    from motosan_ai._stream_collect import collect_model_stream
+
+    assert motosan_ai.collect_model_stream is collect_model_stream
+
+
+def test_capability_constructors_are_reachable_from_the_package_root():
+    caps = motosan_ai.ProviderCapabilities
+    assert caps.with_freeform_tools().supports_freeform_tools is True
+    assert caps.with_image_and_freeform_tools().supports_image is True
+    assert caps.full().supports_freeform_tools is False
+
+
+def test_native_provider_methods_are_wired():
+    from motosan_ai.providers.chatgpt_codex import ChatGptCodexProvider
+    from motosan_ai.providers.openai import OpenAIProvider
+
+    for provider_cls in (ChatGptCodexProvider, OpenAIProvider):
+        assert hasattr(provider_cls, "model_chat"), provider_cls.__name__
+        assert hasattr(provider_cls, "model_stream"), provider_cls.__name__
+    assert hasattr(motosan_ai.Client, "model_chat_with")
+    assert hasattr(motosan_ai.Client, "model_stream_with")
+    assert hasattr(motosan_ai.Client, "model_stream_collect_with")


### PR DESCRIPTION
PR P2 of #270. Capabilities, collect_model_stream, ChatGPT Codex + OpenAI native methods (with the Responses opt-in), and the Client native trio with duck-typed dispatch.