### PR TITLE
feat: TypeScript native model providers, dispatch and client surface (#270)

### DIFF
--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1,7 +1,10 @@
 import { CancelledError, ConfigError } from './error.js'
 import {
   dispatchChat,
+  dispatchModelChat,
+  dispatchModelStream,
   dispatchStream,
+  readTimeoutModelStream,
   readTimeoutStream,
   textOnly,
   type Provider,
@@ -10,7 +13,7 @@ import {
   type RequestOptions,
 } from './provider.js'
 import { RetryPolicy } from './retry.js'
-import { collectStream, type BoxStream } from './stream.js'
+import { collectModelStream, collectStream, type BoxModelStream, type BoxStream } from './stream.js'
 import { stripThink } from './think_stripper.js'
 import { AnthropicProvider } from './providers/anthropic.js'
 import { MinimaxProvider } from './providers/minimax.js'
@@ -19,7 +22,14 @@ import { OpenAIProvider, type OpenAIAuthStyle } from './providers/openai.js'
 import { GeminiProvider } from './providers/gemini.js'
 import { ChatGptCodexProvider, type TokenSource } from './providers/chatgpt_codex.js'
 import { DEFAULT_OLLAMA_MODEL } from './models.js'
-import type { ChatRequest, ChatResponse, StreamEvent } from './types.js'
+import type {
+  ChatRequest,
+  ChatResponse,
+  ModelChatRequest,
+  ModelChatResponse,
+  ModelStreamDelta,
+  StreamEvent,
+} from './types.js'
 
 export type ProviderName = Provider
 
@@ -40,6 +50,12 @@ export interface ProviderLike {
   capabilities?(): ReturnType<DispatchProvider['capabilities']>
   chat(request: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse>
   stream(request: ChatRequest, opts?: ProviderRequestOptions): AsyncIterable<StreamEvent>
+  /** Optional native surface. Forwarded by asDispatchProvider. */
+  modelChat?(request: ModelChatRequest, opts?: ProviderRequestOptions): Promise<ModelChatResponse>
+  modelStream?(
+    request: ModelChatRequest,
+    opts?: ProviderRequestOptions,
+  ): AsyncIterable<ModelStreamDelta>
 }
 
 /**
@@ -67,16 +83,34 @@ const ENV_KEY_BY_PROVIDER: Record<ProviderName, string> = {
   chatgpt_codex: '',
 }
 
+/**
+ * Adapt a caller-supplied ProviderLike to the dispatch contract.
+ *
+ * The rebuild branch names every forwarded property, so new optional provider
+ * methods must be listed here or they will be dropped for providers without
+ * capabilities().
+ */
 function asDispatchProvider(provider: ProviderLike): DispatchProvider {
   if (provider.capabilities) {
     return provider as DispatchProvider
   }
 
-  return {
+  const shim: DispatchProvider = {
     capabilities: textOnly,
     chat: (request: ChatRequest, opts?: ProviderRequestOptions) => provider.chat(request, opts),
     stream: (request: ChatRequest, opts?: ProviderRequestOptions) => provider.stream(request, opts),
   }
+
+  const { modelChat, modelStream } = provider
+  if (modelChat) {
+    shim.modelChat = (request: ModelChatRequest, opts?: ProviderRequestOptions) =>
+      modelChat.call(provider, request, opts)
+  }
+  if (modelStream) {
+    shim.modelStream = (request: ModelChatRequest, opts?: ProviderRequestOptions) =>
+      modelStream.call(provider, request, opts)
+  }
+  return shim
 }
 
 /**
@@ -95,6 +129,7 @@ export class ClientBuilder {
   protected _openaiAuthStyle: OpenAIAuthStyle = { kind: 'bearer' }
   protected _openaiChatUrl?: string
   protected _openaiResponsesFallback = false
+  protected _openaiResponsesApi = false
   protected _openaiResponsesUrl?: string
   protected _ollamaBaseUrl?: string
   protected _ollamaNative?: boolean
@@ -178,6 +213,15 @@ export class ClientBuilder {
     return this
   }
 
+  /**
+   * Opt into the OpenAI Responses API for the native model surface.
+   * Independent of openaiResponsesFallback, which is legacy chat 404 recovery.
+   */
+  openaiResponsesApi(enabled: boolean): this {
+    this._openaiResponsesApi = enabled
+    return this
+  }
+
   openaiResponsesUrl(u: string): this {
     this._openaiResponsesUrl = u
     return this
@@ -246,6 +290,7 @@ export class ClientBuilder {
       let openai = new OpenAIProvider(apiKey, this._model)
         .withRetryPolicy(this._retryPolicy)
         .withAuthStyle(this._openaiAuthStyle)
+        .withResponsesApi(this._openaiResponsesApi)
       if (this._openaiChatUrl) {
         openai = openai.withChatUrl(this._openaiChatUrl)
       }
@@ -487,6 +532,70 @@ export class Client {
     if (request.model) {
       response.model = request.model
     }
+    return response
+  }
+
+  /**
+   * Send a native model request; validates capabilities before any HTTP call.
+   * Signal composition matches chat().
+   */
+  async modelChat(request: ModelChatRequest, opts?: RequestOptions): Promise<ModelChatResponse> {
+    let signal = opts?.signal
+    if (this.totalMs !== undefined) {
+      const total = AbortSignal.timeout(this.totalMs)
+      signal = signal ? AbortSignal.any([signal, total]) : total
+    }
+    try {
+      return await dispatchModelChat(this.provider, request, {
+        signal,
+        callerSignal: opts?.signal,
+        preHeadersTimeoutMs: this.connectMs + this.readIdleMs,
+      })
+    } catch (error) {
+      if (opts?.signal?.aborted && !(error instanceof CancelledError)) {
+        throw new CancelledError()
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Stream a native model request. Native thinking arrives as typed deltas, so
+   * this path applies the read-idle timeout but not stripThink.
+   */
+  modelStream(request: ModelChatRequest, opts?: RequestOptions): BoxModelStream {
+    let stream: BoxModelStream = dispatchModelStream(this.provider, request, {
+      signal: opts?.signal,
+      callerSignal: opts?.signal,
+      preHeadersTimeoutMs: this.connectMs + this.readIdleMs,
+    })
+    stream = readTimeoutModelStream(stream, this.readIdleMs / 1000)
+    return this.translateModelCallerAbort(stream, opts?.signal)
+  }
+
+  /** Mid-stream caller abort surfaces as CancelledError on the native path too. */
+  private async *translateModelCallerAbort(
+    inner: BoxModelStream,
+    callerSignal: AbortSignal | undefined,
+  ): BoxModelStream {
+    try {
+      for await (const delta of inner) yield delta
+    } catch (error) {
+      if (callerSignal?.aborted && !(error instanceof CancelledError)) {
+        throw new CancelledError()
+      }
+      throw error
+    }
+  }
+
+  /** Stream and collect a native response, preferring the request's model override. */
+  async modelStreamCollect(
+    request: ModelChatRequest,
+    opts?: RequestOptions,
+  ): Promise<ModelChatResponse> {
+    const modelHint = request.model ?? ''
+    const response = await collectModelStream(this.modelStream(request, opts))
+    if (!response.model) response.model = modelHint
     return response
   }
 }

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -31,8 +31,36 @@ export {
 } from './models.js'
 export { serializeGeminiRequest } from './serialize/gemini.js'
 export type { ProviderCapabilities, Provider, RequestOptions, ProviderRequestOptions } from './provider.js'
-export { textOnly, withImage, fullCaps, minimaxCaps, validateRequest } from './provider.js'
+export {
+  textOnly,
+  withImage,
+  fullCaps,
+  minimaxCaps,
+  withFreeformTools,
+  withImageAndFreeformTools,
+  validateRequest,
+  validateModelRequest,
+} from './provider.js'
 
 // M4: server-side MCP types (also covered by `export * from './types.js'`; listed
 // explicitly for discoverability). No internal http/serialize symbols are exported.
 export type { McpServerType, McpServerConfig, McpToolConfig } from './types.js'
+
+// Native model API (specs/types.md § Native Model API). Also covered by
+// `export * from './types.js'`; listed explicitly for discoverability.
+// `collectModelStream` / `BoxModelStream` ride `export * from './stream.js'`.
+// The Responses codec stays internal; src/serialize/responses.ts is a test seam.
+export type {
+  FreeformTool,
+  FreeformToolFormat,
+  FunctionCallOutputContentItem,
+  FunctionCallOutputPayload,
+  ImageDetail,
+  ModelChatRequest,
+  ModelChatResponse,
+  ModelContextItem,
+  ModelStreamDelta,
+  ModelToolCall,
+  ModelToolOutput,
+  ModelToolSpec,
+} from './types.js'

--- a/sdks/typescript/src/provider.ts
+++ b/sdks/typescript/src/provider.ts
@@ -6,49 +6,73 @@
  */
 
 import { StreamReadTimeoutError, UnsupportedFeatureError } from './error.js'
-import type { BoxStream } from './stream.js'
-import type { ChatRequest, ChatResponse, ContentBlock, StreamEvent } from './types.js'
+import type { BoxModelStream, BoxStream } from './stream.js'
+import type {
+  ChatRequest,
+  ChatResponse,
+  ContentBlock,
+  ModelChatRequest,
+  ModelChatResponse,
+  ModelStreamDelta,
+  StreamEvent,
+} from './types.js'
 
 /**
  * Describes what features a provider supports.
  *
- * Mirrors Rust `ProviderCapabilities` (types.rs:903-907) PLUS a TS-only
- * `supportsMcp` flag. Rust has no MCP capability — it achieves "no MCP on
- * OpenAI" by serializer omission. TS adds the flag so validateRequest can
- * reject MCP on non-Anthropic providers per the M4 Done-when requirement.
+ * Mirrors Rust `ProviderCapabilities` (types.rs:1518-1523) PLUS a TS-only
+ * `supportsMcp` flag — Rust has no MCP capability and achieves "no MCP on
+ * OpenAI" by serializer omission, while TS lets validateRequest reject it.
+ * `supportsFreeformTools` gates the NATIVE model surface only; it says nothing
+ * about the legacy function-tool surface.
  */
 export interface ProviderCapabilities {
   supportsImage: boolean
   supportsDocument: boolean
   /** TS-only divergence from Rust: whether the provider accepts MCP server/tool config. */
   supportsMcp: boolean
+  /** Whether the provider speaks native Freeform (custom) tools. */
+  supportsFreeformTools: boolean
 }
 
 /**
- * Provider with text only — no images, no documents.
- *
- * Mirrors Rust `ProviderCapabilities::text_only()` (types.rs:910-915).
+ * Provider with text only — no images, no documents, no freeform tools.
  */
 export function textOnly(): ProviderCapabilities {
-  return { supportsImage: false, supportsDocument: false, supportsMcp: false }
+  return {
+    supportsImage: false,
+    supportsDocument: false,
+    supportsMcp: false,
+    supportsFreeformTools: false,
+  }
 }
 
 /**
- * Provider with image support — images but no documents.
- *
- * Mirrors Rust `ProviderCapabilities::with_image()` (types.rs:917-922).
+ * Provider with image support — images but no documents, no freeform tools.
  */
 export function withImage(): ProviderCapabilities {
-  return { supportsImage: true, supportsDocument: false, supportsMcp: false }
+  return {
+    supportsImage: true,
+    supportsDocument: false,
+    supportsMcp: false,
+    supportsFreeformTools: false,
+  }
 }
 
 /**
- * Provider with full support — images and documents.
+ * Provider with full legacy support — images and documents.
  *
- * Mirrors Rust `ProviderCapabilities::full()` (types.rs:924-929).
+ * `supportsFreeformTools` stays FALSE on purpose, matching Rust
+ * `ProviderCapabilities::full()` (types.rs:1558-1564). A provider that flipped
+ * it here would silently claim native support it does not have.
  */
 export function fullCaps(): ProviderCapabilities {
-  return { supportsImage: true, supportsDocument: true, supportsMcp: true }
+  return {
+    supportsImage: true,
+    supportsDocument: true,
+    supportsMcp: true,
+    supportsFreeformTools: false,
+  }
 }
 
 /**
@@ -57,7 +81,39 @@ export function fullCaps(): ProviderCapabilities {
  * Distinct from `textOnly()` so MCP isn't blanket-blocked on the text-only path.
  */
 export function minimaxCaps(): ProviderCapabilities {
-  return { supportsImage: false, supportsDocument: false, supportsMcp: true }
+  return {
+    supportsImage: false,
+    supportsDocument: false,
+    supportsMcp: true,
+    supportsFreeformTools: false,
+  }
+}
+
+/**
+ * Text-only provider that speaks native Freeform tools (ChatGPT Codex).
+ * Mirrors Rust `ProviderCapabilities::with_freeform_tools()`.
+ */
+export function withFreeformTools(): ProviderCapabilities {
+  return {
+    supportsImage: false,
+    supportsDocument: false,
+    supportsMcp: false,
+    supportsFreeformTools: true,
+  }
+}
+
+/**
+ * Image-capable provider that speaks native Freeform tools (OpenAI with the
+ * Responses opt-in on). Mirrors Rust
+ * `ProviderCapabilities::with_image_and_freeform_tools()`.
+ */
+export function withImageAndFreeformTools(): ProviderCapabilities {
+  return {
+    supportsImage: true,
+    supportsDocument: false,
+    supportsMcp: false,
+    supportsFreeformTools: true,
+  }
 }
 
 /**
@@ -120,14 +176,19 @@ export interface ProviderRequestOptions extends RequestOptions {
 }
 
 /**
- * Minimal shape a provider must expose to be dispatched: a capability reshape
- * plus chat/stream. Concrete providers (AnthropicProvider/OpenAIProvider/
- * MinimaxProvider) structurally satisfy this.
+ * Minimal shape a provider must expose to be dispatched.
+ *
+ * `modelChat` / `modelStream` are OPTIONAL: this is a structural contract that
+ * third parties implement, so requiring the native surface would be a breaking
+ * change. Providers that omit them are rejected by dispatchModelChat /
+ * dispatchModelStream with UnsupportedFeatureError.
  */
 export interface ProviderImpl {
   capabilities(): ProviderCapabilities
   chat(req: ChatRequest, opts?: ProviderRequestOptions): Promise<ChatResponse>
   stream(req: ChatRequest, opts?: ProviderRequestOptions): BoxStream
+  modelChat?(req: ModelChatRequest, opts?: ProviderRequestOptions): Promise<ModelChatResponse>
+  modelStream?(req: ModelChatRequest, opts?: ProviderRequestOptions): BoxModelStream
 }
 
 /**
@@ -156,6 +217,73 @@ export function dispatchStream(
 ): BoxStream {
   validateRequest(req, provider.capabilities())
   return provider.stream(req, opts)
+}
+
+/**
+ * Validate a native model request against provider capabilities.
+ *
+ * Mirrors Rust `ProviderImpl::validate_model_request` (providers/mod.rs:82-140)
+ * MINUS the thinking and MCP arms: milestone D3 omits those request fields
+ * entirely, so a caller reaching for them gets a type error rather than a
+ * runtime UnsupportedFeatureError. Throws BEFORE any HTTP call.
+ */
+export function validateModelRequest(req: ModelChatRequest, caps: ProviderCapabilities): void {
+  const hasFreeformSpec = (req.toolSpecs ?? []).some((spec) => spec.kind === 'freeform')
+  const hasFreeformHistory = req.context.some(
+    (item) =>
+      (item.kind === 'toolCall' && item.call.kind === 'freeform') ||
+      (item.kind === 'toolOutput' && item.output.kind === 'custom'),
+  )
+  if ((hasFreeformSpec || hasFreeformHistory) && !caps.supportsFreeformTools) {
+    throw new UnsupportedFeatureError('provider does not support native freeform tools')
+  }
+
+  for (const item of req.context) {
+    if (item.kind !== 'message') continue
+    const blocks: ContentBlock[] = item.message.contentBlocks ?? []
+    for (const block of blocks) {
+      if (block.type === 'image' && !caps.supportsImage) {
+        throw new UnsupportedFeatureError('provider does not support image input')
+      }
+      if (block.type === 'document' && !caps.supportsDocument) {
+        throw new UnsupportedFeatureError('provider does not support document input')
+      }
+    }
+  }
+}
+
+/**
+ * Dispatch a native model request: validate BEFORE any HTTP call, then
+ * provider.modelChat (which owns its retry loop). Mirrors Rust
+ * client.rs dispatch_model_chat.
+ */
+export async function dispatchModelChat(
+  provider: ProviderImpl,
+  req: ModelChatRequest,
+  opts?: ProviderRequestOptions,
+): Promise<ModelChatResponse> {
+  validateModelRequest(req, provider.capabilities())
+  if (!provider.modelChat) {
+    throw new UnsupportedFeatureError('provider does not support native model requests')
+  }
+  return provider.modelChat(req, opts)
+}
+
+/**
+ * Dispatch a native model stream: validate BEFORE connecting, then
+ * provider.modelStream. Sync return, so a rejected request throws
+ * synchronously rather than on first iteration.
+ */
+export function dispatchModelStream(
+  provider: ProviderImpl,
+  req: ModelChatRequest,
+  opts?: ProviderRequestOptions,
+): BoxModelStream {
+  validateModelRequest(req, provider.capabilities())
+  if (!provider.modelStream) {
+    throw new UnsupportedFeatureError('provider does not support native model streams')
+  }
+  return provider.modelStream(req, opts)
 }
 
 /**
@@ -203,6 +331,68 @@ export async function* readTimeoutStream(inner: BoxStream, timeoutSecs: number):
         }
 
         const result = raced as IteratorResult<StreamEvent>
+        if (result.done) {
+          closed = true
+          return
+        }
+        yield result.value
+      } finally {
+        if (timer !== undefined) clearTimeout(timer)
+      }
+    }
+  } finally {
+    await closeInner()
+  }
+}
+
+/**
+ * Native-stream analogue of readTimeoutStream. THROWS StreamReadTimeoutError
+ * when no delta arrives within the deadline; the deadline resets on each
+ * yielded delta and the inner iterator is cancelled before throwing. Mirrors
+ * Rust `ReadTimeoutModelStream` (client.rs:1239-1259).
+ */
+export async function* readTimeoutModelStream(
+  inner: BoxModelStream,
+  timeoutSecs: number,
+): BoxModelStream {
+  const timeoutMs = timeoutSecs * 1000
+  const iterator = inner[Symbol.asyncIterator]()
+  let closed = false
+
+  async function closeInner(): Promise<void> {
+    if (!closed) {
+      closed = true
+      await iterator.return?.()
+    }
+  }
+
+  function cancelInnerWithoutWaiting(): void {
+    if (!closed) {
+      closed = true
+      void iterator.return?.().catch(() => {})
+    }
+  }
+
+  try {
+    while (true) {
+      let timer: ReturnType<typeof setTimeout> | undefined
+      try {
+        const timeout = new Promise<'__timeout__'>((resolve) => {
+          timer = setTimeout(() => resolve('__timeout__'), timeoutMs)
+        })
+        const next = iterator.next()
+        const raced = await Promise.race([next, timeout])
+        if (timer !== undefined) {
+          clearTimeout(timer)
+          timer = undefined
+        }
+
+        if (raced === '__timeout__') {
+          cancelInnerWithoutWaiting()
+          throw new StreamReadTimeoutError(timeoutSecs)
+        }
+
+        const result = raced as IteratorResult<ModelStreamDelta>
         if (result.done) {
           closed = true
           return

--- a/sdks/typescript/src/providers/chatgpt_codex.ts
+++ b/sdks/typescript/src/providers/chatgpt_codex.ts
@@ -12,9 +12,16 @@ import { IncompleteStreamError, StreamError } from '../error.js'
 import { postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_CHATGPT_CODEX_MODEL } from '../models.js'
-import { textOnly, type ProviderCapabilities, type ProviderRequestOptions } from '../provider.js'
-import { attemptWithCancellation, classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import {
+  validateModelRequest,
+  withFreeformTools,
+  type ProviderCapabilities,
+  type ProviderRequestOptions,
+} from '../provider.js'
+import { attemptWithCancellation, classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
+import { buildModelRequestBody, modelStreamAdapter } from '../serialize/responses.js'
+import {
+  collectModelStream,
   collectStream,
   doneWithStopReason,
   textEvent,
@@ -23,9 +30,19 @@ import {
   toolCallEndWithId,
   toolCallStart,
   usageEvent,
+  type BoxModelStream,
   type BoxStream,
 } from '../stream.js'
-import type { ChatRequest, ChatResponse, StopReason, StreamEvent, Usage } from '../types.js'
+import type {
+  ChatRequest,
+  ChatResponse,
+  ModelChatRequest,
+  ModelChatResponse,
+  ModelStreamDelta,
+  StopReason,
+  StreamEvent,
+  Usage,
+} from '../types.js'
 
 export const DEFAULT_CHATGPT_CODEX_URL = 'https://chatgpt.com/backend-api/codex/responses'
 const CHATGPT_CODEX_ORIGINATOR = 'codex_cli_rs'
@@ -103,7 +120,7 @@ export class ChatGptCodexProvider {
   }
 
   capabilities(): ProviderCapabilities {
-    return textOnly()
+    return withFreeformTools()
   }
 
   /** Resolve the bearer token for one attempt: static string, or one TokenSource call. */
@@ -214,6 +231,26 @@ export class ChatGptCodexProvider {
     if (effort !== undefined) body.reasoning = { effort, summary: 'auto' }
 
     if (request.temperature !== undefined) body.temperature = request.temperature
+
+    return body
+  }
+
+  /** Build the native Responses request body. Public for unit tests. */
+  buildModelResponsesBody(request: ModelChatRequest): Record<string, unknown> {
+    const body = buildModelRequestBody(request, this.model, true, 'You are a helpful assistant.')
+    body.store = false
+    body.include = ['reasoning.encrypted_content']
+    body.tool_choice = 'auto'
+    body.parallel_tool_calls = true
+
+    let effort: string | undefined
+    const candidate = request.providerOptions?.reasoning_effort
+    if (typeof candidate === 'string') effort = candidate
+    if (effort === undefined) effort = this._reasoningEffort
+    if (effort !== undefined) {
+      body.reasoning = { effort, summary: 'auto' }
+      delete body.reasoning_effort
+    }
 
     return body
   }
@@ -342,5 +379,39 @@ export class ChatGptCodexProvider {
     throw new IncompleteStreamError(
       'incomplete stream: chatgpt_codex ended without a terminal event',
     )
+  }
+
+  async modelChat(
+    request: ModelChatRequest,
+    opts?: ProviderRequestOptions,
+  ): Promise<ModelChatResponse> {
+    const model = request.model ?? this.model
+    const response = await collectModelStream(this.modelStream(request, opts))
+    if (!response.model) response.model = model
+    return response
+  }
+
+  modelStream(request: ModelChatRequest, opts?: ProviderRequestOptions): BoxModelStream {
+    validateModelRequest(request, this.capabilities())
+    return this.modelStreamImpl(request, opts)
+  }
+
+  private async *modelStreamImpl(
+    request: ModelChatRequest,
+    opts?: ProviderRequestOptions,
+  ): AsyncGenerator<ModelStreamDelta> {
+    const body = this.buildModelResponsesBody(request)
+    const responseBody = await withRetry(
+      this.retryPolicy,
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, async () =>
+          postStream(this.baseUrl, this.headers(await this.resolveToken()), body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
+      classifyForRetry,
+    )
+    yield* modelStreamAdapter(responseBody, 'chatgpt-codex')
   }
 }

--- a/sdks/typescript/src/providers/openai.ts
+++ b/sdks/typescript/src/providers/openai.ts
@@ -1,10 +1,21 @@
-import { IncompleteStreamError } from '../error.js'
+import { IncompleteStreamError, UnsupportedFeatureError } from '../error.js'
 import { postJson, postStream } from '../http/fetch.js'
 import { parseSse } from '../http/sse.js'
 import { DEFAULT_OPENAI_MODEL } from '../models.js'
-import { withImage, type ProviderCapabilities, type ProviderRequestOptions } from '../provider.js'
+import {
+  validateModelRequest,
+  withImage,
+  withImageAndFreeformTools,
+  type ProviderCapabilities,
+  type ProviderRequestOptions,
+} from '../provider.js'
 import { attemptWithCancellation, classifyForRetry, RetryPolicy, withRetry } from '../retry.js'
 import { serializeOpenAiRequest } from '../serialize/openai.js'
+import {
+  buildModelRequestBody,
+  modelChatResponseFromOutput,
+  modelStreamAdapter,
+} from '../serialize/responses.js'
 import {
   doneEvent,
   doneWithStopReason,
@@ -13,9 +24,18 @@ import {
   toolCallEndWithId,
   toolCallStart,
   usageEvent,
+  type BoxModelStream,
   type BoxStream,
 } from '../stream.js'
-import type { ChatRequest, ChatResponse, StopReason, ToolCall } from '../types.js'
+import type {
+  ChatRequest,
+  ChatResponse,
+  ModelChatRequest,
+  ModelChatResponse,
+  ModelStreamDelta,
+  StopReason,
+  ToolCall,
+} from '../types.js'
 
 /** OpenAI authentication style. Mirrors Rust `OpenAIAuthStyle`. */
 export type OpenAIAuthStyle =
@@ -43,6 +63,7 @@ export class OpenAIProvider {
   private chatUrl: string = DEFAULT_OPENAI_CHAT_URL
   private responsesUrl: string = DEFAULT_OPENAI_RESPONSES_URL
   private responsesFallback = false
+  private responsesApi = false
 
   constructor(
     private readonly apiKey: string,
@@ -75,6 +96,15 @@ export class OpenAIProvider {
 
   withResponsesFallback(enabled: boolean): this {
     this.responsesFallback = enabled
+    return this
+  }
+
+  /**
+   * Opt into the OpenAI Responses API for the native model surface.
+   * Distinct from withResponsesFallback, which is only legacy chat 404 recovery.
+   */
+  withResponsesApi(enabled: boolean): this {
+    this.responsesApi = enabled
     return this
   }
 
@@ -319,7 +349,7 @@ export class OpenAIProvider {
   }
 
   capabilities(): ProviderCapabilities {
-    return withImage()
+    return this.responsesApi ? withImageAndFreeformTools() : withImage()
   }
 
   private async *streamImpl(request: ChatRequest, opts?: ProviderRequestOptions) {
@@ -468,5 +498,70 @@ export class OpenAIProvider {
       }
       throw new IncompleteStreamError('incomplete stream: openai ended without a terminal event')
     }
+  }
+
+  /**
+   * Native, genuinely non-streaming model request against the Responses API.
+   * Validation runs before the opt-in gate so freeform capability errors win.
+   */
+  async modelChat(
+    request: ModelChatRequest,
+    opts?: ProviderRequestOptions,
+  ): Promise<ModelChatResponse> {
+    validateModelRequest(request, this.capabilities())
+    if (!this.responsesApi) {
+      throw new UnsupportedFeatureError(
+        'OpenAI Chat Completions does not support native model requests; enable OpenAI Responses API',
+      )
+    }
+
+    const body = buildModelRequestBody(request, this.model, false)
+    const payload = await withRetry(
+      this.retryPolicy,
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postJson<unknown>(this.responsesUrl, this.headers(), body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
+      classifyForRetry,
+    )
+
+    return modelChatResponseFromOutput(payload, this.model)
+  }
+
+  /**
+   * Native model stream. Validation and opt-in gating are synchronous so no
+   * network request starts unless the returned iterable is valid to use.
+   */
+  modelStream(request: ModelChatRequest, opts?: ProviderRequestOptions): BoxModelStream {
+    validateModelRequest(request, this.capabilities())
+    if (!this.responsesApi) {
+      throw new UnsupportedFeatureError(
+        'OpenAI Chat Completions does not support native model streams; enable OpenAI Responses API',
+      )
+    }
+    return this.modelStreamImpl(request, opts)
+  }
+
+  private async *modelStreamImpl(
+    request: ModelChatRequest,
+    opts?: ProviderRequestOptions,
+  ): AsyncGenerator<ModelStreamDelta> {
+    const body = buildModelRequestBody(request, this.model, true)
+    const responseBody = await withRetry(
+      this.retryPolicy,
+      async () =>
+        attemptWithCancellation(opts?.callerSignal, () =>
+          postStream(this.responsesUrl, this.headers(), body, {
+            signal: opts?.signal,
+            preHeadersTimeoutMs: opts?.preHeadersTimeoutMs,
+          }),
+        ),
+      classifyForRetry,
+    )
+
+    yield* modelStreamAdapter(responseBody, 'openai')
   }
 }

--- a/sdks/typescript/src/stream.ts
+++ b/sdks/typescript/src/stream.ts
@@ -1,4 +1,13 @@
-import type { ChatResponse, StopReason, StreamEvent, ToolCall, Usage } from './types.js'
+import type {
+  ChatResponse,
+  ModelChatResponse,
+  ModelStreamDelta,
+  ModelToolCall,
+  StopReason,
+  StreamEvent,
+  ToolCall,
+  Usage,
+} from './types.js'
 
 export type BoxStream = AsyncIterable<StreamEvent>
 
@@ -214,4 +223,105 @@ export async function collectStream(stream: BoxStream): Promise<ChatResponse> {
     usage,
     stopReason,
   }
+}
+
+/** An async iterable of native model stream deltas. Mirrors Rust `BoxModelStream`. */
+export type BoxModelStream = AsyncIterable<ModelStreamDelta>
+
+/**
+ * Reassemble a native model stream into a ModelChatResponse.
+ *
+ * Mirrors Rust `collect_model_stream` (stream.rs:155-239). Three rules differ
+ * from `collectStream` above and are contract, not implementation detail
+ * (milestone D8):
+ *
+ *   1. `tool_call_done` is AUTHORITATIVE. The accumulated `function_arguments`
+ *      / `freeform_input` buffers exist so a caller can render progress; they
+ *      are discarded for the completed call and NEVER lowered into it. In
+ *      particular a freeform `input` is never JSON-parsed.
+ *   2. `usage` REPLACES the running value. (collectStream uses
+ *      replace-with-fallback because Anthropic's message_delta usage is
+ *      cumulative; the Responses terminal frame is not.)
+ *   3. `thinking_done` wins over concatenated `thinking_delta` content, and an
+ *      empty `thinking_done` payload means "no thinking", not "empty string".
+ *
+ * `model` is returned EMPTY — the caller (provider or Client) backfills it
+ * from the request/provider default.
+ */
+export async function collectModelStream(stream: BoxModelStream): Promise<ModelChatResponse> {
+  let content = ''
+  let thinkingDeltaBuf = ''
+  let thinkingDoneBuf: string | undefined
+  const functionArguments = new Map<string, string>()
+  const freeformInputs = new Map<string, string>()
+  const toolCalls: ModelToolCall[] = []
+  let usage: Usage = { inputTokens: 0, outputTokens: 0 }
+  let explicitStopReason: StopReason | undefined
+
+  for await (const delta of stream) {
+    if (delta.type === 'done') {
+      explicitStopReason = delta.stopReason
+      break
+    }
+
+    switch (delta.type) {
+      case 'text':
+        content += delta.delta
+        break
+
+      case 'thinking_delta':
+        thinkingDeltaBuf += delta.delta
+        break
+
+      case 'thinking_done':
+        thinkingDoneBuf = delta.thinking
+        thinkingDeltaBuf = ''
+        break
+
+      case 'function_arguments':
+        functionArguments.set(
+          delta.callId,
+          (functionArguments.get(delta.callId) ?? '') + delta.delta,
+        )
+        break
+
+      case 'freeform_input':
+        freeformInputs.set(delta.callId, (freeformInputs.get(delta.callId) ?? '') + delta.delta)
+        break
+
+      case 'tool_call_done':
+        // Discard the bookkeeping buffer; the completed call is the truth.
+        if (delta.call.kind === 'function') {
+          functionArguments.delete(delta.call.id)
+        } else {
+          freeformInputs.delete(delta.call.id)
+        }
+        toolCalls.push(delta.call)
+        break
+
+      case 'usage':
+        usage = delta.usage
+        break
+    }
+  }
+
+  let thinking: string | undefined
+  if (thinkingDoneBuf !== undefined) {
+    thinking = thinkingDoneBuf.length > 0 ? thinkingDoneBuf : undefined
+  } else if (thinkingDeltaBuf.length > 0) {
+    thinking = thinkingDeltaBuf
+  }
+
+  const stopReason: StopReason =
+    explicitStopReason ?? (toolCalls.length > 0 ? 'tool_use' : 'end_turn')
+
+  const response: ModelChatResponse = {
+    content,
+    toolCalls,
+    model: '',
+    usage,
+    stopReason,
+  }
+  if (thinking !== undefined) response.thinking = thinking
+  return response
 }

--- a/sdks/typescript/tests/capabilities.test.ts
+++ b/sdks/typescript/tests/capabilities.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import {
-  textOnly,
-  withImage,
   fullCaps,
   minimaxCaps,
+  textOnly,
   validateRequest,
+  withFreeformTools,
+  withImage,
+  withImageAndFreeformTools,
   type Provider,
   type ProviderCapabilities,
 } from '../src/provider.js'
@@ -12,27 +14,30 @@ import { UnsupportedFeatureError } from '../src/error.js'
 import type { ChatRequest } from '../src/types.js'
 
 describe('ProviderCapabilities factories', () => {
-  it('textOnly() returns {false, false, supportsMcp:false}', () => {
+  it('textOnly() returns all-false', () => {
     expect(textOnly()).toEqual({
       supportsImage: false,
       supportsDocument: false,
       supportsMcp: false,
+      supportsFreeformTools: false,
     })
   })
 
-  it('withImage() returns {true, false, supportsMcp:false}', () => {
+  it('withImage() adds images only', () => {
     expect(withImage()).toEqual({
       supportsImage: true,
       supportsDocument: false,
       supportsMcp: false,
+      supportsFreeformTools: false,
     })
   })
 
-  it('fullCaps() returns {true, true, supportsMcp:true}', () => {
+  it('fullCaps() keeps supportsFreeformTools FALSE (mirrors Rust full())', () => {
     expect(fullCaps()).toEqual({
       supportsImage: true,
       supportsDocument: true,
       supportsMcp: true,
+      supportsFreeformTools: false,
     })
   })
 
@@ -41,6 +46,25 @@ describe('ProviderCapabilities factories', () => {
       supportsImage: false,
       supportsDocument: false,
       supportsMcp: true,
+      supportsFreeformTools: false,
+    })
+  })
+
+  it('withFreeformTools() is text-only plus native freeform', () => {
+    expect(withFreeformTools()).toEqual({
+      supportsImage: false,
+      supportsDocument: false,
+      supportsMcp: false,
+      supportsFreeformTools: true,
+    })
+  })
+
+  it('withImageAndFreeformTools() adds images to native freeform', () => {
+    expect(withImageAndFreeformTools()).toEqual({
+      supportsImage: true,
+      supportsDocument: false,
+      supportsMcp: false,
+      supportsFreeformTools: true,
     })
   })
 })

--- a/sdks/typescript/tests/index.test.ts
+++ b/sdks/typescript/tests/index.test.ts
@@ -109,6 +109,56 @@ describe('ChatGPT-Codex public surface (index re-exports)', () => {
   })
 })
 
+describe('native model API public surface', () => {
+  it('re-exports the native capability factories and validator', async () => {
+    const mod = await import('../src/index.js')
+    expect(typeof mod.withFreeformTools).toBe('function')
+    expect(typeof mod.withImageAndFreeformTools).toBe('function')
+    expect(typeof mod.validateModelRequest).toBe('function')
+    expect(mod.withFreeformTools()).toEqual({
+      supportsImage: false,
+      supportsDocument: false,
+      supportsMcp: false,
+      supportsFreeformTools: true,
+    })
+    expect(mod.withImageAndFreeformTools().supportsImage).toBe(true)
+  })
+
+  it('re-exports collectModelStream from the root', async () => {
+    const mod = await import('../src/index.js')
+    expect(typeof mod.collectModelStream).toBe('function')
+  })
+
+  it('accepts the native types from the root entrypoint', async () => {
+    const mod = await import('../src/index.js')
+    const request: import('../src/index.js').ModelChatRequest = {
+      context: [{ kind: 'message', message: { role: 'user', content: 'hi' } }],
+      toolSpecs: [
+        {
+          kind: 'freeform',
+          tool: {
+            name: 'exec',
+            description: 'Run JavaScript',
+            format: { type: 'grammar', syntax: 'lark', definition: 'start: source' },
+          },
+        },
+      ],
+    }
+    expect(() => mod.validateModelRequest(request, mod.withFreeformTools())).not.toThrow()
+    expect(() => mod.validateModelRequest(request, mod.withImage())).toThrow(
+      'provider does not support native freeform tools',
+    )
+  })
+
+  it('exposes the native methods on Client and ClientBuilder', async () => {
+    const mod = await import('../src/index.js')
+    expect(typeof mod.Client.prototype.modelChat).toBe('function')
+    expect(typeof mod.Client.prototype.modelStream).toBe('function')
+    expect(typeof mod.Client.prototype.modelStreamCollect).toBe('function')
+    expect(typeof mod.ClientBuilder.prototype.openaiResponsesApi).toBe('function')
+  })
+})
+
 describe('M6 Gemini done-criteria smoke (builder round-trip)', () => {
   afterEach(() => {
     vi.unstubAllGlobals()

--- a/sdks/typescript/tests/index.test.ts
+++ b/sdks/typescript/tests/index.test.ts
@@ -22,16 +22,19 @@ describe('index.ts public exports', () => {
       supportsImage: false,
       supportsDocument: false,
       supportsMcp: false,
+      supportsFreeformTools: false,
     })
     expect(mod.withImage()).toEqual({
       supportsImage: true,
       supportsDocument: false,
       supportsMcp: false,
+      supportsFreeformTools: false,
     })
     expect(mod.fullCaps()).toEqual({
       supportsImage: true,
       supportsDocument: true,
       supportsMcp: true,
+      supportsFreeformTools: false,
     })
 
     expect(typeof mod.DEFAULT_ANTHROPIC_MODEL).toBe('string')

--- a/sdks/typescript/tests/providers-anthropic.test.ts
+++ b/sdks/typescript/tests/providers-anthropic.test.ts
@@ -219,6 +219,7 @@ describe('AnthropicProvider chat', () => {
       supportsImage: true,
       supportsDocument: true,
       supportsMcp: true,
+      supportsFreeformTools: false,
     })
   })
 })

--- a/sdks/typescript/tests/providers-chatgpt-codex.test.ts
+++ b/sdks/typescript/tests/providers-chatgpt-codex.test.ts
@@ -424,12 +424,12 @@ describe('ChatGptCodexProvider HTTP', () => {
     expect(body.input[0].content[0].type).toBe('input_text')
   })
 
-  it('has text-only capabilities', () => {
+  it('has text-only native-freeform capabilities', () => {
     expect(new ChatGptCodexProvider('t', 'a').capabilities()).toEqual({
       supportsImage: false,
       supportsDocument: false,
       supportsMcp: false,
-      supportsFreeformTools: false,
+      supportsFreeformTools: true,
     })
   })
 

--- a/sdks/typescript/tests/providers-chatgpt-codex.test.ts
+++ b/sdks/typescript/tests/providers-chatgpt-codex.test.ts
@@ -429,6 +429,7 @@ describe('ChatGptCodexProvider HTTP', () => {
       supportsImage: false,
       supportsDocument: false,
       supportsMcp: false,
+      supportsFreeformTools: false,
     })
   })
 

--- a/sdks/typescript/tests/providers-native-model.test.ts
+++ b/sdks/typescript/tests/providers-native-model.test.ts
@@ -12,6 +12,7 @@ import {
   type ProviderImpl,
 } from '../src/provider.js'
 import { ChatGptCodexProvider } from '../src/providers/chatgpt_codex.js'
+import { DEFAULT_OPENAI_RESPONSES_URL, OpenAIProvider } from '../src/providers/openai.js'
 import { collectModelStream } from '../src/stream.js'
 import type { ModelChatRequest, ModelStreamDelta } from '../src/types.js'
 
@@ -31,6 +32,18 @@ function sseFetch(sse: string, onRequest?: (url: string, init?: RequestInit) => 
       }),
       { status: 200, headers: { 'content-type': 'text/event-stream' } },
     )
+  })
+  vi.stubGlobal('fetch', mockFetch)
+  return mockFetch
+}
+
+function jsonFetch(body: unknown, onRequest?: (url: string, init?: RequestInit) => void) {
+  const mockFetch = vi.fn(async (url: string, init?: RequestInit) => {
+    onRequest?.(url, init)
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
   })
   vi.stubGlobal('fetch', mockFetch)
   return mockFetch
@@ -477,5 +490,167 @@ describe('ChatGptCodexProvider native surface', () => {
     await expect(
       collectModelStream(new ChatGptCodexProvider('tok', 'acct').modelStream({ context: [] })),
     ).rejects.toBeInstanceOf(IncompleteStreamError)
+  })
+})
+
+describe('OpenAIProvider native surface', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('keeps withResponsesApi and withResponsesFallback independent', () => {
+    const provider = new OpenAIProvider('k', 'gpt-5.5-codex')
+    expect(provider.capabilities().supportsFreeformTools).toBe(false)
+    provider.withResponsesFallback(true)
+    expect(provider.capabilities().supportsFreeformTools).toBe(false)
+    provider.withResponsesApi(true)
+    expect(provider.capabilities()).toEqual({
+      supportsImage: true,
+      supportsDocument: false,
+      supportsMcp: false,
+      supportsFreeformTools: true,
+    })
+    provider.withResponsesApi(false)
+    expect(provider.capabilities().supportsFreeformTools).toBe(false)
+  })
+
+  it('POSTs the Responses endpoint and decodes a freeform call (non-streaming)', async () => {
+    const raw = 'const x = {a: 1};\nconsole.log(x.a);\n'
+    let sent: Record<string, any> = {}
+    const mockFetch = jsonFetch(
+      {
+        model: 'gpt-5.5-codex',
+        status: 'completed',
+        output: [{ type: 'custom_tool_call', call_id: 'call_js', name: 'exec', input: raw }],
+        usage: { input_tokens: 9, output_tokens: 7 },
+      },
+      (_url, init) => {
+        sent = JSON.parse(String(init?.body))
+      },
+    )
+
+    const response = await new OpenAIProvider('test-key', 'gpt-5.5-codex')
+      .withResponsesApi(true)
+      .modelChat({
+        context: [{ kind: 'message', message: { role: 'user', content: 'run js' } }],
+        toolSpecs: [{ kind: 'freeform', tool: FREEFORM_TOOL }],
+      })
+
+    expect(String(mockFetch.mock.calls[0][0])).toBe(DEFAULT_OPENAI_RESPONSES_URL)
+    expect(sent.stream).toBeUndefined()
+    expect(sent.tools[0]).toEqual({
+      type: 'custom',
+      name: 'exec',
+      description: 'Run JavaScript',
+      format: { type: 'grammar', syntax: 'lark', definition: 'start: source' },
+    })
+    expect(response.toolCalls).toEqual([
+      { kind: 'freeform', id: 'call_js', name: 'exec', input: raw },
+    ])
+    expect(response.stopReason).toBe('tool_use')
+    expect(response.usage.inputTokens).toBe(9)
+  })
+
+  it('encodes image content blocks as input_image data URLs', async () => {
+    let sent: Record<string, any> = {}
+    jsonFetch(
+      {
+        model: 'gpt-5.5-codex',
+        status: 'completed',
+        output: [{ type: 'message', content: [{ type: 'output_text', text: 'ok' }] }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+      (_url, init) => {
+        sent = JSON.parse(String(init?.body))
+      },
+    )
+
+    const response = await new OpenAIProvider('test-key', 'gpt-5.5-codex')
+      .withResponsesApi(true)
+      .modelChat({
+        context: [
+          {
+            kind: 'message',
+            message: {
+              role: 'user',
+              content: 'inspect',
+              contentBlocks: [
+                { type: 'text', text: 'inspect' },
+                {
+                  type: 'image',
+                  source: { type: 'base64', mediaType: 'image/png', data: 'abc123' },
+                },
+              ],
+            },
+          },
+        ],
+      })
+
+    expect(sent.input[0].content).toEqual([
+      { type: 'input_text', text: 'inspect' },
+      { type: 'input_image', image_url: 'data:image/png;base64,abc123' },
+    ])
+    expect(response.content).toBe('ok')
+  })
+
+  it('rejects native freeform BEFORE any HTTP call when the opt-in is off', async () => {
+    const mockFetch = jsonFetch({})
+    const provider = new OpenAIProvider('test-key', 'gpt-5.5-codex')
+    const request: ModelChatRequest = {
+      context: [{ kind: 'message', message: { role: 'user', content: 'run js' } }],
+      toolSpecs: [{ kind: 'freeform', tool: FREEFORM_TOOL }],
+    }
+
+    await expect(provider.modelChat(request)).rejects.toThrow(
+      'provider does not support native freeform tools',
+    )
+    expect(() => provider.modelStream(request)).toThrow(
+      'provider does not support native freeform tools',
+    )
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('reports the endpoint message for a non-freeform request with the opt-in off', async () => {
+    const mockFetch = jsonFetch({})
+    const provider = new OpenAIProvider('test-key', 'gpt-5.5-codex')
+    await expect(provider.modelChat({ context: [] })).rejects.toThrow(
+      'OpenAI Chat Completions does not support native model requests; enable OpenAI Responses API',
+    )
+    expect(() => provider.modelStream({ context: [] })).toThrow(
+      'OpenAI Chat Completions does not support native model streams; enable OpenAI Responses API',
+    )
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('streams native custom deltas and collects them', async () => {
+    const sse =
+      'data: {"type":"response.custom_tool_call_input.delta","call_id":"call_js","delta":"console."}\n\n' +
+      'data: {"type":"response.custom_tool_call_input.delta","call_id":"call_js","delta":"log(1);\\n"}\n\n' +
+      'data: {"type":"response.output_item.done","item":{"type":"custom_tool_call","call_id":"call_js","name":"exec","input":"console.log(1);\\n"}}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":3}}}\n\n'
+    sseFetch(sse)
+
+    const response = await collectModelStream(
+      new OpenAIProvider('test-key', 'gpt-5.5-codex').withResponsesApi(true).modelStream({
+        context: [{ kind: 'message', message: { role: 'user', content: 'run js' } }],
+        toolSpecs: [{ kind: 'freeform', tool: FREEFORM_TOOL }],
+      }),
+    )
+    expect(response.toolCalls).toEqual([
+      { kind: 'freeform', id: 'call_js', name: 'exec', input: 'console.log(1);\n' },
+    ])
+    expect(response.usage.outputTokens).toBe(3)
+  })
+
+  it('throws IncompleteStreamError with the openai payload on truncation', async () => {
+    sseFetch(
+      'data: {"type":"response.output_text.delta","delta":"hel"}\n\n' +
+        'data: {"type":"response.output_text.delta","delta":"lo"}\n\n',
+    )
+    await expect(
+      collectModelStream(
+        new OpenAIProvider('test-key', 'gpt-5.5-codex')
+          .withResponsesApi(true)
+          .modelStream({ context: [] }),
+      ),
+    ).rejects.toThrow('incomplete stream: openai ended without a terminal event')
   })
 })

--- a/sdks/typescript/tests/providers-native-model.test.ts
+++ b/sdks/typescript/tests/providers-native-model.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest'
+import { StreamReadTimeoutError, UnsupportedFeatureError } from '../src/error.js'
+import {
+  dispatchModelChat,
+  dispatchModelStream,
+  readTimeoutModelStream,
+  textOnly,
+  validateModelRequest,
+  withFreeformTools,
+  withImage,
+  withImageAndFreeformTools,
+  type ProviderImpl,
+} from '../src/provider.js'
 import { collectModelStream } from '../src/stream.js'
-import type { ModelStreamDelta } from '../src/types.js'
+import type { ModelChatRequest, ModelStreamDelta } from '../src/types.js'
 
 async function* deltas(items: ModelStreamDelta[]): AsyncGenerator<ModelStreamDelta> {
   for (const item of items) yield item
@@ -110,5 +122,186 @@ describe('collectModelStream', () => {
       throw new Error('boom')
     }
     await expect(collectModelStream(failing())).rejects.toThrow('boom')
+  })
+})
+
+const FREEFORM_SPEC_REQUEST: ModelChatRequest = {
+  context: [{ kind: 'message', message: { role: 'user', content: 'run js' } }],
+  toolSpecs: [
+    {
+      kind: 'freeform',
+      tool: {
+        name: 'exec',
+        description: 'Run JavaScript',
+        format: { type: 'grammar', syntax: 'lark', definition: 'start: source' },
+      },
+    },
+  ],
+}
+
+describe('freeform capability factories (D5)', () => {
+  it('withFreeformTools() is text-only plus freeform', () => {
+    expect(withFreeformTools()).toEqual({
+      supportsImage: false,
+      supportsDocument: false,
+      supportsMcp: false,
+      supportsFreeformTools: true,
+    })
+  })
+
+  it('withImageAndFreeformTools() adds images', () => {
+    expect(withImageAndFreeformTools()).toEqual({
+      supportsImage: true,
+      supportsDocument: false,
+      supportsMcp: false,
+      supportsFreeformTools: true,
+    })
+  })
+
+  it('the pre-existing factories keep freeform false', () => {
+    expect(textOnly().supportsFreeformTools).toBe(false)
+    expect(withImage().supportsFreeformTools).toBe(false)
+  })
+})
+
+describe('validateModelRequest', () => {
+  it('rejects a freeform tool spec on a non-freeform provider', () => {
+    expect(() => validateModelRequest(FREEFORM_SPEC_REQUEST, withImage())).toThrow(
+      UnsupportedFeatureError,
+    )
+    expect(() => validateModelRequest(FREEFORM_SPEC_REQUEST, withImage())).toThrow(
+      'provider does not support native freeform tools',
+    )
+  })
+
+  it('rejects freeform history even without a freeform spec', () => {
+    const withCall: ModelChatRequest = {
+      context: [
+        { kind: 'toolCall', call: { kind: 'freeform', id: 'c', name: 'exec', input: 'x' } },
+      ],
+    }
+    const withOutput: ModelChatRequest = {
+      context: [{ kind: 'toolOutput', output: { kind: 'custom', callId: 'c', output: 'x' } }],
+    }
+    expect(() => validateModelRequest(withCall, withImage())).toThrow(UnsupportedFeatureError)
+    expect(() => validateModelRequest(withOutput, withImage())).toThrow(UnsupportedFeatureError)
+  })
+
+  it('accepts freeform on a freeform-capable provider', () => {
+    expect(() => validateModelRequest(FREEFORM_SPEC_REQUEST, withFreeformTools())).not.toThrow()
+  })
+
+  it('accepts function specs and function history everywhere', () => {
+    const req: ModelChatRequest = {
+      context: [
+        { kind: 'toolCall', call: { kind: 'function', id: 'c', name: 'f', arguments: '{}' } },
+        { kind: 'toolOutput', output: { kind: 'function', callId: 'c', output: 'ok' } },
+      ],
+      toolSpecs: [{ kind: 'function', tool: { name: 'f', description: 'F', inputSchema: {} } }],
+    }
+    expect(() => validateModelRequest(req, textOnly())).not.toThrow()
+  })
+
+  it('rejects image blocks in context on a text-only provider', () => {
+    const req: ModelChatRequest = {
+      context: [
+        {
+          kind: 'message',
+          message: {
+            role: 'user',
+            content: '',
+            contentBlocks: [
+              { type: 'image', source: { type: 'url', url: 'https://e.example/a.png' } },
+            ],
+          },
+        },
+      ],
+    }
+    expect(() => validateModelRequest(req, withFreeformTools())).toThrow(
+      'provider does not support image input',
+    )
+    expect(() => validateModelRequest(req, withImageAndFreeformTools())).not.toThrow()
+  })
+
+  it('rejects document blocks in context', () => {
+    const req: ModelChatRequest = {
+      context: [
+        {
+          kind: 'message',
+          message: {
+            role: 'user',
+            content: '',
+            contentBlocks: [
+              { type: 'document', source: { type: 'url', url: 'https://e.example/a.pdf' } },
+            ],
+          },
+        },
+      ],
+    }
+    expect(() => validateModelRequest(req, withImageAndFreeformTools())).toThrow(
+      'provider does not support document input',
+    )
+  })
+})
+
+describe('native dispatch', () => {
+  const bareProvider: ProviderImpl = {
+    capabilities: withFreeformTools,
+    chat: async () => {
+      throw new Error('unused')
+    },
+    stream: () => {
+      throw new Error('unused')
+    },
+  }
+
+  it('rejects modelChat on a provider that implements no native surface', async () => {
+    await expect(dispatchModelChat(bareProvider, { context: [] })).rejects.toThrow(
+      'provider does not support native model requests',
+    )
+  })
+
+  it('rejects modelStream on a provider that implements no native surface', () => {
+    expect(() => dispatchModelStream(bareProvider, { context: [] })).toThrow(
+      'provider does not support native model streams',
+    )
+  })
+
+  it('validates BEFORE consulting the native surface', async () => {
+    const imageOnly: ProviderImpl = { ...bareProvider, capabilities: withImage }
+    await expect(dispatchModelChat(imageOnly, FREEFORM_SPEC_REQUEST)).rejects.toThrow(
+      'provider does not support native freeform tools',
+    )
+  })
+})
+
+describe('readTimeoutModelStream', () => {
+  it('passes deltas through untouched', async () => {
+    const out: ModelStreamDelta[] = []
+    for await (const delta of readTimeoutModelStream(
+      deltas([{ type: 'text', delta: 'a' }, { type: 'done', stopReason: 'end_turn' }]),
+      5,
+    )) {
+      out.push(delta)
+    }
+    expect(out).toEqual([{ type: 'text', delta: 'a' }, { type: 'done', stopReason: 'end_turn' }])
+  })
+
+  it('throws StreamReadTimeoutError on an idle gap and fabricates no done', async () => {
+    async function* stalls(): AsyncGenerator<ModelStreamDelta> {
+      yield { type: 'text', delta: 'tick' }
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      yield { type: 'done', stopReason: 'end_turn' }
+    }
+
+    const out: ModelStreamDelta[] = []
+    let caught: unknown
+    try {
+      for await (const delta of readTimeoutModelStream(stalls(), 0.05)) out.push(delta)
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(StreamReadTimeoutError)
+    expect(out).toEqual([{ type: 'text', delta: 'tick' }])
   })
 })

--- a/sdks/typescript/tests/providers-native-model.test.ts
+++ b/sdks/typescript/tests/providers-native-model.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { collectModelStream } from '../src/stream.js'
+import type { ModelStreamDelta } from '../src/types.js'
+
+async function* deltas(items: ModelStreamDelta[]): AsyncGenerator<ModelStreamDelta> {
+  for (const item of items) yield item
+}
+
+describe('collectModelStream', () => {
+  it('preserves the completed freeform call and never lowers accumulated deltas', async () => {
+    const response = await collectModelStream(
+      deltas([
+        { type: 'freeform_input', callId: 'call_js', delta: 'console.' },
+        { type: 'freeform_input', callId: 'call_js', delta: 'log(1);' },
+        {
+          type: 'tool_call_done',
+          call: { kind: 'freeform', id: 'call_js', name: 'exec', input: 'console.log(1);' },
+        },
+        { type: 'usage', usage: { inputTokens: 2, outputTokens: 3 } },
+        { type: 'done', stopReason: 'tool_use' },
+      ]),
+    )
+
+    expect(response.toolCalls).toEqual([
+      { kind: 'freeform', id: 'call_js', name: 'exec', input: 'console.log(1);' },
+    ])
+    expect(response.stopReason).toBe('tool_use')
+    expect(response.usage.outputTokens).toBe(3)
+    expect(response.model).toBe('')
+  })
+
+  it('prefers thinking_done over accumulated thinking deltas', async () => {
+    const response = await collectModelStream(
+      deltas([
+        { type: 'thinking_delta', delta: 'think ' },
+        { type: 'thinking_delta', delta: 'hard' },
+        { type: 'thinking_done', thinking: 'think hard' },
+        { type: 'text', delta: 'answer' },
+        { type: 'done', stopReason: 'end_turn' },
+      ]),
+    )
+    expect(response.content).toBe('answer')
+    expect(response.thinking).toBe('think hard')
+  })
+
+  it('falls back to concatenated thinking deltas when no thinking_done arrives', async () => {
+    const response = await collectModelStream(
+      deltas([
+        { type: 'thinking_delta', delta: 'partial ' },
+        { type: 'thinking_delta', delta: 'reasoning' },
+        { type: 'done', stopReason: 'end_turn' },
+      ]),
+    )
+    expect(response.thinking).toBe('partial reasoning')
+  })
+
+  it('drops an empty thinking_done payload entirely', async () => {
+    const response = await collectModelStream(
+      deltas([
+        { type: 'thinking_delta', delta: 'ignored' },
+        { type: 'thinking_done', thinking: '' },
+        { type: 'done', stopReason: 'end_turn' },
+      ]),
+    )
+    expect(response.thinking).toBeUndefined()
+  })
+
+  it('REPLACES usage rather than merging it', async () => {
+    const response = await collectModelStream(
+      deltas([
+        { type: 'usage', usage: { inputTokens: 100, outputTokens: 100, cacheReadInputTokens: 9 } },
+        { type: 'usage', usage: { inputTokens: 1, outputTokens: 2 } },
+        { type: 'done', stopReason: 'end_turn' },
+      ]),
+    )
+    expect(response.usage).toEqual({ inputTokens: 1, outputTokens: 2 })
+  })
+
+  it('stops at the terminal done and ignores anything after it', async () => {
+    const response = await collectModelStream(
+      deltas([
+        { type: 'text', delta: 'kept' },
+        { type: 'done', stopReason: 'end_turn' },
+        { type: 'text', delta: 'dropped' },
+      ]),
+    )
+    expect(response.content).toBe('kept')
+  })
+
+  it('infers tool_use when no done delta carried a stop reason', async () => {
+    const response = await collectModelStream(
+      deltas([
+        {
+          type: 'tool_call_done',
+          call: { kind: 'function', id: 'call_1', name: 'f', arguments: '{}' },
+        },
+      ]),
+    )
+    expect(response.stopReason).toBe('tool_use')
+  })
+
+  it('infers end_turn for a bare text stream with no done delta', async () => {
+    const response = await collectModelStream(deltas([{ type: 'text', delta: 'hi' }]))
+    expect(response.stopReason).toBe('end_turn')
+  })
+
+  it('propagates a mid-stream error instead of returning a partial response', async () => {
+    async function* failing(): AsyncGenerator<ModelStreamDelta> {
+      yield { type: 'text', delta: 'partial' }
+      throw new Error('boom')
+    }
+    await expect(collectModelStream(failing())).rejects.toThrow('boom')
+  })
+})

--- a/sdks/typescript/tests/providers-native-model.test.ts
+++ b/sdks/typescript/tests/providers-native-model.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { StreamReadTimeoutError, UnsupportedFeatureError } from '../src/error.js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { IncompleteStreamError, StreamReadTimeoutError, UnsupportedFeatureError } from '../src/error.js'
 import {
   dispatchModelChat,
   dispatchModelStream,
@@ -11,11 +11,29 @@ import {
   withImageAndFreeformTools,
   type ProviderImpl,
 } from '../src/provider.js'
+import { ChatGptCodexProvider } from '../src/providers/chatgpt_codex.js'
 import { collectModelStream } from '../src/stream.js'
 import type { ModelChatRequest, ModelStreamDelta } from '../src/types.js'
 
 async function* deltas(items: ModelStreamDelta[]): AsyncGenerator<ModelStreamDelta> {
   for (const item of items) yield item
+}
+
+function sseFetch(sse: string, onRequest?: (url: string, init?: RequestInit) => void) {
+  const mockFetch = vi.fn(async (url: string, init?: RequestInit) => {
+    onRequest?.(url, init)
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(sse))
+          controller.close()
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'text/event-stream' } },
+    )
+  })
+  vi.stubGlobal('fetch', mockFetch)
+  return mockFetch
 }
 
 describe('collectModelStream', () => {
@@ -138,6 +156,12 @@ const FREEFORM_SPEC_REQUEST: ModelChatRequest = {
     },
   ],
 }
+
+const FREEFORM_TOOL = {
+  name: 'exec',
+  description: 'Run JavaScript',
+  format: { type: 'grammar', syntax: 'lark', definition: 'start: source' },
+} as const
 
 describe('freeform capability factories (D5)', () => {
   it('withFreeformTools() is text-only plus freeform', () => {
@@ -303,5 +327,155 @@ describe('readTimeoutModelStream', () => {
     }
     expect(caught).toBeInstanceOf(StreamReadTimeoutError)
     expect(out).toEqual([{ type: 'text', delta: 'tick' }])
+  })
+})
+
+describe('ChatGptCodexProvider native surface', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('declares freeform yes / image no / document no', () => {
+    expect(new ChatGptCodexProvider('tok', 'acct').capabilities()).toEqual({
+      supportsImage: false,
+      supportsDocument: false,
+      supportsMcp: false,
+      supportsFreeformTools: true,
+    })
+  })
+
+  it('hard-sets the codex body fields, overriding the caller tool choice', () => {
+    const body = new ChatGptCodexProvider('tok', 'acct').buildModelResponsesBody({
+      context: [{ kind: 'message', message: { role: 'user', content: 'hi' } }],
+      toolChoice: { type: 'required' },
+    })
+    expect(body.store).toBe(false)
+    expect(body.stream).toBe(true)
+    expect(body.include).toEqual(['reasoning.encrypted_content'])
+    expect(body.parallel_tool_calls).toBe(true)
+    expect(body.tool_choice).toBe('auto')
+    expect(body.instructions).toBe('You are a helpful assistant.')
+    expect(body.model).toBe('gpt-5.5')
+  })
+
+  it('normalizes a per-request reasoning effort and deletes the raw key', () => {
+    const body = new ChatGptCodexProvider('tok', 'acct').buildModelResponsesBody({
+      context: [],
+      providerOptions: { reasoning_effort: 'high' },
+    })
+    expect(body.reasoning).toEqual({ effort: 'high', summary: 'auto' })
+    expect(body.reasoning_effort).toBeUndefined()
+    expect('reasoning_effort' in body).toBe(false)
+  })
+
+  it('lets the per-request effort beat the provider default', () => {
+    const body = new ChatGptCodexProvider('tok', 'acct')
+      .reasoningEffort('low')
+      .buildModelResponsesBody({ context: [], providerOptions: { reasoning_effort: 'high' } })
+    expect(body.reasoning).toEqual({ effort: 'high', summary: 'auto' })
+  })
+
+  it('uses the provider default when the request supplies none', () => {
+    const body = new ChatGptCodexProvider('tok', 'acct')
+      .reasoningEffort('high')
+      .buildModelResponsesBody({ context: [] })
+    expect(body.reasoning).toEqual({ effort: 'high', summary: 'auto' })
+  })
+
+  it('omits reasoning entirely when neither is set', () => {
+    expect(
+      new ChatGptCodexProvider('tok', 'acct').buildModelResponsesBody({ context: [] }).reasoning,
+    ).toBeUndefined()
+  })
+
+  it('streams a freeform call and collects it', async () => {
+    const sse =
+      'data: {"type":"response.custom_tool_call_input.delta","call_id":"call_js","delta":"console."}\n\n' +
+      'data: {"type":"response.output_item.done","item":{"type":"custom_tool_call","call_id":"call_js","name":"exec","input":"console.log(1);\\n"}}\n\n' +
+      'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":3}}}\n\n'
+    sseFetch(sse)
+
+    const response = await collectModelStream(
+      new ChatGptCodexProvider('tok', 'acct').modelStream({
+        context: [{ kind: 'message', message: { role: 'user', content: 'run js' } }],
+        toolSpecs: [{ kind: 'freeform', tool: FREEFORM_TOOL }],
+      }),
+    )
+    expect(response.toolCalls).toEqual([
+      { kind: 'freeform', id: 'call_js', name: 'exec', input: 'console.log(1);\n' },
+    ])
+    expect(response.stopReason).toBe('tool_use')
+    expect(response.usage.outputTokens).toBe(3)
+  })
+
+  it('modelChat collects the native stream and backfills the model id', async () => {
+    const sse =
+      `data: {"type":"response.output_item.done","item":{"type":"custom_tool_call","call_id":"call_js","name":"exec","input":"text('captured');"}}\n\n` +
+      'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4,"output_tokens":5}}}\n\n'
+    sseFetch(sse)
+
+    const response = await new ChatGptCodexProvider('tok', 'acct').modelChat({
+      context: [{ kind: 'message', message: { role: 'user', content: 'run js' } }],
+      toolSpecs: [{ kind: 'freeform', tool: FREEFORM_TOOL }],
+    })
+    expect(response.toolCalls).toEqual([
+      { kind: 'freeform', id: 'call_js', name: 'exec', input: "text('captured');" },
+    ])
+    expect(response.model).toBe('gpt-5.5')
+  })
+
+  it('maps response.incomplete to max_tokens', async () => {
+    sseFetch(
+      'data: {"type":"response.output_text.delta","delta":"partial"}\n\n' +
+        'data: {"type":"response.incomplete","response":{"status":"incomplete","usage":{"input_tokens":6,"output_tokens":7}}}\n\n',
+    )
+    const response = await new ChatGptCodexProvider('tok', 'acct').modelChat({
+      context: [{ kind: 'message', message: { role: 'user', content: 'short' } }],
+    })
+    expect(response.content).toBe('partial')
+    expect(response.stopReason).toBe('max_tokens')
+    expect(response.usage.outputTokens).toBe(7)
+  })
+
+  it('sends the custom tool and the symmetric history byte-exact', async () => {
+    const raw = '{"this":"looks like json"}\nconsole.log(\'but is JS\');'
+    let sent: Record<string, any> = {}
+    sseFetch(
+      'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      (_url, init) => {
+        sent = JSON.parse(String(init?.body))
+      },
+    )
+
+    const response = await new ChatGptCodexProvider('tok', 'acct').modelChat({
+      context: [
+        { kind: 'message', message: { role: 'user', content: 'run js' } },
+        { kind: 'toolCall', call: { kind: 'freeform', id: 'call_js', name: 'exec', input: raw } },
+        {
+          kind: 'toolOutput',
+          output: { kind: 'custom', callId: 'call_js', name: 'exec', output: 'done' },
+        },
+      ],
+      toolSpecs: [{ kind: 'freeform', tool: FREEFORM_TOOL }],
+    })
+
+    expect(sent.tools[0].type).toBe('custom')
+    expect(sent.input.map((item: Record<string, unknown>) => item.type)).toEqual([
+      'message',
+      'custom_tool_call',
+      'custom_tool_call_output',
+    ])
+    expect(sent.input[1].input).toBe(raw)
+    expect(response.stopReason).toBe('end_turn')
+  })
+
+  it('throws IncompleteStreamError with the hyphenated provider token on truncation', async () => {
+    sseFetch(
+      'data: {"type":"response.custom_tool_call_input.delta","call_id":"call_js","delta":"console."}\n\n',
+    )
+    await expect(
+      collectModelStream(new ChatGptCodexProvider('tok', 'acct').modelStream({ context: [] })),
+    ).rejects.toThrow('incomplete stream: chatgpt-codex ended without a terminal event')
+    await expect(
+      collectModelStream(new ChatGptCodexProvider('tok', 'acct').modelStream({ context: [] })),
+    ).rejects.toBeInstanceOf(IncompleteStreamError)
   })
 })

--- a/sdks/typescript/tests/providers-native-model.test.ts
+++ b/sdks/typescript/tests/providers-native-model.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { IncompleteStreamError, StreamReadTimeoutError, UnsupportedFeatureError } from '../src/error.js'
+import { Client, ClientBuilder, type ProviderLike } from '../src/client.js'
 import {
   dispatchModelChat,
   dispatchModelStream,
@@ -14,7 +15,7 @@ import {
 import { ChatGptCodexProvider } from '../src/providers/chatgpt_codex.js'
 import { DEFAULT_OPENAI_RESPONSES_URL, OpenAIProvider } from '../src/providers/openai.js'
 import { collectModelStream } from '../src/stream.js'
-import type { ModelChatRequest, ModelStreamDelta } from '../src/types.js'
+import type { ModelChatRequest, ModelChatResponse, ModelStreamDelta } from '../src/types.js'
 
 async function* deltas(items: ModelStreamDelta[]): AsyncGenerator<ModelStreamDelta> {
   for (const item of items) yield item
@@ -652,5 +653,183 @@ describe('OpenAIProvider native surface', () => {
           .modelStream({ context: [] }),
       ),
     ).rejects.toThrow('incomplete stream: openai ended without a terminal event')
+  })
+})
+
+describe('Client native surface', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('modelChat dispatches through the built provider', async () => {
+    jsonFetch({
+      model: 'gpt-5.5-codex',
+      status: 'completed',
+      output: [{ type: 'message', content: [{ type: 'output_text', text: 'ok' }] }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    })
+
+    const client = Client.builder()
+      .provider('openai')
+      .apiKey('test-key')
+      .model('gpt-5.5-codex')
+      .openaiResponsesApi(true)
+      .build()
+
+    const response = await client.modelChat({
+      context: [{ kind: 'message', message: { role: 'user', content: 'hi' } }],
+    })
+    expect(response.content).toBe('ok')
+  })
+
+  it('openaiResponsesApi(true) flips the built provider capabilities', () => {
+    const provider = new ClientBuilder()
+      .provider('openai')
+      .apiKey('k')
+      .openaiResponsesApi(true)
+      .buildProviderForTest()
+    expect(provider.capabilities().supportsFreeformTools).toBe(true)
+  })
+
+  it('defaults the responses opt-in to off, independent of the fallback flag', () => {
+    const plain = new ClientBuilder().provider('openai').apiKey('k').buildProviderForTest()
+    expect(plain.capabilities().supportsFreeformTools).toBe(false)
+
+    const fallbackOnly = new ClientBuilder()
+      .provider('openai')
+      .apiKey('k')
+      .openaiResponsesFallback(true)
+      .buildProviderForTest()
+    expect(fallbackOnly.capabilities().supportsFreeformTools).toBe(false)
+  })
+
+  it('modelStream rejects synchronously before any HTTP when unsupported', () => {
+    const mockFetch = jsonFetch({})
+    const client = Client.builder().provider('openai').apiKey('test-key').build()
+    expect(() =>
+      client.modelStream({
+        context: [],
+        toolSpecs: [{ kind: 'freeform', tool: FREEFORM_TOOL }],
+      }),
+    ).toThrow('provider does not support native freeform tools')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('modelStreamCollect backfills the model from the request', async () => {
+    sseFetch(
+      'data: {"type":"response.output_text.delta","delta":"hi"}\n\n' +
+        'data: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+    )
+    const client = Client.builder()
+      .provider('openai')
+      .apiKey('test-key')
+      .openaiResponsesApi(true)
+      .build()
+
+    const response = await client.modelStreamCollect({
+      context: [{ kind: 'message', message: { role: 'user', content: 'hi' } }],
+      model: 'gpt-5.5-codex',
+    })
+    expect(response.content).toBe('hi')
+    expect(response.model).toBe('gpt-5.5-codex')
+  })
+
+  it('applies the read-idle timeout to native streams', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  new TextEncoder().encode(
+                    'data: {"type":"response.output_text.delta","delta":"tick"}\n\n',
+                  ),
+                )
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+    )
+
+    const client = Client.builder()
+      .provider('openai')
+      .apiKey('test-key')
+      .openaiResponsesApi(true)
+      .timeouts({ readIdleMs: 50 })
+      .build()
+
+    const seen: ModelStreamDelta[] = []
+    let caught: unknown
+    try {
+      for await (const delta of client.modelStream({ context: [] })) seen.push(delta)
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(StreamReadTimeoutError)
+    expect(seen).toEqual([{ type: 'text', delta: 'tick' }])
+  })
+})
+
+describe('asDispatchProvider forwards the native surface', () => {
+  const nativeResponse: ModelChatResponse = {
+    content: 'shimmed',
+    toolCalls: [],
+    model: 'm',
+    usage: { inputTokens: 0, outputTokens: 0 },
+    stopReason: 'end_turn',
+  }
+
+  it('keeps modelChat/modelStream when the provider has no capabilities()', async () => {
+    const bare: ProviderLike = {
+      chat: async () => {
+        throw new Error('unused')
+      },
+      stream: () => {
+        throw new Error('unused')
+      },
+      modelChat: async () => nativeResponse,
+      modelStream: () => deltas([{ type: 'done', stopReason: 'end_turn' }]),
+    }
+
+    const client = new Client(bare)
+    expect((await client.modelChat({ context: [] })).content).toBe('shimmed')
+
+    const seen: ModelStreamDelta[] = []
+    for await (const delta of client.modelStream({ context: [] })) seen.push(delta)
+    expect(seen).toEqual([{ type: 'done', stopReason: 'end_turn' }])
+  })
+
+  it('still rejects when a shimmed provider omits the native surface', async () => {
+    const bare: ProviderLike = {
+      chat: async () => {
+        throw new Error('unused')
+      },
+      stream: () => {
+        throw new Error('unused')
+      },
+    }
+    const client = new Client(bare)
+    await expect(client.modelChat({ context: [] })).rejects.toThrow(
+      'provider does not support native model requests',
+    )
+    expect(() => client.modelStream({ context: [] })).toThrow(
+      'provider does not support native model streams',
+    )
+  })
+
+  it('keeps the native surface on a provider that DOES expose capabilities()', async () => {
+    const full: ProviderLike = {
+      capabilities: () => withFreeformTools(),
+      chat: async () => {
+        throw new Error('unused')
+      },
+      stream: () => {
+        throw new Error('unused')
+      },
+      modelChat: async () => nativeResponse,
+    }
+    const client = new Client(full)
+    expect((await client.modelChat({ context: [] })).content).toBe('shimmed')
   })
 })


### PR DESCRIPTION
Task group T2 of the Freeform parity milestone (#270). Wires the T1 codec into ChatGPT Codex (native by default) and OpenAI (behind `withResponsesApi` / `openaiResponsesApi`), adds `supportsFreeformTools`, native validation and dispatch, `collectModelStream`, the `readTimeoutModelStream` wrapper, `Client.modelChat`/`modelStream`/`modelStreamCollect`, and the `asDispatchProvider` forwarding fix.

Capability-shape assertions in `tests/capabilities.test.ts` and `tests/index.test.ts` flip to include `supportsFreeformTools` - expected per milestone D5, not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
