### PR TITLE
fix: record how the Python freeform conformance suite is proven non-vacuous

### DIFF
--- a/docs/superpowers/plans/2026-07-28-freeform-parity-PROMPT-SHEET.md
+++ b/docs/superpowers/plans/2026-07-28-freeform-parity-PROMPT-SHEET.md
@@ -166,7 +166,8 @@ Done when ALL hold:
 3. TypeScript gates and repo-wide gates green.
 4. Commit per the plan; push SHA-verified against refs/heads/feat/ts-freeform-conformance.
 5. PR open; `gh pr checks` shows `metadata` and `typescript` SUCCESS.
-6. Report the PR URL and list each mutation with the failure it produced. Do NOT merge.
+6. The suite's module docstring records the three mutations and the test each one fails, so the gate can be re-proven after a future refactor. A suite whose non-vacuity proof exists only in a chat log is unmaintainable.
+7. Report the PR URL and list each mutation with the failure it produced. Do NOT merge.
 
 Stop-loss: 3 consecutive failures on one step, or a mutation that does NOT make the suite fail → STOP and report verbatim. No --no-verify; no reset --hard.
 ```
@@ -185,7 +186,8 @@ Done when ALL hold:
 4. Repo-wide: `treefmt --fail-on-change`, `python3 scripts/check-versions.py` (versions must be untouched).
 5. Commit per the plan; push SHA-verified against refs/heads/feat/rust-freeform-conformance.
 6. PR open; `gh pr checks` shows `metadata`, `rust`, and `rust-msrv-no-features` SUCCESS.
-7. Report the PR URL and list each mutation with its failure. Do NOT merge.
+7. The suite's file-level doc comment records the three mutations and the test each one fails, so the gate can be re-proven after a future refactor.
+8. Report the PR URL and list each mutation with its failure. Do NOT merge.
 
 Stop-loss: 3 consecutive failures on one step, or any diff appearing under sdks/rust/src → STOP and report verbatim. No --no-verify; no reset --hard.
 ```

--- a/sdks/python/tests/test_freeform_conformance.py
+++ b/sdks/python/tests/test_freeform_conformance.py
@@ -7,6 +7,32 @@ Anchored to specs/types.md § Native Model API. Cross-SDK mirrors:
 Expected values come from the Rust tests that already pin this behaviour
 (tests/core_types.rs, tests/openai_provider.rs, tests/chatgpt_codex.rs,
 tests/native_collect_stream.rs). Do not invent new fixtures here.
+
+Proving this suite still bites
+------------------------------
+A conformance suite passes by construction the day it is written, so passing
+says nothing. Re-prove it after any refactor of the native surface by making
+each mutation below in turn, running this file, and confirming the named test
+fails — then reverting. Every one was verified against the suite as merged.
+
+1. ``providers/responses.py`` — in ``encode_tool_call``, replace
+   ``"input": call.input`` with a JSON round-trip such as
+   ``json.dumps(json.loads(call.input))``.
+   Fails: ``test_freeform_input_is_never_parsed_as_json_or_lowered_into_arguments``
+   (and ``test_ordered_mixed_history_replays_in_order``).
+2. ``_stream_collect.py`` — in ``collect_model_stream``, delete
+   ``tool_calls.append(delta.call)`` from the ToolCallDone arm so the
+   accumulated deltas would win instead.
+   Fails: ``test_tool_call_done_is_authoritative``.
+3. ``providers/chatgpt_codex.py`` — change the incomplete-stream payload from
+   ``chatgpt-codex`` to ``chatgpt_codex`` (the legacy adapter's spelling).
+   Fails: ``test_codex_eof_without_terminal_raises_incomplete_stream``.
+4. ``provider_base.py`` — make ``ProviderCapabilities.full()`` return
+   ``supports_freeform_tools=True``.
+   Fails: ``test_capability_matrix_matches_the_spec``.
+
+Deleting a whole module and watching the import fail is NOT such a check: an
+empty file with zero assertions produces the identical collection error.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Follow-up to #276, for #270.

A conformance suite passes by construction the day it is written, so passing proves nothing about it. The Python suite's non-vacuity was established by four behavioural mutations — but that proof lived only in a chat log and an issue comment, which means the next person to refactor the native surface has no way to check the gate still bites. That is exactly how a gate rots into decoration.

This records the four verified mutations in the suite's module docstring: which line to break, and which test fails when you do.

| Mutation | Fails |
|---|---|
| `encode_tool_call`: round-trip freeform `input` through `json.dumps(json.loads(...))` | `test_freeform_input_is_never_parsed_as_json_or_lowered_into_arguments` (+ the ordered-history test) |
| `collect_model_stream`: delete `tool_calls.append(delta.call)` from the ToolCallDone arm | `test_tool_call_done_is_authoritative` |
| Codex payload `chatgpt-codex` → `chatgpt_codex` | `test_codex_eof_without_terminal_raises_incomplete_stream` |
| `ProviderCapabilities.full()` returns `supports_freeform_tools=True` | `test_capability_matrix_matches_the_spec` |

The docstring also states what does **not** count, because that was the original defect: the plan's Task 16 told the executor to delete `providers/responses.py` and watch `ModuleNotFoundError` at collection. A zero-assertion file produces the identical error, so it proved only that the file imports the module. The executor followed the plan faithfully — the weak check was mine, and my review of the draft missed it while the TypeScript plan got it right.

Also amends the two remaining conformance goals in the prompt sheet so C-TS and C-RS record their own mutation lists in the suite rather than only in a run report, and all three SDKs end up with the same self-documenting gate.

No behaviour change; the suite is unmodified apart from its docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)