### PR TITLE
chore(release): python-v0.20.0 and ts-v0.16.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Multi-provider AI SDK. Rust (`sdks/rust/`) + Python (`sdks/python/`) + TypeScript (`sdks/typescript/`). Independent idiomatic implementations — no shared runtime.
 
-Rust v0.27.1 · Python v0.19.0 (PyPI) · TypeScript v0.15.0 (npm)
+Rust v0.27.1 · Python v0.20.0 (PyPI) · TypeScript v0.16.0 (npm)
 
 Python 0.13.0 adds CLI-runtime setters (`.cwd()`, session continuity via `session_id` + `resume()`, per-run `.env()/.envs()`, CLI tool-call stream events, configurable `.timeout()/.no_timeout()`) and a **breaking** fallible stream: HTTP provider `stream()` now raises `motosan_ai.error.StreamError` mid-stream instead of swallowing transport/parse faults (`collect_stream` propagates it; `Client.stream_with` does not retry after a mid-stream raise).
 
@@ -19,6 +19,8 @@ Rust 0.25.0 / Python 0.18.0 / TypeScript 0.15.0 are the M4 spec-and-parity relea
 Rust 0.26.0 is the AI0 native Freeform/custom tool transport release. It preserves the legacy function-only `ChatRequest`, `Tool`, `ToolCall`, `ChatResponse`, and `StreamEvent` APIs, and adds a parallel ordered native model API (`ModelChatRequest`, `ModelContextItem`, `ModelToolSpec`, `FreeformTool`, `ModelToolCall`, `ModelToolOutput`, `ModelChatResponse`, `ModelStreamDelta`, `BoxModelStream`) for Function and Freeform tool definitions/calls/outputs, blocking responses, streaming deltas, and subsequent-request history. OpenAI Responses and ChatGPT Codex share one Responses codec. Raw Freeform input (for example JavaScript) must remain byte-for-byte intact and must never be lowered into JSON function arguments. Providers without native Freeform support must reject before network I/O with `MotosanError::UnsupportedFeature`.
 
 Rust 0.27.0 / Python 0.19.0 are the correctness quick-wins releases (TypeScript unchanged at 0.15.0). Rust: `ThinkStripper` no longer panics on multi-byte UTF-8 inside an unterminated `<think>` block, and native model streams report EOF truncation with the conventional `incomplete stream: <provider> ended without a terminal event` payload — `providers::responses::model_stream_adapter` now takes a provider name, and `specs/types.md` pins the native termination contract while labelling the legacy `stream()` rows in its terminal-event table. Python: provider capabilities are enforced centrally before any network or CLI dispatch, so unsupported content blocks raise `InvalidRequestError` instead of being silently dropped (**breaking**), `MinimaxProvider` is corrected to `text_only()` because its wire format never carried images (**breaking**), and the package ships a PEP 561 `py.typed` marker with `mypy motosan_ai/` clean and gated in CI.
+
+Python 0.20.0 / TypeScript 0.16.0 are the Freeform tool parity releases: both SDKs gain the native model API Rust shipped in 0.26.0 — ordered Function and Freeform/custom tool transport (`ModelChatRequest`, `ModelToolSpec`, `FreeformTool`, `ModelToolCall`, `ModelToolOutput`, `ModelStreamDelta`), a shared OpenAI Responses codec, the native client trio and stream collector, `supports_freeform_tools` capabilities, and an OpenAI Responses opt-in (ChatGPT Codex is native by default). The legacy `ChatRequest` / `Tool` / `ToolCall` / `ChatResponse` / `StreamEvent` APIs stay function-tool-only — the native API is parallel, not a widening. Raw Freeform input must remain byte-for-byte intact and must never be lowered into JSON function arguments. Python adds `UnsupportedFeatureError(InvalidRequestError)`. All three SDKs now carry a spec-anchored Freeform conformance suite.
 
 ## Current Rust Tool Schema Note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [python-0.20.0 / ts-0.16.0] — 2026-07-28
