### PR TITLE
fix: ignore stray repo-root node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ sdks/typescript/dist/
 
 # CodeGraph index (local, rebuilt via `codegraph init`)
 /.codegraph/
+
+# Stray repo-root node_modules. Only sdks/typescript has a real dependency
+# tree; anything at the root is a tool artefact (a Vite cache, typically) and
+# was showing up as untracked noise in every `git status`.
+/node_modules/


### PR DESCRIPTION
Repository cleanup. Only `sdks/typescript` has a real dependency tree — the `.gitignore` already covers it. A `node_modules/` at the repo root is a tool artefact (in this case a 4 KB directory containing nothing but a Vite cache) and was showing up as untracked noise in every `git status`.

Part of a wider cleanup pass: 70 merged remote branches deleted, 41 merged local branches deleted, three stale worktrees removed, and 18 untracked planning docs discarded after verifying each was byte-identical to its committed twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)