+
+Freeform tool parity. Python and TypeScript gain the native model API that Rust
+shipped in 0.26.0, so `specs/types.md` § Native Model API is now implemented by
+all three SDKs rather than one. No Rust package version changed.
+
+### Added
+
+- **Native model API** in both SDKs: ordered Function and Freeform/custom tool
+  transport — `ModelChatRequest`, `ModelContextItem`, `ModelToolSpec`,
+  `FreeformTool`, `ModelToolCall`, `ModelToolOutput`, `ModelChatResponse`,
+  `ModelStreamDelta` — plus the client trio (`model_chat_with` /
+  `model_stream_with` / `model_stream_collect_with` in Python, `modelChat` /
+  `modelStream` / `modelStreamCollect` in TypeScript) and a stream collector.
+  The legacy `ChatRequest` / `Tool` / `ToolCall` / `ChatResponse` / `StreamEvent`
+  surface is untouched and stays function-tool-only: this is a parallel API.
+- **Shared OpenAI Responses codec** per SDK (`motosan_ai/providers/responses.py`,
+  `src/serialize/responses.ts`). Freeform `input` is raw model text and survives
+  byte-for-byte — never parsed as JSON, never lowered into function-call
+  `arguments`.
+- **OpenAI Responses opt-in.** ChatGPT Codex is natively capable by default;
+  OpenAI only when the caller asks — Python `Client(openai_responses_api=True)`,
+  TypeScript `ClientBuilder.openaiResponsesApi(true)`. TypeScript's existing
+  `withResponsesFallback` is unrelated 404 recovery and remains distinct.
+- **`supports_freeform_tools` / `supportsFreeformTools`** on provider
+  capabilities. `full()` / `fullCaps()` deliberately leave it off, so a provider
+  cannot advertise support it does not have.
+- **`UnsupportedFeatureError` in Python**, a subclass of `InvalidRequestError`:
+  existing `except InvalidRequestError` handlers keep working, while callers that
+  must distinguish can match the subclass.
+- **A spec-anchored conformance suite in all three SDKs**, including Rust, which
+  already implemented the behaviour — a cross-SDK gate that skips an SDK is not a
+  gate. Each suite documents the source mutations that prove it is not vacuous.
+
 ## [rust-0.27.1] — 2026-07-28
 
 Documentation-only patch for the Rust crate. No Python or TypeScript package

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ response = await client.chat([Message.user("Hello")])
 | Language | Package | Version |
 |----------|---------|---------|
 | Rust | [`motosan-ai`](https://crates.io/crates/motosan-ai) | v0.27.1 |
-| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.19.0 |
-| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) | v0.15.0 |
+| Python | [`motosan-ai`](https://pypi.org/project/motosan-ai/) | v0.20.0 |
+| TypeScript | [`@motosan-ai/sdk`](https://www.npmjs.com/package/@motosan-ai/sdk) | v0.16.0 |
 
 ## Install
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Multi-provider LLM SDK for Python and Rust. Unified API for Anthropic, OpenAI, Ollama, MiniMax, and Gemini — with streaming, tool use, retry, and ThinkStripper built in.
 
-- Python 0.19.0 · TypeScript 0.15.0 · Rust 0.27.1
+- Python 0.20.0 · TypeScript 0.16.0 · Rust 0.27.1
 - Python 0.13.0: CLI-runtime setters (`.cwd()`, `session_id` + `resume()`, `.env()/.envs()`, CLI tool-call stream events, `.timeout()/.no_timeout()`) and a **breaking** fallible stream — HTTP provider `stream()` raises `motosan_ai.error.StreamError` mid-stream instead of swallowing transport/parse faults (`collect_stream` propagates it; `Client.stream_with` does not retry after a mid-stream raise).
 - Python 0.14.0 / TypeScript 0.11.0: **chatgpt-codex** provider — native ChatGPT-backend HTTP client over the OpenAI Responses API (`chatgpt.com/backend-api/codex/responses`; pre-obtained OAuth token + account id, no `api_key`). Python `Client.chatgpt_codex(...)`, TypeScript `Client.builder().chatgptCodex(...)`.
 - Rust 0.24.0 / Python 0.17.0 / TypeScript 0.14.0 (M3): **breaking** stream termination — EOF without the provider terminal event (OpenAI wire: `[DONE]` or a `finish_reason` chunk, either suffices) raises Rust `MotosanError::IncompleteStream` / Python `IncompleteStreamError(StreamError)` / TypeScript `IncompleteStreamError extends StreamError`; one timeout model (connect 10 s / read-idle 120 s / total opt-in) on all builders; Rust build-once shared `reqwest::Client`; TypeScript per-request `AbortSignal` + `CancelledError` (never retried); Python `Client.aclose()` / `async with`.

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to `motosan-ai` Python SDK are documented in this file.
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-28
+
+### Added
+- Native model API for ordered Function and Freeform/custom tools, mirroring
+  Rust 0.26.0 and specified by `specs/types.md` § Native Model API. The legacy
+  `ChatRequest` / `Tool` / `ToolCall` / `ChatResponse` / `StreamEvent` surface
+  is untouched and stays function-tool-only — this is a parallel API, not a
+  widening of the existing one.
+- New types: `FreeformTool`, `FreeformToolFormat`, `ModelToolSpec`, `ModelToolCall`,
+  `ModelToolOutput`, `FunctionCallOutputPayload`, `ModelContextItem`,
+  `ModelChatRequest` (+ `ModelChatRequestBuilder`), `ModelChatResponse`, and the
+  eight `ModelStreamDelta` variants — all exported from the package root.
+- `Client.model_chat_with()`, `Client.model_stream_with()`, and
+  `Client.model_stream_collect_with()`, plus `collect_model_stream()`. Dispatch is
+  duck-typed, so providers outside `BaseProvider` participate.
+- `motosan_ai.providers.responses`: the shared OpenAI Responses codec used by
+  both native providers. Freeform `input` is transported as raw text — never
+  parsed as JSON, never lowered into function-call `arguments`.
+- `ProviderCapabilities` gains `supports_freeform_tools`. ChatGPT Codex declares freeform support;
+  OpenAI declares it only when the caller opts into the Responses API. `ProviderCapabilities.full()`
+  deliberately leaves freeform off, so a provider cannot claim support it lacks.
+- Providers without a native path reject freeform specs or history with `UnsupportedFeatureError` before any network I/O.
+- `UnsupportedFeatureError`, a subclass of `InvalidRequestError` so existing
+  `except InvalidRequestError` handlers keep working while callers that need to
+  distinguish can match the subclass.
+- `OpenAIProvider(responses_api=True)`, `Client(openai_responses_api=True)`, and
+  `Client.openai(openai_responses_api=True)` opt into the OpenAI Responses API.
+- A spec-anchored conformance suite (`tests/test_freeform_conformance.py`), one of
+  three that now gate this contract across the SDKs.
+
 ## [0.19.0] - 2026-07-28
 
 ### Breaking

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motosan-ai"
-version = "0.19.0"
+version = "0.20.0"
 description = "Python SDK for Anthropic, OpenAI, MiniMax, Gemini, Ollama, and CLI AI providers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-28
+
+### Added
+- Native model API for ordered Function and Freeform/custom tools, mirroring
+  Rust 0.26.0 and specified by `specs/types.md` § Native Model API. The legacy
+  `ChatRequest` / `Tool` / `ToolCall` / `ChatResponse` / `StreamEvent` surface
+  is untouched and stays function-tool-only — this is a parallel API, not a
+  widening of the existing one.
+- New types: `FreeformTool`, `FreeformToolFormat`, `ModelToolSpec`, `ModelToolCall`,
+  `ModelToolOutput`, `FunctionCallOutputPayload`, `ModelContextItem`,
+  `ModelChatRequest`, `ModelChatResponse`, `ModelStreamDelta`, and `BoxModelStream`.
+  Unions whose model shape and wire shape disagree are tagged on `kind`; unions
+  whose tag values are the wire values are tagged on `type`.
+- `Client.modelChat()`, `Client.modelStream()`, and `Client.modelStreamCollect()`,
+  plus `collectModelStream()`. `ProviderImpl.modelChat` / `modelStream` are optional,
+  so external providers implementing the structural contract are unaffected.
+- `serialize/responses.ts`: the shared OpenAI Responses codec used by both native
+  providers. Freeform `input` is transported as raw text — never parsed as JSON,
+  never lowered into function-call `arguments`.
+- `ProviderCapabilities` gains `supportsFreeformTools`. ChatGPT Codex declares freeform support;
+  OpenAI declares it only when the caller opts into the Responses API. `fullCaps()`
+  deliberately leaves freeform off, so a provider cannot claim support it lacks.
+- Providers without a native path reject freeform specs or history with `UnsupportedFeatureError` before any network I/O.
+- `OpenAIProvider.withResponsesApi(true)` and `ClientBuilder.openaiResponsesApi(true)`
+  opt into the OpenAI Responses API. These are distinct from the pre-existing
+  `withResponsesFallback`, which is only 404 recovery on the legacy chat path.
+- A spec-anchored conformance suite (`tests/freeform-conformance.test.ts`), one of
+  three that now gate this contract across the SDKs.
+
 ## [0.15.0] - 2026-07-17
 
 ### Added

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@motosan-ai/sdk",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@motosan-ai/sdk",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.13.10",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motosan-ai/sdk",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Multi-provider TypeScript/ESM SDK for Anthropic, OpenAI, MiniMax, Ollama, Gemini, and ChatGPT Codex. Self-implemented wire protocol via native fetch — zero official-provider-SDK dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/motosan-ai/SKILL.md
+++ b/skills/motosan-ai/SKILL.md
@@ -5,7 +5,7 @@ description: Help developers use the motosan-ai SDK (Python and Rust) and the co
 
 # motosan-ai SDK
 
-Multi-provider LLM SDK — Python 0.19.0 / Rust 0.27.1 / TypeScript 0.15.0
+Multi-provider LLM SDK — Python 0.20.0 / Rust 0.27.1 / TypeScript 0.16.0
 
 Providers: Anthropic, OpenAI (+ OpenAI-compatible: Groq, DeepSeek, Together, self-hosted proxies), MiniMax, Ollama, Gemini, Gemini Code Assist, Claude Code CLI, Codex CLI, Gemini CLI, ChatGPT Codex (Responses API)
 

--- a/specs/types.md
+++ b/specs/types.md
@@ -55,7 +55,7 @@ DocumentSource::Url    { url: string }
 |-------|------|-------|
 | `supports_image` | `bool` | Provider accepts `ContentBlock::Image` |
 | `supports_document` | `bool` | Provider accepts `ContentBlock::Document` |
-| `supports_freeform_tools` | `bool` | Provider accepts native `ModelToolSpec::Freeform` / `ModelToolCall::Freeform` transport (Rust 0.26.0+; Python and TypeScript ports in progress — see #270) |
+| `supports_freeform_tools` | `bool` | Provider accepts native `ModelToolSpec::Freeform` / `ModelToolCall::Freeform` transport (Rust 0.26.0+, Python 0.20.0+, TypeScript 0.16.0+) |
 
 Named constructors: `text_only()` / `with_image()` / `with_freeform_tools()` /
 `with_image_and_freeform_tools()` / `full()`.
@@ -106,7 +106,7 @@ network call.
 
 ## Native Model API
 
-> Implemented in Rust 0.26.0+. Python and TypeScript ports in progress — see #270.
+> Implemented in Rust 0.26.0+, Python 0.20.0+, and TypeScript 0.16.0+.
 
 The legacy cross-SDK `ChatRequest`, `Tool`, `ToolCall`, `ChatResponse`, and
 `StreamEvent` APIs remain function-tool-only. Every SDK MUST expose a parallel

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "motosan-ai"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "sdks/python" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Ships the Freeform tool parity milestone (#270). No Rust package version changes.

`specs/types.md` § Native Model API is now implemented by all three SDKs rather than one, so this also completes decision D10's second step: the section's status line moves from "Python and TypeScript ports in progress" to the shipped versions. Both in-progress markers are cleared — the heading blockquote and the `supports_freeform_tools` capability row, which is easy to miss and would have left the spec claiming work was unfinished.

Bumped with `scripts/bump-version.py --python 0.20.0 --ts 0.16.0`: manifests, both lockfiles, the CHANGELOG headings, and all four version banners. Hand-written: the two SDK CHANGELOG entries, the root CHANGELOG entry, and the AGENTS.md release paragraph.

Gates: full Python suite, full TypeScript suite (754 passed / 9 skipped), `treefmt --fail-on-change`, `check-versions.py`.

**Publishing will be done from a local checkout**, as with rust-v0.27.1 — Trusted Publishing has no publisher registered on PyPI or npm yet, so the tag-triggered workflows would fail at the OIDC auth step. Tagging is therefore deferred until that is configured; once it is, `gh workflow run release-tag.yml -f packages="python ts"` creates the tags and the publish runs will verify-and-skip against the already-published artifacts rather than re-uploading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)